### PR TITLE
Correction: register calibration E147, E148

### DIFF
--- a/events-free.json
+++ b/events-free.json
@@ -4820,7 +4820,7 @@
       "date": "1 September 2025",
       "location": "Beijing, China",
       "scope": "People's Republic of China (Mainland)",
-      "description": "Mandatory AI content labelling regulation (人工智能生成合成内容标识办法) jointly issued by CAC, MIIT, MPS, and NRTA requiring explicit and implicit labelling of all AI-generated synthetic content across text, image, audio, and video modalities. Accompanied by mandatory national technical standard GB 45438-2025 specifying labelling implementation requirements.",
+      "description": "Mandatory AI content labelling regulation jointly issued by CAC, MIIT, MPS, and NRTA requiring explicit and implicit labelling of all AI-generated synthetic content across text, image, audio, and video modalities. Accompanied by mandatory national technical standard GB 45438-2025 specifying labelling implementation requirements.",
       "investment": "Regulatory framework (penalties via CAC/MPS enforcement authority); companion mandatory national standard GB 45438-2025",
       "domain": "Technology",
       "confidence": "A",


### PR DESCRIPTION
## Summary
- E147 description: removed parenthesised Chinese title (人工智能生成合成内容标识办法)
- E147 PISA-5 AI Centrality: removed inline Chinese translation (人工智能)
- E147 relatedEvents: added pinyin gloss (gēnjù) to 根据 in 3 relationship fields
- E148 PISA-5 AI Centrality: changed "intelligenza artificiale" to "AI"

All corrections align foreign-language usage with established corpus patterns. No events added/removed, counts unchanged (122 events, 107 CCs).

## Test plan
- [x] Event count unchanged at 122
- [x] E147 free-tier description verified via API (no Chinese title)
- [x] Only E147 and E148 changed (hash comparison against backup)
- [x] No HTML files modified
- [x] metadata.event_count and last_updated unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)