### PR TITLE
fix(data): correct FALLBACK_EVENTS path

### DIFF
--- a/events.html
+++ b/events.html
@@ -3123,7 +3123,7 @@ function mapApiConnectionToEventsFormat(c) {
 // Load all data from API with static fallback
 async function loadWEOData(password) {
   const API_BASE = 'https://warmthengine.com/api';
-  const FALLBACK_EVENTS = '/data/events-free.json';
+  const FALLBACK_EVENTS = '/events-free.json';
   const headers = password ? { 'X-WEO-Password': password } : {};
 
   let apiEvents = null;

--- a/index.html
+++ b/index.html
@@ -5574,7 +5574,7 @@ function mapApiConnectionToInternal(c) {
 // Load data from API with static fallback
 async function loadWEOData(password) {
   const API_BASE = 'https://warmthengine.com/api';
-  const FALLBACK_EVENTS = '/data/events-free.json';
+  const FALLBACK_EVENTS = '/events-free.json';
   const headers = password ? { 'X-WEO-Password': password } : {};
 
   let eventsLoaded = false;


### PR DESCRIPTION
## Summary
- Fixed `FALLBACK_EVENTS` path from `/data/events-free.json` to `/events-free.json` in `index.html` and `events.html`
- The `/data/` path returns 404 in production; the root path returns 200

Closes #4

## Test plan
- [ ] Disable Cloudflare API (or block in DevTools) and verify fallback loads successfully on both index and events pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)