### PR TITLE
fix: restore production API URL and fallback path

### DIFF
--- a/events.html
+++ b/events.html
@@ -3415,8 +3415,8 @@ function mapApiConnectionToEventsFormat(c) {
 
 // Load all data from API with static fallback
 async function loadWEOData(password) {
-  const API_BASE = 'http://localhost:0/api'; // DEV: force fallback to local JSON (restore to https://warmthengine.com/api before deploy)
-  const FALLBACK_EVENTS = '/data/events-free.json';
+  const API_BASE = 'https://warmthengine.com/api';
+  const FALLBACK_EVENTS = '/events-free.json';
   const headers = password ? { 'X-WEO-Password': password } : {};
 
   let apiEvents = null;

--- a/index.html
+++ b/index.html
@@ -6136,8 +6136,8 @@ function mapApiConnectionToInternal(c) {
 
 // Load data from API with static fallback
 async function loadWEOData(password) {
-  const API_BASE = 'http://localhost:0/api'; // DEV: force fallback to local JSON (restore to https://warmthengine.com/api before deploy)
-  const FALLBACK_EVENTS = '/data/events-free.json';
+  const API_BASE = 'https://warmthengine.com/api';
+  const FALLBACK_EVENTS = '/events-free.json';
   const headers = password ? { 'X-WEO-Password': password } : {};
 
   let eventsLoaded = false;


### PR DESCRIPTION
## Summary
- API_BASE was `localhost:0` (dev override left in place during deployment)
- FALLBACK_EVENTS pointed to `/data/events-free.json` instead of `/events-free.json`
- Fixes both `index.html` and `events.html`

**This is a P0 hotfix — site is broken without it.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)