### PR TITLE
Fix: CC chevron auth, status overflow, route-based undefined

### DIFF
--- a/events.html
+++ b/events.html
@@ -3374,7 +3374,7 @@ function mapApiEventToFull(e) {
   if (e.basel5 != null) { full.basel_factors = e.basel5; full.basel_factors_met = e.basel5_factors_met; }
   if (e.keohane != null) { full.keohane_factors = e.keohane; full.keohane_factors_met = e.keohane_factors_met; }
   if (e.pisa5 != null) { full.pisa5_factors = e.pisa5; full.pisa5_factors_met = e.pisa5_factors_met; }
-  if ((e.route_based ?? e.routeBased) != null) { full.route_based_factors = e.route_based ?? e.routeBased; }
+  if ((e.route_based ?? e.routeBased) != null) { full.route_based_factors = e.route_based ?? e.routeBased; full.route_based_factors_met = e.route_based_factors_met ?? (full.route_based_factors ? full.route_based_factors.filter(function(f) { return f.pass; }).length : undefined); }
 
   // camelCase fields (accept both formats)
   if ((e.rolling_updates ?? e.rollingUpdates) != null) full.rollingUpdates = e.rolling_updates ?? e.rollingUpdates;
@@ -3430,7 +3430,7 @@ async function loadWEOData(password) {
   try {
     const [eventsRes, connectionsRes] = await Promise.all([
       fetch(API_BASE + '/events', { headers, cache: password ? 'no-store' : 'default' }),
-      fetch(API_BASE + '/connections')
+      fetch(API_BASE + '/connections', { headers, cache: password ? 'no-store' : 'default' })
     ]);
     if (eventsRes.ok) {
       const eventsJson = await eventsRes.json();

--- a/index.html
+++ b/index.html
@@ -666,7 +666,7 @@
       border-radius: var(--weo-radius-lg);
       padding: 16px 20px;
       padding-right: 56px; /* Make room for hamburger */
-      width: 280px;
+      width: 300px;
       box-shadow: 0 4px 24px rgba(0, 0, 0, 0.5), 0 0 0 1px rgba(0, 0, 0, 0.2), inset 0 1px 0 rgba(255, 255, 255, 0.03);
       backdrop-filter: blur(8px);
       z-index: 449;
@@ -6153,7 +6153,7 @@ async function loadWEOData(password) {
   try {
     const [eventsRes, connectionsRes] = await Promise.all([
       fetch(API_BASE + '/events', { headers, cache: password ? 'no-store' : 'default' }),
-      fetch(API_BASE + '/connections')
+      fetch(API_BASE + '/connections', { headers, cache: password ? 'no-store' : 'default' })
     ]);
 
     if (eventsRes.ok) {


### PR DESCRIPTION
## Summary
- **CC chevrons broken**: `/api/connections` fetch was missing auth headers — authenticated users always got free-tier stripped data (no `evidence_detail`), so only sample-event CCs had working expand chevrons
- **Status panel overflow**: "101 Connections" text overflowed behind hamburger icon — widened panel from 280px to 300px
- **Route-Based "undefined/2"**: `events.html` `mapApiEventToFull()` mapped the route_based array but never mapped `route_based_factors_met`, causing undefined display on E142

## Test plan
- [ ] Authenticate and verify CC chevrons expand on non-sample events
- [ ] Verify "117 Events · 101 Connections" fits within status panel
- [ ] Open E142 PyTorch Foundation detail — confirm "2/2 routes met"

🤖 Generated with [Claude Code](https://claude.com/claude-code)