### PR TITLE
feat(ui): add site version display (#1)

### DIFF
--- a/404.html
+++ b/404.html
@@ -2,6 +2,7 @@
 <html lang="en-GB">
 <head>
     <meta charset="UTF-8">
+    <meta name="weo-version" content="1.0.0">
     <link rel="icon" type="image/png" sizes="48x48" href="favicon_48x48.png">
     <link rel="icon" type="image/png" sizes="32x32" href="favicon_32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="favicon_16x16.png">
@@ -124,5 +125,17 @@
     </div>
 <script data-goatcounter="https://warmthengine.goatcounter.com/count"
         async src="//gc.zgo.at/count.js"></script>
+<script>
+(function(){
+  var v = document.querySelector('meta[name="weo-version"]');
+  if (!v) return;
+  var ver = v.getAttribute('content');
+  console.log('WEO v' + ver);
+  var el = document.createElement('div');
+  el.textContent = 'WEO v' + ver;
+  el.style.cssText = 'position:fixed;bottom:4px;right:8px;font-size:11px;opacity:0.4;font-family:monospace;pointer-events:none;z-index:9999';
+  document.body.appendChild(el);
+})();
+</script>
 </body>
 </html>

--- a/about.html
+++ b/about.html
@@ -2,6 +2,7 @@
 <html lang="en-GB">
 <head>
     <meta charset="UTF-8">
+    <meta name="weo-version" content="1.0.0">
     <link rel="icon" type="image/png" sizes="48x48" href="favicon_48x48.png">
     <link rel="icon" type="image/png" sizes="32x32" href="favicon_32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="favicon_16x16.png">
@@ -1242,5 +1243,17 @@
     </script>
 <script data-goatcounter="https://warmthengine.goatcounter.com/count"
         async src="//gc.zgo.at/count.js"></script>
+<script>
+(function(){
+  var v = document.querySelector('meta[name="weo-version"]');
+  if (!v) return;
+  var ver = v.getAttribute('content');
+  console.log('WEO v' + ver);
+  var el = document.createElement('div');
+  el.textContent = 'WEO v' + ver;
+  el.style.cssText = 'position:fixed;bottom:4px;right:8px;font-size:11px;opacity:0.4;font-family:monospace;pointer-events:none;z-index:9999';
+  document.body.appendChild(el);
+})();
+</script>
 </body>
 </html>

--- a/blocs.html
+++ b/blocs.html
@@ -2,6 +2,7 @@
 <html lang="en-GB">
 <head>
     <meta charset="UTF-8">
+    <meta name="weo-version" content="1.0.0">
     <link rel="icon" type="image/png" sizes="48x48" href="favicon_48x48.png">
     <link rel="icon" type="image/png" sizes="32x32" href="favicon_32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="favicon_16x16.png">
@@ -1733,5 +1734,17 @@
     </script>
 <script data-goatcounter="https://warmthengine.goatcounter.com/count"
         async src="//gc.zgo.at/count.js"></script>
+<script>
+(function(){
+  var v = document.querySelector('meta[name="weo-version"]');
+  if (!v) return;
+  var ver = v.getAttribute('content');
+  console.log('WEO v' + ver);
+  var el = document.createElement('div');
+  el.textContent = 'WEO v' + ver;
+  el.style.cssText = 'position:fixed;bottom:4px;right:8px;font-size:11px;opacity:0.4;font-family:monospace;pointer-events:none;z-index:9999';
+  document.body.appendChild(el);
+})();
+</script>
 </body>
 </html>

--- a/events.html
+++ b/events.html
@@ -2,6 +2,7 @@
 <html lang="en-GB">
 <head>
     <meta charset="UTF-8">
+    <meta name="weo-version" content="1.0.0">
     <link rel="icon" type="image/png" sizes="48x48" href="favicon_48x48.png">
     <link rel="icon" type="image/png" sizes="32x32" href="favicon_32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="favicon_16x16.png">
@@ -5571,5 +5572,17 @@ if (navToggle && navLinks) {
 
 <script data-goatcounter="https://warmthengine.goatcounter.com/count"
         async src="//gc.zgo.at/count.js"></script>
+<script>
+(function(){
+  var v = document.querySelector('meta[name="weo-version"]');
+  if (!v) return;
+  var ver = v.getAttribute('content');
+  console.log('WEO v' + ver);
+  var el = document.createElement('div');
+  el.textContent = 'WEO v' + ver;
+  el.style.cssText = 'position:fixed;bottom:4px;right:8px;font-size:11px;opacity:0.4;font-family:monospace;pointer-events:none;z-index:9999';
+  document.body.appendChild(el);
+})();
+</script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="en-GB">
 <head>
   <meta charset="UTF-8">
+  <meta name="weo-version" content="1.0.0">
   <link rel="icon" type="image/png" sizes="48x48" href="favicon_48x48.png">
   <link rel="icon" type="image/png" sizes="32x32" href="favicon_32x32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="favicon_16x16.png">
@@ -9865,5 +9866,17 @@ function generateCCSection(eventId, showFullContent) {
 
 <script data-goatcounter="https://warmthengine.goatcounter.com/count"
         async src="//gc.zgo.at/count.js"></script>
+<script>
+(function(){
+  var v = document.querySelector('meta[name="weo-version"]');
+  if (!v) return;
+  var ver = v.getAttribute('content');
+  console.log('WEO v' + ver);
+  var el = document.createElement('div');
+  el.textContent = 'WEO v' + ver;
+  el.style.cssText = 'position:fixed;bottom:4px;right:8px;font-size:11px;opacity:0.4;font-family:monospace;pointer-events:none;z-index:9999';
+  document.body.appendChild(el);
+})();
+</script>
 </body>
 </html>

--- a/legal.html
+++ b/legal.html
@@ -2,6 +2,7 @@
 <html lang="en-GB">
 <head>
     <meta charset="UTF-8">
+    <meta name="weo-version" content="1.0.0">
     <link rel="icon" type="image/png" sizes="48x48" href="favicon_48x48.png">
     <link rel="icon" type="image/png" sizes="32x32" href="favicon_32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="favicon_16x16.png">
@@ -630,5 +631,17 @@
     </script>
 <script data-goatcounter="https://warmthengine.goatcounter.com/count"
         async src="//gc.zgo.at/count.js"></script>
+<script>
+(function(){
+  var v = document.querySelector('meta[name="weo-version"]');
+  if (!v) return;
+  var ver = v.getAttribute('content');
+  console.log('WEO v' + ver);
+  var el = document.createElement('div');
+  el.textContent = 'WEO v' + ver;
+  el.style.cssText = 'position:fixed;bottom:4px;right:8px;font-size:11px;opacity:0.4;font-family:monospace;pointer-events:none;z-index:9999';
+  document.body.appendChild(el);
+})();
+</script>
 </body>
 </html>

--- a/methodology.html
+++ b/methodology.html
@@ -2,6 +2,7 @@
 <html lang="en-GB">
 <head>
     <meta charset="UTF-8">
+    <meta name="weo-version" content="1.0.0">
     <link rel="icon" type="image/png" sizes="48x48" href="favicon_48x48.png">
     <link rel="icon" type="image/png" sizes="32x32" href="favicon_32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="favicon_16x16.png">
@@ -1618,5 +1619,17 @@
     </script>
 <script data-goatcounter="https://warmthengine.goatcounter.com/count"
         async src="//gc.zgo.at/count.js"></script>
+<script>
+(function(){
+  var v = document.querySelector('meta[name="weo-version"]');
+  if (!v) return;
+  var ver = v.getAttribute('content');
+  console.log('WEO v' + ver);
+  var el = document.createElement('div');
+  el.textContent = 'WEO v' + ver;
+  el.style.cssText = 'position:fixed;bottom:4px;right:8px;font-size:11px;opacity:0.4;font-family:monospace;pointer-events:none;z-index:9999';
+  document.body.appendChild(el);
+})();
+</script>
 </body>
 </html>

--- a/research.html
+++ b/research.html
@@ -2,6 +2,7 @@
 <html lang="en-GB">
 <head>
     <meta charset="UTF-8">
+    <meta name="weo-version" content="1.0.0">
     <link rel="icon" type="image/png" sizes="48x48" href="favicon_48x48.png">
     <link rel="icon" type="image/png" sizes="32x32" href="favicon_32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="favicon_16x16.png">
@@ -938,5 +939,17 @@
     </script>
 <script data-goatcounter="https://warmthengine.goatcounter.com/count"
         async src="//gc.zgo.at/count.js"></script>
+<script>
+(function(){
+  var v = document.querySelector('meta[name="weo-version"]');
+  if (!v) return;
+  var ver = v.getAttribute('content');
+  console.log('WEO v' + ver);
+  var el = document.createElement('div');
+  el.textContent = 'WEO v' + ver;
+  el.style.cssText = 'position:fixed;bottom:4px;right:8px;font-size:11px;opacity:0.4;font-family:monospace;pointer-events:none;z-index:9999';
+  document.body.appendChild(el);
+})();
+</script>
 </body>
 </html>

--- a/support.html
+++ b/support.html
@@ -2,6 +2,7 @@
 <html lang="en-GB">
 <head>
     <meta charset="UTF-8">
+    <meta name="weo-version" content="1.0.0">
     <link rel="icon" type="image/png" sizes="48x48" href="favicon_48x48.png">
     <link rel="icon" type="image/png" sizes="32x32" href="favicon_32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="favicon_16x16.png">
@@ -1086,5 +1087,17 @@
     </script>
 <script data-goatcounter="https://warmthengine.goatcounter.com/count"
         async src="//gc.zgo.at/count.js"></script>
+<script>
+(function(){
+  var v = document.querySelector('meta[name="weo-version"]');
+  if (!v) return;
+  var ver = v.getAttribute('content');
+  console.log('WEO v' + ver);
+  var el = document.createElement('div');
+  el.textContent = 'WEO v' + ver;
+  el.style.cssText = 'position:fixed;bottom:4px;right:8px;font-size:11px;opacity:0.4;font-family:monospace;pointer-events:none;z-index:9999';
+  document.body.appendChild(el);
+})();
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
Adds site version v1.0.0 display to all 9 HTML pages via three channels:
- `<meta name="weo-version" content="1.0.0">` in `<head>`
- `console.log('WEO v1.0.0')` on page load
- Fixed-position footer string (11px, opacity 0.4, bottom-right)

JS reads the meta tag so version is defined once per file.

Closes #1

## Test plan
- [ ] Open any page in browser — verify "WEO v1.0.0" appears bottom-right, subtle
- [ ] Open DevTools console — verify `WEO v1.0.0` logged
- [ ] Inspect `<head>` — verify `<meta name="weo-version" content="1.0.0">` present
- [ ] Run `grep -r 'weo-version' *.html` — verify 9 files, all `1.0.0`
- [ ] Confirm google84e030ea8aa2c149.html is unmodified

🤖 Generated with [Claude Code](https://claude.com/claude-code)