### PR TITLE
Audit remediation: remove CC-53-96-1 (Policy Cascade CC-E, below CC-V minimum)

### DIFF
--- a/events.html
+++ b/events.html
@@ -3310,7 +3310,7 @@
     // ========================================
     const WEO_DB = {
       event_count: 127,
-      cc_count: 105,
+      cc_count: 104,
       last_updated: "2026-04-19",
       db_version: "1.5.0"
     };

--- a/index.html
+++ b/index.html
@@ -5939,7 +5939,7 @@
     // ========================================
     const WEO_DB = {
       event_count: 127,
-      cc_count: 105,
+      cc_count: 104,
       last_updated: "2026-04-19",
       db_version: "1.5.0"
     };


### PR DESCRIPTION
## Summary
- Removes `CC-53-96-1` (Policy Cascade, confidence CC-E) from the active corpus — below the CC-V minimum confidence threshold
- Updates `WEO_DB.cc_count` 105 → 104 in `index.html` and `events.html`

## What's already deployed
- `connections-canonical-v5_1.json` updated in pipeline:
  - Array length 105 → 104; `metadata.total_connections` and `metadata.connection_count` both = 104
  - Statistics recomputed from actual data: `policy_cascade` 3 → 2; `CC-E` 6 → 5
- KV `connections` re-uploaded; worker `weo-api` redeployed (Version `3f56e915-311f-4748-97e3-1bf1788b7081`)

## Verified
- Production API: 127 events, 104 connections
- `CC-53-96-1` absent from `/api/connections`
- Metadata block self-consistent (sums match array length)

## Test plan
- [ ] `/api/connections` returns 104 records
- [ ] `/api/events` returns 127 records
- [ ] Site stats badges show 104 connections / 127 events

🤖 Generated with [Claude Code](https://claude.com/claude-code)