### PR TITLE
WS-1.5: Source durability — snapshot URLs in static fallback

### DIFF
--- a/events-free.json
+++ b/events-free.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "event_count": 127,
-    "cc_count": 114,
+    "cc_count": 103,
     "last_updated": "2026-04-19",
     "db_version": "1.5.0",
     "schema_version": "1.0",
@@ -81,39 +81,60 @@
         {
           "id": "P1",
           "desc": "Gov.cn — ¥43.5B direct investment confirmed",
-          "url": "https://english.www.gov.cn/news/202408/29/content_WS66d03a1ac6d0868f4e8ea539.html"
+          "url": "https://english.www.gov.cn/news/202408/29/content_WS66d03a1ac6d0868f4e8ea539.html",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429071432/https://english.www.gov.cn/news/202408/29/content_WS66d03a1ac6d0868f4e8ea539.html"
         },
         {
           "id": "P2",
           "desc": "Gov.cn — 60% of new computing capacity concentrated in 8 hubs",
-          "url": "https://english.www.gov.cn/news/202312/27/content_WS658b72afc6d0868f4e8e28ba.html"
+          "url": "https://english.www.gov.cn/news/202312/27/content_WS658b72afc6d0868f4e8e28ba.html",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429070419/https://english.www.gov.cn/news/202312/27/content_WS658b72afc6d0868f4e8e28ba.html"
         },
         {
           "id": "P3",
           "desc": "Gov.cn — Computing power expansion plans",
-          "url": "https://english.www.gov.cn/news/202508/28/content_WS68b00fe2c6d0868f4e8f522a.html"
+          "url": "https://english.www.gov.cn/news/202508/28/content_WS68b00fe2c6d0868f4e8f522a.html",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429071819/https://english.www.gov.cn/news/202508/28/content_WS68b00fe2c6d0868f4e8f522a.html"
         }
       ],
       "sources_corroborating": [
         {
           "id": "C1",
           "desc": "Futunn News — 80.8% intelligent computing share",
-          "url": "https://news.futunn.com/en/post/56125572/hong-kong-stock-concept-tracking-the-scale-of-intelligent-computing"
+          "url": "https://news.futunn.com/en/post/56125572/hong-kong-stock-concept-tracking-the-scale-of-intelligent-computing",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429084346/https://news.futunn.com/en/post/56125572/hong-kong-stock-concept-tracking-the-scale-of-intelligent-computing"
         },
         {
           "id": "C2",
           "desc": "DC Pulse — EDWC strategic analysis",
-          "url": "https://dcpulse.com/article/china-cloud-edwc-eastern-data-western-computing"
+          "url": "https://dcpulse.com/article/china-cloud-edwc-eastern-data-western-computing",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429061225/https://dcpulse.com/article/china-cloud-edwc-eastern-data-western-computing"
         },
         {
           "id": "C3",
           "desc": "Data Center Dynamics — $6.1B investment figure confirmed",
-          "url": "https://www.datacenterdynamics.com/en/news/china-has-spent-61bn-building-data-centers-in-the-past-two-years/"
+          "url": "https://www.datacenterdynamics.com/en/news/china-has-spent-61bn-building-data-centers-in-the-past-two-years/",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429143631/https://www.datacenterdynamics.com/en/news/china-has-spent-61bn-building-data-centers-in-the-past-two-years/"
         },
         {
           "id": "C4",
           "desc": "China Briefing — Cross-regional computing plan",
-          "url": "https://www.china-briefing.com/news/china-data-centers-new-cross-regional-plan-to-boost-computing-power-across-regions/"
+          "url": "https://www.china-briefing.com/news/china-data-centers-new-cross-regional-plan-to-boost-computing-power-across-regions/",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429130846/https://www.china-briefing.com/news/china-data-centers-new-cross-regional-plan-to-boost-computing-power-across-regions/"
         }
       ],
       "source_count_primary": 3,
@@ -145,12 +166,18 @@
             {
               "citation": "NDRC EDWC Programme Document (发改高技〔2021〕709号)",
               "type": "primary",
-              "url": "https://www.ndrc.gov.cn/xxgk/zcfb/tz/202105/t20210526_1280838.html"
+              "url": "https://www.ndrc.gov.cn/xxgk/zcfb/tz/202105/t20210526_1280838.html",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429044858/https://www.ndrc.gov.cn/xxgk/zcfb/tz/202105/t20210526_1280838.html"
             },
             {
               "citation": "GB 40879-2021 (数据中心能效限定值及能效等级), Standardization Administration of China",
               "type": "primary",
-              "url": "https://openstd.samr.gov.cn/bzgk/gb/newGbInfo?hcno=4AAF5CA9387980A1FEA1FA47ABA503BA"
+              "url": "https://openstd.samr.gov.cn/bzgk/gb/newGbInfo?hcno=4AAF5CA9387980A1FEA1FA47ABA503BA",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429043625/https://openstd.samr.gov.cn/bzgk/std/newGbInfo?hcno=4AAF5CA9387980A1FEA1FA47ABA503BA"
             }
           ]
         },
@@ -164,12 +191,18 @@
             {
               "citation": "WEO Methodology Rationale V1.3, §8.9 Evidence Chain — [EB Benchmark] (Pathway A)",
               "type": "primary",
-              "url": "https://doi.org/10.5281/zenodo.18427582"
+              "url": "https://doi.org/10.5281/zenodo.18427582",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429040553/https://zenodo.org/records/19366463"
             },
             {
               "citation": "WEO Methodology Rationale V1.3, §8.11 Chinese Cascade Model",
               "type": "primary",
-              "url": "https://doi.org/10.5281/zenodo.18427582"
+              "url": "https://doi.org/10.5281/zenodo.18427582",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429040553/https://zenodo.org/records/19366463"
             }
           ]
         }
@@ -208,14 +241,7 @@
           "name": "Resource Demand",
           "mechanism": "TSMC JASM operates under Kumamoto prefectural groundwater preservation ordinances, consuming 7,500 metric tons of groundwater per day for UPW and cooling, documented in EIA commitments.",
           "evidenceBasis": "Documented",
-          "vector": "Water",
-          "sources": [
-            {
-              "citation": "TSMC Kumamoto groundwater reporting, Japan Times",
-              "type": "corroborating",
-              "url": "https://www.japantimes.co.jp/business/2025/12/26/companies/tsmc-kumamoto-plant-groundwater-concerns/"
-            }
-          ]
+          "vector": "Water"
         }
       ],
       "cc_count": 0
@@ -294,39 +320,60 @@
         {
           "id": "P1",
           "desc": "IEEE Standards Association — P7000-2021 Standard",
-          "url": "https://standards.ieee.org/standard/7000-2021.html"
+          "url": "https://standards.ieee.org/standard/7000-2021.html",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429104446/https://standards.ieee.org/ieee/7000/6781/"
         },
         {
           "id": "P2",
           "desc": "IEEE — ISO/IEC/IEEE 24748-7000",
-          "url": "https://standards.ieee.org/ieee/24748-7000/11098/"
+          "url": "https://standards.ieee.org/ieee/24748-7000/11098/",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429104134/https://standards.ieee.org/ieee/24748-7000/11098/"
         },
         {
           "id": "P3",
           "desc": "ISO — ISO/IEC 42001 AI Management Standard",
-          "url": "https://www.iso.org/standard/84893.html"
+          "url": "https://www.iso.org/standard/84893.html",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429174100/https://www.iso.org/standard/84893.html"
         },
         {
           "id": "P4",
           "desc": "ISO Committee — SC 42 Participation",
-          "url": "https://committee.iso.org/committee/45086.html?view=participation"
+          "url": "https://committee.iso.org/committee/45086.html?view=participation",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429060409/https://committee.iso.org/committee/45086.html?view=participation"
         }
       ],
       "sources_corroborating": [
         {
           "id": "C1",
           "desc": "IEEE News — IEEE 7000 announcement",
-          "url": "https://standards.ieee.org/news/ieee-7000/"
+          "url": "https://standards.ieee.org/news/ieee-7000/",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429104303/https://standards.ieee.org/news/ieee-7000/"
         },
         {
           "id": "C2",
           "desc": "IEEE — CertifAIEd Framework Vienna case study",
-          "url": "https://standards.ieee.org/beyond-standards/the-ieee-certifaied-framework-for-ai-ethics-applied-to-the-city-of-vienna/"
+          "url": "https://standards.ieee.org/beyond-standards/the-ieee-certifaied-framework-for-ai-ethics-applied-to-the-city-of-vienna/",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429104036/https://standards.ieee.org/beyond-standards/the-ieee-certifaied-framework-for-ai-ethics-applied-to-the-city-of-vienna/"
         },
         {
           "id": "C3",
           "desc": "VBE Academy — Austrian Standards AI certification",
-          "url": "https://vbe.academy/insights/post/austrian-standards-launches-first-european-certification-for-ethical-ai/"
+          "url": "https://vbe.academy/insights/post/austrian-standards-launches-first-european-certification-for-ethical-ai/",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429112834/https://vbe.academy/insights/post/austrian-standards-launches-first-european-certification-for-ethical-ai/"
         }
       ],
       "source_count_primary": 4,
@@ -341,7 +388,29 @@
       "industry_secondary": [],
       "version_date": "2026-03-04",
       "environmentalNexusTags": [],
-      "cc_count": 1
+      "cc_count": 1,
+      "keohane": [
+        {
+          "factor": "Type",
+          "pass": true,
+          "rationale": "Keohane Type 2 — Institutional Consensus Standard"
+        },
+        {
+          "factor": "Coordination Evidence",
+          "pass": true,
+          "rationale": "IEEE SA individual-participation process; 850+ global experts including US, EU, China, India, Japan, Korea; ISO-adopted via SC 7 (40 P-members)"
+        },
+        {
+          "factor": "Implementation",
+          "pass": true,
+          "rationale": "CertifAIEd operational with 167 assessors across 28 countries; Wiener Stadtwerke pilot completed; ISO/IEC/IEEE 24748-7000 adopted"
+        },
+        {
+          "factor": "Cross-Bloc Participation",
+          "pass": true,
+          "rationale": "Genuine cross-bloc technical coordination — both Western and Eastern blocs participated in creating the standard"
+        }
+      ]
     },
     {
       "id": "05",
@@ -445,59 +514,92 @@
         {
           "id": "P1",
           "desc": "Public Law 117-167 (CHIPS and Science Act full text)",
-          "url": "https://www.govinfo.gov/content/pkg/PLAW-117publ167/html/PLAW-117publ167.htm"
+          "url": "https://www.govinfo.gov/content/pkg/PLAW-117publ167/html/PLAW-117publ167.htm",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429165155/https://www.govinfo.gov/content/pkg/PLAW-117publ167/html/PLAW-117publ167.htm"
         },
         {
           "id": "P2",
           "desc": "Congress.gov bill text",
-          "url": "https://www.congress.gov/bill/117th-congress/house-bill/4346/text"
+          "url": "https://www.congress.gov/bill/117th-congress/house-bill/4346/text",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429135719/https://www.congress.gov/bill/117th-congress/house-bill/4346/text"
         },
         {
           "id": "P3",
           "desc": "NIST CHIPS program page",
-          "url": "https://www.nist.gov/chips"
+          "url": "https://www.nist.gov/chips",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429185041/https://www.nist.gov/chips"
         },
         {
           "id": "P4",
           "desc": "NIST CHIPS America Fact Sheet",
-          "url": "https://www.nist.gov/document/chips-america-fact-sheet-federal-incentives"
+          "url": "https://www.nist.gov/document/chips-america-fact-sheet-federal-incentives",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429185354/https://www.nist.gov/system/files/documents/2024/04/22/Fact%20Sheet%20-%20Federal%20Incentives-updated-508C.pdf"
         },
         {
           "id": "P5",
           "desc": "White House Fact Sheet — 'counter China'",
-          "url": "https://bidenwhitehouse.archives.gov/briefing-room/statements-releases/2022/08/09/fact-sheet-chips-and-science-act-will-lower-costs-create-jobs-strengthen-supply-chains-and-counter-china/"
+          "url": "https://bidenwhitehouse.archives.gov/briefing-room/statements-releases/2022/08/09/fact-sheet-chips-and-science-act-will-lower-costs-create-jobs-strengthen-supply-chains-and-counter-china/",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429053628/https://bidenwhitehouse.archives.gov/briefing-room/statements-releases/2022/08/09/fact-sheet-chips-and-science-act-will-lower-costs-create-jobs-strengthen-supply-chains-and-counter-china/"
         },
         {
           "id": "P6",
           "desc": "NIST AI Congressional Mandates",
-          "url": "https://www.nist.gov/artificial-intelligence/ai-congressional-mandates-executive-orders-and-actions"
+          "url": "https://www.nist.gov/artificial-intelligence/ai-congressional-mandates-executive-orders-and-actions",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429184819/https://www.nist.gov/artificial-intelligence/ai-congressional-mandates-executive-orders-and-actions"
         },
         {
           "id": "P7",
           "desc": "Commerce Dept CHIPS bulletin",
-          "url": "https://content.govdelivery.com/accounts/USDOC/bulletins/3c823cf"
+          "url": "https://content.govdelivery.com/accounts/USDOC/bulletins/3c823cf",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429060519/https://content.govdelivery.com/accounts/USDOC/bulletins/3c823cf"
         }
       ],
       "sources_corroborating": [
         {
           "id": "C1",
           "desc": "CRS Report on CHIPS Act",
-          "url": "https://crsreports.congress.gov/product/pdf/R/R47523"
+          "url": "https://crsreports.congress.gov/product/pdf/R/R47523",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429060903/https://crsreports.congress.gov/product/pdf/R/R47523"
         },
         {
           "id": "C2",
           "desc": "National Governors Association CHIPS resources",
-          "url": "https://www.nga.org/chips-resources/"
+          "url": "https://www.nga.org/chips-resources/",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429184752/https://www.nga.org/chips-resources/"
         },
         {
           "id": "C3",
           "desc": "US Chamber of Commerce CHIPS anniversary",
-          "url": "https://www.uschamber.com/technology/chips-and-science-act-anniversary-progress-made-but-work-remains"
+          "url": "https://www.uschamber.com/technology/chips-and-science-act-anniversary-progress-made-but-work-remains",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429213550/https://www.uschamber.com/technology/chips-and-science-act-anniversary-progress-made-but-work-remains"
         },
         {
           "id": "C4",
           "desc": "Data Center Dynamics — SK Hynix CHIPS funding",
-          "url": "https://www.datacenterdynamics.com/en/news/sk-hynix-secures-458m-in-chips-act-funding/"
+          "url": "https://www.datacenterdynamics.com/en/news/sk-hynix-secures-458m-in-chips-act-funding/",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429144840/https://www.datacenterdynamics.com/en/news/sk-hynix-secures-458m-in-chips-act-funding/"
         }
       ],
       "source_count_primary": 7,
@@ -642,14 +744,7 @@
           "name": "Resource Demand",
           "mechanism": "Intel Ocotillo operates under Industrial User Permit No. 009 (City of Chandler) and APP P-100140 (ADEQ), with dedicated water reclamation via the Ocotillo Brine Reduction Facility.",
           "evidenceBasis": "Documented",
-          "vector": "Water",
-          "sources": [
-            {
-              "citation": "Draft Environmental Assessment NIST-CPO/EA-003, NIST CHIPS Program Office",
-              "type": "primary",
-              "url": "https://www.nist.gov/system/files/documents/2024/07/08/Intel%20Ocotillo%20EA_DRAFT%20FINAL_VOLUME%201%208July2024.pdf"
-            }
-          ]
+          "vector": "Water"
         },
         {
           "type": "ENT-4",
@@ -657,14 +752,7 @@
           "mechanism": "Intel Ocotillo fabs in Chandler, AZ operate in WRI Aqueduct 'Extremely High' water stress zone (West Salt River Valley) and require continuous water-based cooling and UPW, with municipal co-dependency documented in ADEQ permits.",
           "evidenceBasis": "Assessed",
           "dependencyType": "Water stress",
-          "riskIndex": "WRI Aqueduct",
-          "sources": [
-            {
-              "citation": "WRI Aqueduct Water Risk Atlas 4.0 — West Salt River Valley sub-basin",
-              "type": "corroborating",
-              "url": "https://www.wri.org/aqueduct"
-            }
-          ]
+          "riskIndex": "WRI Aqueduct"
         }
       ],
       "cc_count": 5
@@ -700,14 +788,7 @@
           "type": "ENT-2",
           "name": "Environmental Enablement",
           "mechanism": "European Chips Act Article 2(11) defines qualifying 'first-of-a-kind facilities' as requiring innovation in 'energy and environmental performance,' acting as a binding definitional gatekeeper for facility recognition and state aid under Articles 13-15.",
-          "evidenceBasis": "Documented",
-          "sources": [
-            {
-              "citation": "Regulation (EU) 2023/1781, Article 2(11), 2(12), 2(13)",
-              "type": "primary",
-              "url": "https://eur-lex.europa.eu/eli/reg/2023/1781/oj/eng"
-            }
-          ]
+          "evidenceBasis": "Documented"
         }
       ],
       "cc_count": 1
@@ -786,34 +867,51 @@
         {
           "id": "P1",
           "desc": "MOFCOM Press Conference — Export controls announcement",
-          "url": "https://english.mofcom.gov.cn/News/PressConference/art/2023/art_36fb2d80e4b4453891bb8fc83e2b3c4e.html"
+          "url": "https://english.mofcom.gov.cn/News/PressConference/art/2023/art_36fb2d80e4b4453891bb8fc83e2b3c4e.html",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429065438/https://english.mofcom.gov.cn/favicon.ico"
         },
         {
           "id": "P2",
           "desc": "MOFCOM Regulatory Text — Announcement No. 23 of 2023",
-          "url": "https://aqygzj.mofcom.gov.cn/qdml/art/2023/art_c2ae3d2061e14e97ba608de1ed565f78.html"
+          "url": "https://aqygzj.mofcom.gov.cn/qdml/art/2023/art_c2ae3d2061e14e97ba608de1ed565f78.html",
+          "accessDate": "2026-04-29",
+          "captureStatus": "no_capture"
         }
       ],
       "sources_corroborating": [
         {
           "id": "C1",
           "desc": "Global Policy Watch — China export restrictions analysis",
-          "url": "https://www.globalpolicywatch.com/2023/07/china-slaps-export-restrictions-on-two-critical-metals/"
+          "url": "https://www.globalpolicywatch.com/2023/07/china-slaps-export-restrictions-on-two-critical-metals/",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429162028/https://www.globalpolicywatch.com/2023/07/china-slaps-export-restrictions-on-two-critical-metals/"
         },
         {
           "id": "C2",
           "desc": "SDxCentral — Chip shortage risk analysis",
-          "url": "https://www.sdxcentral.com/news/chinese-export-controls-on-gallium-and-germanium-could-lead-to-chip-shortages-report/"
+          "url": "https://www.sdxcentral.com/news/chinese-export-controls-on-gallium-and-germanium-could-lead-to-chip-shortages-report/",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429200202/https://www.sdxcentral.com/news/chinese-export-controls-on-gallium-and-germanium-could-lead-to-chip-shortages-report/"
         },
         {
           "id": "C3",
           "desc": "CSIS — Gallium supply chains analysis",
-          "url": "https://www.csis.org/analysis/beyond-rare-earths-chinas-growing-threat-gallium-supply-chains"
+          "url": "https://www.csis.org/analysis/beyond-rare-earths-chinas-growing-threat-gallium-supply-chains",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429141710/https://www.csis.org/analysis/beyond-rare-earths-chinas-growing-threat-gallium-supply-chains"
         },
         {
           "id": "C4",
           "desc": "Clark Hill — China rare earth controls legal analysis",
-          "url": "https://www.clarkhill.com/news-events/news/china-hits-pause-on-rare-earth-export-controls-and-what-it-means-for-supply-chains/"
+          "url": "https://www.clarkhill.com/news-events/news/china-hits-pause-on-rare-earth-export-controls-and-what-it-means-for-supply-chains/",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429132441/https://www.clarkhill.com/news-events/news/china-hits-pause-on-rare-earth-export-controls-and-what-it-means-for-supply-chains/"
         }
       ],
       "source_count_primary": 2,
@@ -837,7 +935,189 @@
       ],
       "version_date": "2026-03-11",
       "environmentalNexusTags": [],
-      "cc_count": 0
+      "cc_count": 0,
+      "piet": {
+        "implementationDate": "2023-08-01",
+        "assessmentDate": "2025-02-01",
+        "gatesPassed": 4,
+        "gatesRequired": 3,
+        "confidence": "Trade-Impact Confirmed",
+        "result": "4/4 gates",
+        "t2ImpactDemonstrated": true,
+        "t2Basis": "Gate 3 cleared — 6 qualifying other-bloc government responses across 3 jurisdictions (EU, Japan, Canada)",
+        "gates": [
+          {
+            "factor": "Trade Flow Disruption",
+            "pass": true,
+            "rationale": "China GAC data (via USGS MCS 2025): gallium/germanium exports fell to zero Aug–Sep 2023; >50% global decline sustained 18+ months. US bilateral exports declined >97%. No suspension or reversal; regime tightened Dec 2024.",
+            "sources": [
+              {
+                "id": "PIET-G1-1",
+                "desc": "USGS Mineral Commodity Summaries 2025 — Gallium",
+                "url": "https://pubs.usgs.gov/periodicals/mcs2025/mcs2025-gallium.pdf",
+                "type": "PRIMARY"
+              },
+              {
+                "id": "PIET-G1-2",
+                "desc": "USGS Mineral Commodity Summaries 2025 — Germanium",
+                "url": "https://pubs.usgs.gov/periodicals/mcs2025/mcs2025-germanium.pdf",
+                "type": "PRIMARY"
+              }
+            ],
+            "summary": ">50% global decline sustained 18+ months; US bilateral exports declined >97%",
+            "evidence": [
+              {
+                "label": "Source",
+                "value": "China GAC data via USGS Mineral Commodity Summaries 2025"
+              },
+              {
+                "label": "Metric",
+                "value": "Gallium/germanium exports fell to zero Aug–Sep 2023"
+              },
+              {
+                "label": "Duration",
+                "value": ">50% global decline sustained 18+ months"
+              },
+              {
+                "label": "Status",
+                "value": "No suspension or reversal; regime tightened Dec 2024"
+              }
+            ]
+          },
+          {
+            "factor": "Commodity Price Movement",
+            "pass": true,
+            "rationale": "Fastmarkets Rotterdam 99.99% gallium: +60–114% within 5 months, sustained 18+ months. Germanium: +56–114% by mid-2024, sustained 12+ months. Both Tier B non-exchange-traded minor metals; USGS MCS 2025 confirms 2024 annual average gallium import unit value +33%.",
+            "sources": [
+              {
+                "id": "PIET-G2-1",
+                "desc": "USGS MCS 2025 — Gallium (Argus Media annual average data)",
+                "url": "https://pubs.usgs.gov/periodicals/mcs2025/mcs2025-gallium.pdf",
+                "type": "PRIMARY"
+              },
+              {
+                "id": "PIET-G2-2",
+                "desc": "USGS MCS 2025 — Germanium (Argus Media annual average data)",
+                "url": "https://pubs.usgs.gov/periodicals/mcs2025/mcs2025-germanium.pdf",
+                "type": "PRIMARY"
+              }
+            ],
+            "summary": "Gallium +60–114%, germanium +56–114%, sustained 12–18+ months",
+            "evidence": [
+              {
+                "label": "Source",
+                "value": "Fastmarkets Rotterdam / USGS MCS 2025 (Argus Media data)"
+              },
+              {
+                "label": "Gallium",
+                "value": "99.99% grade: +60–114% within 5 months, sustained 18+ months"
+              },
+              {
+                "label": "Germanium",
+                "value": "+56–114% by mid-2024, sustained 12+ months"
+              },
+              {
+                "label": "Classification",
+                "value": "Tier B non-exchange-traded minor metals"
+              }
+            ]
+          },
+          {
+            "factor": "Government Policy Response",
+            "pass": true,
+            "rationale": "6 qualifying responses across 3 governments within 18 months. EU Commission White Paper COM(2024) 25 (Jan 2024) citing ‘3 July 2023…controls covering products containing gallium and germanium’; EU Council ST-6622-2024-INIT (Feb 2024); Japan METI Minister Nishimura strategy announcement (Aug 2023); Japan METI 2024 WTO Compliance Report (Jun 2024); Canada Global Affairs parliamentary briefing (Jun 2024); Canada Minister Wilkinson Wilson Center remarks (Jan 2025).",
+            "sources": [
+              {
+                "id": "PIET-G3-1",
+                "desc": "European Commission White Paper on Export Controls — COM(2024) 25 final",
+                "url": "https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:52024DC0025",
+                "type": "PRIMARY"
+              },
+              {
+                "id": "PIET-G3-2",
+                "desc": "Council of the EU — ST-6622-2024-INIT",
+                "url": "https://data.consilium.europa.eu/doc/document/ST-6622-2024-INIT/en/pdf",
+                "type": "PRIMARY"
+              },
+              {
+                "id": "PIET-G3-3",
+                "desc": "Japan METI Minister Nishimura press conference — 1 August 2023",
+                "url": "https://www.meti.go.jp/english/speeches/press_conferences/2023/0801001.html",
+                "type": "PRIMARY"
+              },
+              {
+                "id": "PIET-G3-4",
+                "desc": "Japan METI 2024 Report on WTO Compliance",
+                "url": "https://www.meti.go.jp/english/report/data/2024WTO/pdf/2024_2.pdf",
+                "type": "PRIMARY"
+              },
+              {
+                "id": "PIET-G3-5",
+                "desc": "Global Affairs Canada — Parliamentary briefing on China export controls",
+                "url": "https://international.canada.ca/en/global-affairs/corporate/transparency/briefing-documents/parliamentary-committee/2024-06-17-cacn",
+                "type": "PRIMARY"
+              },
+              {
+                "id": "PIET-G3-6",
+                "desc": "NRCan Minister Wilkinson — Woodrow Wilson Center remarks",
+                "url": "https://www.canada.ca/en/natural-resources-canada/news/2025/01/january-15-2025-woodrow-wilson-international-center-for-scholars-washington-dc.html",
+                "type": "PRIMARY"
+              }
+            ],
+            "summary": "6 qualifying responses across 3 governments (EU, Japan, Canada) within 18 months",
+            "evidence": [
+              {
+                "label": "Count",
+                "value": "6 qualifying responses, 3 jurisdictions, 18-month window"
+              },
+              {
+                "label": "EU",
+                "value": "COM(2024) 25 White Paper (Jan 2024); Council ST-6622-2024-INIT (Feb 2024)"
+              },
+              {
+                "label": "Japan",
+                "value": "METI Minister strategy announcement (Aug 2023); METI WTO Compliance Report (Jun 2024)"
+              },
+              {
+                "label": "Canada",
+                "value": "Global Affairs parliamentary briefing (Jun 2024); Minister Wilkinson Wilson Center remarks (Jan 2025)"
+              }
+            ]
+          },
+          {
+            "factor": "Named Entity Commercial Disclosure",
+            "pass": true,
+            "rationale": "AXT Inc. (NASDAQ: AXTI) — 4 SEC filings (10-Q Q3 2023, 10-Q Q2 2023, 10-K FY2023, 10-Q Q3 2024) naming MOFCOM July 3 2023 controls, August 1 2023 effective date, export permit requirements for subsidiary Tongmei, and operational impact on business, financial condition, and results of operations.",
+            "sources": [
+              {
+                "id": "PIET-G4-1",
+                "desc": "AXT Inc. Form 10-Q — Quarter ending September 30, 2023 (SEC EDGAR)",
+                "url": "https://www.sec.gov/Archives/edgar/data/0001051627/000155837023018573/axti-20230930x10q.htm",
+                "type": "PRIMARY"
+              }
+            ],
+            "summary": "AXT Inc. (AXTI, NASDAQ) 10-K filings: names restriction as material risk, 50%+ revenue impact",
+            "evidence": [
+              {
+                "label": "Entity",
+                "value": "AXT Inc. (AXTI, NASDAQ)"
+              },
+              {
+                "label": "Filing",
+                "value": "10-K Annual Reports FY2023–2024 (SEC)"
+              },
+              {
+                "label": "Disclosure",
+                "value": "Names ‘China’s export restrictions on gallium and germanium’ as material risk"
+              },
+              {
+                "label": "Impact",
+                "value": "50%+ revenue impact; facility restructuring (Beijing subsidiary closure, Liaoning JV)"
+              }
+            ]
+          }
+        ]
+      }
     },
     {
       "id": "15",
@@ -958,14 +1238,7 @@
           "name": "Resource Demand",
           "mechanism": "TSMC Fab 21 operates under Draft EA NIST-CPO/EA-002 specifying 17.29 MGD total water demand, with mandated Industrial Reclamation Water Plant achieving ≥95% recycling.",
           "evidenceBasis": "Documented",
-          "vector": "Water",
-          "sources": [
-            {
-              "citation": "Draft Environmental Assessment NIST-CPO/EA-002, NIST CHIPS Program Office",
-              "type": "primary",
-              "url": "https://www.nist.gov/system/files/documents/2024/06/04/TSMC%20Draft%20EA%20June%203%202024%20.pdf"
-            }
-          ]
+          "vector": "Water"
         },
         {
           "type": "ENT-4",
@@ -973,14 +1246,7 @@
           "mechanism": "TSMC Fab 21 in Phoenix operates in WRI Aqueduct 'Extremely High' zone and requires 17.29 MGD water demand as documented in NIST-CPO/EA-002.",
           "evidenceBasis": "Assessed",
           "dependencyType": "Water stress",
-          "riskIndex": "WRI Aqueduct",
-          "sources": [
-            {
-              "citation": "WRI Aqueduct Water Risk Atlas 4.0 — West Salt River Valley sub-basin",
-              "type": "corroborating",
-              "url": "https://www.wri.org/aqueduct"
-            }
-          ]
+          "riskIndex": "WRI Aqueduct"
         }
       ],
       "cc_count": 5
@@ -1111,44 +1377,67 @@
         {
           "id": "P1",
           "desc": "Microsoft Official Blog — Microsoft and G42 partner to accelerate AI innovation",
-          "url": "https://blogs.microsoft.com/blog/2024/04/15/microsoft-and-g42-partner-to-accelerate-ai-innovation-in-uae-and-beyond/"
+          "url": "https://blogs.microsoft.com/blog/2024/04/15/microsoft-and-g42-partner-to-accelerate-ai-innovation-in-uae-and-beyond/",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429054203/https://blogs.microsoft.com/blog/2024/04/15/microsoft-and-g42-partner-to-accelerate-ai-innovation-in-uae-and-beyond/"
         },
         {
           "id": "P2",
           "desc": "Microsoft News — Microsoft invests $1.5 billion in Abu Dhabi's G42",
-          "url": "https://news.microsoft.com/source/2024/04/16/microsoft-invests-1-5-billion-in-abu-dhabis-g42-to-accelerate-ai-development-and-gl/"
+          "url": "https://news.microsoft.com/source/2024/04/16/microsoft-invests-1-5-billion-in-abu-dhabis-g42-to-accelerate-ai-development-and-gl/",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429084448/https://news.microsoft.com/source/2024/04/16/microsoft-invests-1-5-billion-in-abu-dhabis-g42-to-accelerate-ai-development-and-global-expansion/"
         },
         {
           "id": "P3",
           "desc": "Microsoft Blog (Brad Smith) — Microsoft's $15.2 billion USD investment in the UAE",
-          "url": "https://blogs.microsoft.com/on-the-issues/2025/11/03/microsofts-15-2-billion-usd-investment-in-the-uae/"
+          "url": "https://blogs.microsoft.com/on-the-issues/2025/11/03/microsofts-15-2-billion-usd-investment-in-the-uae/",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429054244/https://blogs.microsoft.com/on-the-issues/2025/11/03/microsofts-15-2-billion-usd-investment-in-the-uae/"
         }
       ],
       "sources_corroborating": [
         {
           "id": "C1",
           "desc": "Reuters — Microsoft to invest $1.5 bln in Emirati AI firm G42",
-          "url": "https://www.reuters.com/markets/deals/microsoft-invest-15-bln-emirati-ai-firm-g42-new-york-times-reports-2024-04-16/"
+          "url": "https://www.reuters.com/markets/deals/microsoft-invest-15-bln-emirati-ai-firm-g42-new-york-times-reports-2024-04-16/",
+          "accessDate": "2026-04-29",
+          "captureStatus": "no_capture"
         },
         {
           "id": "C2",
           "desc": "New York Times — Microsoft Invests in G42, an Emirati A.I. Firm",
-          "url": "https://www.nytimes.com/2024/04/16/technology/microsoft-g42-uae-ai.html"
+          "url": "https://www.nytimes.com/2024/04/16/technology/microsoft-g42-uae-ai.html",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429192112/https://www.nytimes.com/2024/04/16/technology/microsoft-g42-uae-ai.html"
         },
         {
           "id": "C3",
           "desc": "ComputerWeekly — Microsoft's $15.2bn investment in the UAE",
-          "url": "https://www.computerweekly.com/news/366634005/Microsofts-152bn-investment-in-the-UAE-A-strategic-bet-on-AI-talent-and-trust"
+          "url": "https://www.computerweekly.com/news/366634005/Microsofts-152bn-investment-in-the-UAE-A-strategic-bet-on-AI-talent-and-trust",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429135235/https://www.computerweekly.com/news/366634005/Microsofts-152bn-investment-in-the-UAE-A-strategic-bet-on-AI-talent-and-trust"
         },
         {
           "id": "C4",
           "desc": "Data Center Dynamics — Microsoft and Core42 to build sovereign cloud and AI infrastructure",
-          "url": "https://www.datacenterdynamics.com/en/news/microsoft-and-core42-to-build-sovereign-cloud-and-ai-infrastructure-for-abu-dhabi/"
+          "url": "https://www.datacenterdynamics.com/en/news/microsoft-and-core42-to-build-sovereign-cloud-and-ai-infrastructure-for-abu-dhabi/",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429144306/https://www.datacenterdynamics.com/en/news/microsoft-and-core42-to-build-sovereign-cloud-and-ai-infrastructure-for-abu-dhabi/"
         },
         {
           "id": "C5",
           "desc": "TechInformed — Microsoft-G42 announce 200 megawatt UAE data center expansion",
-          "url": "https://techinformed.com/microsoft-g42-announce-200-megawatt-uae-data-center-expansion/"
+          "url": "https://techinformed.com/microsoft-g42-announce-200-megawatt-uae-data-center-expansion/",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429110313/https://techinformed.com/microsoft-g42-announce-200-megawatt-uae-data-center-expansion/"
         }
       ],
       "source_count_primary": 3,
@@ -1182,7 +1471,10 @@
             {
               "citation": "Cisco Stargate UAE initiative announcement, May 2025",
               "type": "primary",
-              "url": "https://newsroom.cisco.com/c/r/newsroom/en/us/a/y2025/m05/cisco-joins-stargate-uae-initiative.html"
+              "url": "https://newsroom.cisco.com/c/r/newsroom/en/us/a/y2025/m05/cisco-joins-stargate-uae-initiative.html",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429043529/https://newsroom.cisco.com/c/r/newsroom/en/us/a/y2025/m05/cisco-joins-stargate-uae-initiative.html"
             }
           ]
         },
@@ -1197,12 +1489,55 @@
             {
               "citation": "Khazna Data Centers cooling technology documentation",
               "type": "corroborating",
-              "url": "https://khaznadatacenters.com/thought-leadership/growth-of-data-centers-in-the-middle-east/"
+              "url": "https://khaznadatacenters.com/thought-leadership/growth-of-data-centers-in-the-middle-east/",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429043451/https://khaznadatacenters.com/thought-leadership/growth-of-data-centers-in-the-middle-east/"
             }
           ]
         }
       ],
-      "cc_count": 0
+      "cc_count": 0,
+      "genesis": {
+        "description": "Microsoft invests $1.5B in G42 (UAE AI company), acquires minority stake, joins board. Partnership includes binding Intergovernmental Assurance Agreement (IGAA) developed with US and UAE governments establishing AI safety, cybersecurity, and export control standards.",
+        "investment": "$1.5B equity (2024); $15.2B total UAE investment (2023-2029); 200MW datacenter expansion; 81,900 GPUs"
+      },
+      "genesisDate": "2024-04-16",
+      "rollingUpdates": [
+        {
+          "id": "PU-22-001",
+          "version": "1.1",
+          "date": "2024-06-24",
+          "description": "Investment conditions completed: G42 Chinese divestment finalised (February 2024, $10B+ including ByteDance stake); Huawei equipment removal from data centres confirmed by White House.",
+          "changedFields": [
+            "investmentStatus"
+          ],
+          "sources": [
+            {
+              "desc": "Fortune - White House Confirms Divestment",
+              "url": "https://fortune.com/asia/2024/06/25/white-house-explains-microsoft-investment-uae-ai-champion-g42-pushed-out-huawei/",
+              "date": "2024-06-24",
+              "type": "PRIMARY"
+            },
+            {
+              "desc": "Reuters - Microsoft-G42 Deal Huawei Ties Cut",
+              "url": "https://www.reuters.com/technology/microsoft-g42-deal-positive-because-it-cut-huawei-ties-white-house-official-says-2024-06-24/",
+              "date": "2024-06-24",
+              "type": "CORROBORATING"
+            },
+            {
+              "desc": "CSIS Analysis - UAE AI Ambitions (G42 Divestment Details)",
+              "url": "https://www.csis.org/analysis/united-arab-emirates-ai-ambitions",
+              "date": "2025-01-27",
+              "type": "CORROBORATING"
+            }
+          ],
+          "previousValues": {
+            "description": "Microsoft invests $1.5B in G42 (UAE AI company), acquires minority stake, joins board. Partnership includes binding Intergovernmental Assurance Agreement (IGAA) developed with US and UAE governments establishing AI safety, cybersecurity, and export control standards.",
+            "investment": "$1.5B equity (2024); $15.2B total UAE investment (2023-2029); 200MW datacenter expansion; 81,900 GPUs"
+          }
+        }
+      ]
     },
     {
       "id": "24",
@@ -1294,14 +1629,7 @@
           "name": "Resource Demand",
           "mechanism": "SDAIA targets 1.5 GW national data centre capacity by 2030, documented in sovereign programme specifications.",
           "evidenceBasis": "Documented",
-          "vector": "Energy",
-          "sources": [
-            {
-              "citation": "Saudi Arabia National Data Center Strategy, MCIT/SDAIA",
-              "type": "primary",
-              "url": "https://www.trade.gov/market-intelligence/saudi-arabia-ict-new-data-center-strategy-accelerate-ai-and-cloud-expansion"
-            }
-          ]
+          "vector": "Energy"
         },
         {
           "type": "ENT-4",
@@ -1309,14 +1637,7 @@
           "mechanism": "SDAIA Hexagon in Riyadh operates in WRI Aqueduct 'Extremely High' water stress zone (Wadi Hanifah / Central Arabian sub-basin) with extreme ambient temperatures preventing free cooling, mandating continuous mechanical chilling and driving adoption of DLC architecture to avoid evaporative water dependency.",
           "evidenceBasis": "Assessed",
           "dependencyType": "Extreme weather",
-          "riskIndex": "WRI Aqueduct",
-          "sources": [
-            {
-              "citation": "SDAIA Hexagon facility specifications",
-              "type": "corroborating",
-              "url": "https://saudigazette.com.sa/article/657881/SAUDI-ARABIA/Saudi-Arabia-launches-Hexagon-the-worlds-largest-Tier-IV-government-data-center"
-            }
-          ]
+          "riskIndex": "WRI Aqueduct"
         }
       ],
       "cc_count": 0
@@ -1410,28 +1731,14 @@
           "type": "ENT-2",
           "name": "Environmental Enablement",
           "mechanism": "EU AI Act Article 53 and Annex XI impose binding energy documentation requirements on GPAI providers as operative legislative provisions.",
-          "evidenceBasis": "Documented",
-          "sources": [
-            {
-              "citation": "Regulation (EU) 2024/1689, Annex XI, Section 1(2)(d) and (e)",
-              "type": "primary",
-              "url": "https://eur-lex.europa.eu/eli/reg/2024/1689/oj/eng"
-            }
-          ]
+          "evidenceBasis": "Documented"
         },
         {
           "type": "ENT-5",
           "name": "Environmental Coordination",
           "mechanism": "EU AI Act Article 53 and Annex XI create legally binding energy documentation requirements for GPAI providers, enforceable with penalties up to €35M or 7% global turnover.",
           "evidenceBasis": "Documented",
-          "pathway": "A",
-          "sources": [
-            {
-              "citation": "Regulation (EU) 2024/1689, Article 101(1)",
-              "type": "primary",
-              "url": "https://eur-lex.europa.eu/eli/reg/2024/1689/oj/eng"
-            }
-          ]
+          "pathway": "A"
         }
       ],
       "cc_count": 3
@@ -1468,13 +1775,7 @@
           "name": "Resource Demand",
           "mechanism": "IndiaAI Mission compute deploys via empanelled operators including Yotta NM1 (210 MW documented) in Navi Mumbai.",
           "evidenceBasis": "Documented",
-          "vector": "Energy",
-          "sources": [
-            {
-              "citation": "Yotta NM1 facility specifications",
-              "type": "corroborating"
-            }
-          ]
+          "vector": "Energy"
         },
         {
           "type": "ENT-4",
@@ -1482,14 +1783,7 @@
           "mechanism": "IndiaAI Mission primary deployment hub (Navi Mumbai) is classified 'Extremely High' baseline water stress by WRI Aqueduct, with data centre cooling operations dependent on regional water infrastructure.",
           "evidenceBasis": "Assessed",
           "dependencyType": "Water stress",
-          "riskIndex": "WRI Aqueduct",
-          "sources": [
-            {
-              "citation": "WRI Aqueduct Water Risk Atlas 4.0 — Ulhas River / Panvel sub-basin",
-              "type": "corroborating",
-              "url": "https://www.wri.org/aqueduct"
-            }
-          ]
+          "riskIndex": "WRI Aqueduct"
         }
       ],
       "cc_count": 2
@@ -1641,14 +1935,7 @@
           "type": "ENT-2",
           "name": "Environmental Enablement",
           "mechanism": "SCIP evaluation framework mandates proponents 'demonstrate a plan to minimize the environmental footprint of the project, including sustainable design, energy efficiency' as a binding evaluation criterion for sovereign compute funding.",
-          "evidenceBasis": "Documented",
-          "sources": [
-            {
-              "citation": "Canada SCIP Programme Guidelines, ISED",
-              "type": "primary",
-              "url": "https://ised-isde.canada.ca/site/ised/en/ai-sovereign-compute-infrastructure-program"
-            }
-          ]
+          "evidenceBasis": "Documented"
         }
       ],
       "cc_count": 2
@@ -1713,28 +2000,14 @@
           "type": "ENT-2",
           "name": "Environmental Enablement",
           "mechanism": "Computing Power Plan mandates renewable energy integration and source-grid-load-storage for computing hubs, with binding implementation through GB 40879-2021 and provincial enforcement.",
-          "evidenceBasis": "Documented",
-          "sources": [
-            {
-              "citation": "GB 40879-2021 (数据中心能效限定值及能效等级), Standardization Administration of China",
-              "type": "primary",
-              "url": "https://openstd.samr.gov.cn/bzgk/gb/newGbInfo?hcno=4AAF5CA9387980A1FEA1FA47ABA503BA"
-            }
-          ]
+          "evidenceBasis": "Documented"
         },
         {
           "type": "ENT-5",
           "name": "Environmental Coordination",
           "mechanism": "Computing Power Plan generates binding environmental operational requirements on computing infrastructure through the same cascade mechanism as EDWC.",
           "evidenceBasis": "Documented",
-          "pathway": "A",
-          "sources": [
-            {
-              "citation": "WEO Methodology Rationale V1.3, §8.9 and §8.11 — cascade model confirmed across 4 provinces, 2 enforcement pathways",
-              "type": "primary",
-              "url": "https://doi.org/10.5281/zenodo.18427582"
-            }
-          ]
+          "pathway": "A"
         }
       ],
       "cc_count": 0
@@ -1799,14 +2072,7 @@
           "type": "ENT-2",
           "name": "Environmental Enablement",
           "mechanism": "NAIS 2.0 Action 10 mandates 'sufficient carbon budget and power allocated to support data centres that house GPUs' with a binding roadmap toward 'net-zero, green data centres powered by renewable energy.'",
-          "evidenceBasis": "Documented",
-          "sources": [
-            {
-              "citation": "Singapore National AI Strategy 2.0, System 3 / Enabler 7 / Action 10",
-              "type": "primary",
-              "url": "https://file.go.gov.sg/nais2023.pdf"
-            }
-          ]
+          "evidenceBasis": "Documented"
         }
       ],
       "cc_count": 2
@@ -1959,14 +2225,7 @@
           "name": "Resource Demand",
           "mechanism": "CG Power-Renesas-Stars OSAT facility operates under MoEFCC Environmental Clearance specifying 17,549 KLD total water requirement.",
           "evidenceBasis": "Documented",
-          "vector": "Water",
-          "sources": [
-            {
-              "citation": "MoEFCC Environmental Clearance, Parivesh Portal",
-              "type": "primary",
-              "url": "https://www.scribd.com/document/925180831/Ind-Ahm-Project"
-            }
-          ]
+          "vector": "Water"
         },
         {
           "type": "ENT-4",
@@ -1974,14 +2233,7 @@
           "mechanism": "CG Power OSAT in Sanand operates in CGWB-classified 'Over-exploited' aquifer zone (113.55% extraction) with documented 17,549 KLD water requirement.",
           "evidenceBasis": "Assessed",
           "dependencyType": "Water stress",
-          "riskIndex": "CGWB NAQUIM",
-          "sources": [
-            {
-              "citation": "CGWB Dynamic Ground Water Resources Assessment — Gandhinagar district",
-              "type": "corroborating",
-              "url": "http://cgwb.gov.in"
-            }
-          ]
+          "riskIndex": "CGWB NAQUIM"
         }
       ],
       "cc_count": 0
@@ -2395,14 +2647,7 @@
           "name": "Resource Demand",
           "mechanism": "Micron Clay operates under FEIS EISX-006-55-CPO-001 and NYSDEC Lake Ontario Water Withdrawal Permit authorising 48 MGD delivery infrastructure.",
           "evidenceBasis": "Documented",
-          "vector": "Water",
-          "sources": [
-            {
-              "citation": "Draft Environmental Impact Statement EISX-006-55-CPO-001, NIST CHIPS Program Office / OCIDA",
-              "type": "primary",
-              "url": "https://ongoved.com"
-            }
-          ]
+          "vector": "Water"
         }
       ],
       "cc_count": 5
@@ -2439,13 +2684,7 @@
           "name": "Resource Demand",
           "mechanism": "Viettel HCM City data centre expansion has documented 140MW power capacity.",
           "evidenceBasis": "Documented",
-          "vector": "Energy",
-          "sources": [
-            {
-              "citation": "Event description — documented in WEO event canonical JSON",
-              "type": "primary"
-            }
-          ]
+          "vector": "Energy"
         },
         {
           "type": "ENT-4",
@@ -2453,14 +2692,7 @@
           "mechanism": "Viettel data centres in Vietnam (ND-GAIN Rank 101, Vulnerability 0.468) utilise water-cooled chillers, with documented typhoon/flood risk (Typhoon Yagi 2024) threatening cooling infrastructure.",
           "evidenceBasis": "Assessed",
           "dependencyType": "Extreme weather",
-          "riskIndex": "ND-GAIN",
-          "sources": [
-            {
-              "citation": "ND-GAIN Country Index — Vietnam",
-              "type": "corroborating",
-              "url": "https://gain.nd.edu/our-work/country-index/"
-            }
-          ]
+          "riskIndex": "ND-GAIN"
         }
       ],
       "cc_count": 0
@@ -2613,32 +2845,14 @@
           "name": "Resource Demand",
           "mechanism": "xAI Colossus has documented ~397MW total power capacity (150MW TVA grid + ~247MW onsite gas turbines).",
           "evidenceBasis": "Documented",
-          "vector": "Energy",
-          "sources": [
-            {
-              "citation": "Event description — documented in WEO event canonical JSON",
-              "type": "primary"
-            }
-          ]
+          "vector": "Energy"
         },
         {
           "type": "ENT-3",
           "name": "Environmental Consequence",
           "mechanism": "EPA NSPS ruling (January 2026) classified xAI Colossus gas turbines as stationary sources under the Clean Air Act, followed by formal 60-day Notice of Intent to sue (February 2026) citing violations of PSD, BACT, and NESHAP Subpart YYYY for operating up to 495MW of unpermitted generation capacity.",
           "evidenceBasis": "Documented",
-          "activationStatus": "Active (Acute)",
-          "sources": [
-            {
-              "citation": "EPA NSPS Final Rule, Federal Register, January 15, 2026",
-              "type": "primary",
-              "url": "https://www.federalregister.gov/documents/2026/01/15/2026-00677/new-source-performance-standards-review-for-stationary-combustion-turbines-and-stationary-gas"
-            },
-            {
-              "citation": "SELC/Earthjustice/NAACP 60-day Notice of Intent to Sue, February 13, 2026",
-              "type": "primary",
-              "url": "https://earthjustice.org/wp-content/uploads/2026/02/2026.02.13-final-xai-southaven-noi-with-exhibit-a.pdf"
-            }
-          ]
+          "activationStatus": "Active (Acute)"
         }
       ],
       "cc_count": 3
@@ -2704,14 +2918,7 @@
           "name": "Resource Demand",
           "mechanism": "Amkor Peoria operates under City of Peoria Class A Industrial Wastewater Discharge Permit and CHIPS PMT mandating 20% water intensity reduction and PFAS sampling.",
           "evidenceBasis": "Documented",
-          "vector": "Water",
-          "sources": [
-            {
-              "citation": "CHIPS Preliminary Memorandum of Terms, NIST CHIPS Program Office",
-              "type": "primary",
-              "url": "https://www.nist.gov/chips/amkor-technology-inc-arizona-peoria"
-            }
-          ]
+          "vector": "Water"
         },
         {
           "type": "ENT-4",
@@ -2719,14 +2926,7 @@
           "mechanism": "Amkor Peoria operates in WRI Aqueduct 'Extremely High' zone (Agua Fria sub-basin) with water-dependent advanced packaging processes documented in Class A discharge permit.",
           "evidenceBasis": "Assessed",
           "dependencyType": "Water stress",
-          "riskIndex": "WRI Aqueduct",
-          "sources": [
-            {
-              "citation": "WRI Aqueduct Water Risk Atlas 4.0 — Agua Fria / West Salt River Valley sub-basin",
-              "type": "corroborating",
-              "url": "https://www.wri.org/aqueduct"
-            }
-          ]
+          "riskIndex": "WRI Aqueduct"
         }
       ],
       "cc_count": 5
@@ -2879,14 +3079,7 @@
           "name": "Resource Demand",
           "mechanism": "Samsung Taylor operates under PUC Docket No. 55256 (water service area transfer of 814.56 acres from Manville WSC to City of Taylor) and Project Funding Agreement specifying water/sewer infrastructure.",
           "evidenceBasis": "Documented",
-          "vector": "Water",
-          "sources": [
-            {
-              "citation": "PUC Texas Docket No. 55256",
-              "type": "primary",
-              "url": "https://interchange.puc.texas.gov/Documents/55256_31_1392171.PDF"
-            }
-          ]
+          "vector": "Water"
         }
       ],
       "cc_count": 4
@@ -2924,14 +3117,7 @@
           "mechanism": "TI Lehi operates in WRI Aqueduct 'High' water stress zone (Jordan River / Utah Lake sub-basin) with continuous evaporative cooling tower dependency, extracting groundwater under Utah Division of Water Rights permits WR 55-646, 55-1644, and 55-2640 (2,109 ML documented extraction 2025).",
           "evidenceBasis": "Assessed",
           "dependencyType": "Water stress",
-          "riskIndex": "WRI Aqueduct",
-          "sources": [
-            {
-              "citation": "Utah Division of Water Rights, Industrial Water Supplier System ID 2197",
-              "type": "primary",
-              "url": "https://waterrights.utah.gov/asp_apps/viewEditIND/indView.asp?SYSTEM_ID=2197"
-            }
-          ]
+          "riskIndex": "WRI Aqueduct"
         }
       ],
       "cc_count": 2
@@ -2968,19 +3154,7 @@
           "name": "Resource Demand",
           "mechanism": "GlobalFoundries Malta operates under NYSDEC Water Withdrawal Permit WWA# 11,633 and SEQRA findings documenting 10.7 MGD primary water demand.",
           "evidenceBasis": "Documented",
-          "vector": "Water",
-          "sources": [
-            {
-              "citation": "NYSDEC Water Withdrawal Permit WWA# 11,633 (12th Modification)",
-              "type": "primary",
-              "url": "https://documents.dps.ny.gov/public/Common/ViewDoc.aspx?DocRefId={993D2DB2-5281-42CB-97EE-CB710377B8C4}"
-            },
-            {
-              "citation": "Town of Malta SEQRA Statement of Findings",
-              "type": "primary",
-              "url": "https://www.townofmaltany.gov/Archive/ViewFile/Item/2711"
-            }
-          ]
+          "vector": "Water"
         }
       ],
       "cc_count": 3
@@ -3058,44 +3232,67 @@
         {
           "id": "P1",
           "desc": "EuroHPC JU — LUMI Inauguration",
-          "url": "https://www.eurohpc-ju.europa.eu/inauguration-lumi-fastest-greenest-supercomputer-europe-2022-06-13_en"
+          "url": "https://www.eurohpc-ju.europa.eu/inauguration-lumi-fastest-greenest-supercomputer-europe-2022-06-13_en",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429153107/https://www.eurohpc-ju.europa.eu/inauguration-lumi-fastest-greenest-supercomputer-europe-2022-06-13_en"
         },
         {
           "id": "P2",
           "desc": "CSC — LUMI Specifications",
-          "url": "https://www.lumi-supercomputer.eu/"
+          "url": "https://www.lumi-supercomputer.eu/",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429180416/https://lumi-supercomputer.eu/"
         },
         {
           "id": "P3",
           "desc": "Council Regulation (EU) 2021/1173",
-          "url": "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32021R1173"
+          "url": "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32021R1173",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429072026/https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32021R1173"
         },
         {
           "id": "P4",
           "desc": "Top500 — LUMI November 2022",
-          "url": "https://www.top500.org/system/180048/"
+          "url": "https://www.top500.org/system/180048/",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429211357/https://www.top500.org/system/180048/"
         }
       ],
       "sources_corroborating": [
         {
           "id": "C1",
           "desc": "HPCwire — LUMI Inauguration Coverage",
-          "url": "https://www.hpcwire.com/2022/06/13/lumi-europes-most-powerful-supercomputer-is-inaugurated-in-finland/"
+          "url": "https://www.hpcwire.com/2022/06/13/lumi-europes-most-powerful-supercomputer-is-inaugurated-in-finland/",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429170902/https://www.hpcwire.com/2022/06/13/lumi-europes-most-powerful-supercomputer-is-inaugurated-in-finland/"
         },
         {
           "id": "C2",
           "desc": "European Commission — LUMI Press Release",
-          "url": "https://ec.europa.eu/commission/presscorner/detail/en/ip_22_3635"
+          "url": "https://ec.europa.eu/commission/presscorner/detail/en/ip_22_3635",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429063652/https://ec.europa.eu/commission/presscorner/pageNotFound"
         },
         {
           "id": "C3",
           "desc": "Nature — LUMI Scientific Applications",
-          "url": "https://www.nature.com/articles/d41586-022-01649-8"
+          "url": "https://www.nature.com/articles/d41586-022-01649-8",
+          "accessDate": "2026-04-29",
+          "captureStatus": "dead_source"
         },
         {
           "id": "C4",
           "desc": "Science Business — EuroHPC LUMI Analysis",
-          "url": "https://sciencebusiness.net/news/lumi-supercomputer-inaugurated-finland"
+          "url": "https://sciencebusiness.net/news/lumi-supercomputer-inaugurated-finland",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429102012/https://sciencebusiness.net/news/lumi-supercomputer-inaugurated-finland"
         }
       ],
       "source_count_primary": 4,
@@ -3288,14 +3485,7 @@
           "name": "Resource Demand",
           "mechanism": "Amazon-Talen 17-year nuclear PPA for 1,920MW from Susquehanna Nuclear Station.",
           "evidenceBasis": "Documented",
-          "vector": "Energy-PPA",
-          "sources": [
-            {
-              "citation": "Talen Energy investor presentation",
-              "type": "primary",
-              "url": "https://ir.talenenergy.com/static-files/b6df3768-fe1d-4efe-84d5-68bc230b8438"
-            }
-          ]
+          "vector": "Energy-PPA"
         }
       ],
       "cc_count": 4
@@ -3709,19 +3899,7 @@
           "type": "ENT-2",
           "name": "Environmental Enablement",
           "mechanism": "SenseTime AIDC operates under mandatory GB 40879-2021 PUE standards via MIIT 智算中心 designation, with Shanghai municipal power rationing (6kW standard rack quotas) and Lingang-specific efficiency subsidies conditioning operational parameters.",
-          "evidenceBasis": "Documented",
-          "sources": [
-            {
-              "citation": "Shanghai Municipal Commission of Economy and Information Technology data centre policy",
-              "type": "primary",
-              "url": "https://sheitc.sh.gov.cn/xxfw/20210407/3774163f0b3f4bb399e15ad592f7c2f8.html"
-            },
-            {
-              "citation": "GB 40879-2021 (数据中心能效限定值及能效等级)",
-              "type": "primary",
-              "url": "https://openstd.samr.gov.cn/bzgk/gb/newGbInfo?hcno=4AAF5CA9387980A1FEA1FA47ABA503BA"
-            }
-          ]
+          "evidenceBasis": "Documented"
         }
       ],
       "cc_count": 0
@@ -3934,14 +4112,7 @@
           "name": "Resource Demand",
           "mechanism": "SK Hynix West Lafayette operates under IDEM Industrial Wastewater Discharge Permit with documented 2.8M gallons/day average water usage.",
           "evidenceBasis": "Documented",
-          "vector": "Water",
-          "sources": [
-            {
-              "citation": "SK Hynix West Lafayette facility documentation",
-              "type": "primary",
-              "url": "https://neuron.prf.org/wp-content/uploads/2025/04/Leaflet-for-SK-hynix-West-Lafayette_FINAL.pdf"
-            }
-          ]
+          "vector": "Water"
         }
       ],
       "cc_count": 8
@@ -4036,13 +4207,7 @@
           "name": "Resource Demand",
           "mechanism": "Stargate Abilene campus has documented 1.2 GW power capacity.",
           "evidenceBasis": "Documented",
-          "vector": "Energy",
-          "sources": [
-            {
-              "citation": "Event description — documented in WEO event canonical JSON",
-              "type": "primary"
-            }
-          ]
+          "vector": "Energy"
         }
       ],
       "cc_count": 6
@@ -4108,14 +4273,7 @@
           "type": "ENT-2",
           "name": "Environmental Enablement",
           "mechanism": "China Mobile Hohhot operates under mandatory PUE standards (GB 40879-2021) and Inner Mongolia provincial energy efficiency requirements via administrative-hierarchy enforcement.",
-          "evidenceBasis": "Documented",
-          "sources": [
-            {
-              "citation": "GB 40879-2021 (数据中心能效限定值及能效等级)",
-              "type": "primary",
-              "url": "https://openstd.samr.gov.cn/bzgk/gb/newGbInfo?hcno=4AAF5CA9387980A1FEA1FA47ABA503BA"
-            }
-          ]
+          "evidenceBasis": "Documented"
         },
         {
           "type": "ENT-4",
@@ -4123,13 +4281,7 @@
           "mechanism": "China Mobile Hohhot operates in WRI Aqueduct 'High to Extremely High' zone with cold-plate liquid cooling requiring evaporative heat rejection via secondary cooling loops.",
           "evidenceBasis": "Assessed",
           "dependencyType": "Water stress",
-          "riskIndex": "WRI Aqueduct",
-          "sources": [
-            {
-              "citation": "China Mobile corporate communications — cold-plate liquid cooling (冷板式液冷), PUE 1.15, 69% green electricity",
-              "type": "corroborating"
-            }
-          ]
+          "riskIndex": "WRI Aqueduct"
         }
       ],
       "cc_count": 1
@@ -4253,14 +4405,7 @@
           "name": "Resource Demand",
           "mechanism": "Microsoft 20-year PPA with Constellation for 835MW nuclear baseload from Crane Clean Energy Center.",
           "evidenceBasis": "Documented",
-          "vector": "Energy-PPA",
-          "sources": [
-            {
-              "citation": "Constellation Energy / Microsoft TMI restart announcement",
-              "type": "corroborating",
-              "url": "https://www.utilitydive.com/news/constellation-three-mile-island-nuclear-power-plant-microsoft-data-center-ppa/727652/"
-            }
-          ]
+          "vector": "Energy-PPA"
         }
       ],
       "cc_count": 4
@@ -4297,14 +4442,7 @@
           "name": "Resource Demand",
           "mechanism": "Amazon anchor investment targets 320MW initial Xe-100 SMR deployment for data centre power.",
           "evidenceBasis": "Documented",
-          "vector": "Energy",
-          "sources": [
-            {
-              "citation": "X-energy Series C-1 financing announcement",
-              "type": "corroborating",
-              "url": "https://www.neimagazine.com/news/amazon-invests-in-nuclear-energy/"
-            }
-          ]
+          "vector": "Energy"
         }
       ],
       "cc_count": 4
@@ -4399,14 +4537,7 @@
           "name": "Environmental Coordination",
           "mechanism": "DestinE Phase 1 deploys dedicated EuroHPC compute allocations for Earth system digital twins as the programme's explicit primary purpose at EU sovereign/multilateral scale.",
           "evidenceBasis": "Documented",
-          "pathway": "B",
-          "sources": [
-            {
-              "citation": "European Commission DestinE programme documentation",
-              "type": "primary",
-              "url": "https://ec.europa.eu/commission/presscorner/detail/nl/ip_22_1977"
-            }
-          ]
+          "pathway": "B"
         }
       ],
       "cc_count": 4
@@ -4442,14 +4573,7 @@
           "type": "ENT-2",
           "name": "Environmental Enablement",
           "mechanism": "Brazil PBIA establishes the 'Pro-Infra Sustainable AI initiative' mandating 'environmental sustainability, with the use of supercomputers powered by renewable energies' within Axis 1 infrastructure programmes.",
-          "evidenceBasis": "Documented",
-          "sources": [
-            {
-              "citation": "Brazil PBIA 2024-2028, CCT Resolution No. 4",
-              "type": "primary",
-              "url": "https://www.gov.br/mcti/pt-br/acompanhe-o-mcti/cct/legislacao/arquivos/IA_para_o_Bem_de_Todos.pdf"
-            }
-          ]
+          "evidenceBasis": "Documented"
         }
       ],
       "cc_count": 3
@@ -4515,17 +4639,7 @@
           "name": "Resource Demand",
           "mechanism": "IPCEI ME/CT fabs operate under ICPE authorisation (STMicro Crolles, 958 m³/h) and BImSchG permits (Infineon Dresden, 21.3M m³/year).",
           "evidenceBasis": "Documented",
-          "vector": "Water",
-          "sources": [
-            {
-              "citation": "ICPE/DREAL Auvergne-Rhône-Alpes environmental authorisation — STMicroelectronics Crolles",
-              "type": "primary"
-            },
-            {
-              "citation": "BImSchG permits, Landesdirektion Sachsen — Infineon Technologies Dresden",
-              "type": "primary"
-            }
-          ]
+          "vector": "Water"
         }
       ],
       "cc_count": 1
@@ -4620,19 +4734,7 @@
           "type": "ENT-4",
           "name": "Environmental Dependency",
           "mechanism": "WRI Aqueduct 4.0 classifies Oak Ridge, Tennessee sub-basin (Powell) as Medium-High baseline water stress (20–40%); Frontier's evaporative cooling towers create water-dependent operations in a stressed watershed.",
-          "evidenceBasis": "Assessed",
-          "sources": [
-            {
-              "citation": "WRI Aqueduct Water Risk Atlas V4.0 — Oak Ridge, TN (Powell sub-basin, Medium-High 20–40%)",
-              "type": "primary",
-              "url": "https://www.wri.org/applications/aqueduct/water-risk-atlas/"
-            },
-            {
-              "citation": "ORNL Energy Data Set of Frontier Supercomputer — evaporative cooling towers",
-              "type": "primary",
-              "url": "https://info.ornl.gov/sites/publications/Files/Pub207081.pdf"
-            }
-          ]
+          "evidenceBasis": "Assessed"
         }
       ],
       "cc_count": 4
@@ -4668,24 +4770,7 @@
           "type": "ENT-4",
           "name": "Environmental Dependency",
           "mechanism": "Livermore, California faces documented extreme drought risk (Alameda County Vulnerability Score 3, historical D4 exceptional drought classification) and wildfire risk; El Capitan’s evaporative cooling system circulates 5–9 million gallons of water daily through cooling towers, creating operational dependency on regional hydrological stability.",
-          "evidenceBasis": "Assessed",
-          "sources": [
-            {
-              "citation": "WRI Aqueduct Water Risk Atlas V4.0 — Livermore, CA (San Francisco Bay sub-basin, Low-Medium 10–20%)",
-              "type": "primary",
-              "url": "https://www.wri.org/applications/aqueduct/water-risk-atlas/"
-            },
-            {
-              "citation": "ND-GAIN Urban Adaptation Assessment — Alameda/Berkeley (Risk Score 51.52)",
-              "type": "primary",
-              "url": "https://gain-uaa.nd.edu/1600000US0606000/city_profile/"
-            },
-            {
-              "citation": "LLNL El Capitan Fun Facts — cooling towers, 5–9M gal/day",
-              "type": "primary",
-              "url": "https://hpc.llnl.gov/sites/default/files/El-Cap-Fun-Facts.pdf"
-            }
-          ]
+          "evidenceBasis": "Assessed"
         }
       ],
       "cc_count": 4
@@ -4721,60 +4806,19 @@
           "type": "ENT-1",
           "name": "Resource Demand",
           "mechanism": "Aurora's 60MW exascale computing facility creates documented demand on grid infrastructure (requiring dedicated 138kV transmission line construction with NEPA review), water resources (56.7 million gallons/year canal water), and land (tree-clearing for transmission infrastructure).",
-          "evidenceBasis": "Documented",
-          "sources": [
-            {
-              "citation": "DOE NEPA Categorical Exclusion — 138kV transmission line construction for Argonne",
-              "type": "primary",
-              "url": "https://www.energy.gov/sites/default/files/2019/01/f58/CX-019252.pdf"
-            },
-            {
-              "citation": "Argonne Site Sustainability Plan — HPC facilities energy and water use data",
-              "type": "primary",
-              "url": "https://www.anl.gov/sites/www/files/2020-06/Argonne_Site_Sustainability_Plan.pdf"
-            }
-          ]
+          "evidenceBasis": "Documented"
         },
         {
           "type": "ENT-2",
           "name": "Environmental Enablement",
           "mechanism": "DOE Order 436.1 establishes binding PUE efficiency targets (1.2–1.4 for new data centres) and sustainable acquisition requirements as operative conditions governing Aurora's facility operations at Argonne National Laboratory.",
-          "evidenceBasis": "Documented",
-          "sources": [
-            {
-              "citation": "Argonne Sustainability Plan FY2017 — DOE Order 436.1 mandate and PUE targets",
-              "type": "primary",
-              "url": "https://www.anl.gov/sites/www/files/2018-02/anl_site_sustainability_plan_20170101.pdf"
-            },
-            {
-              "citation": "Argonne Sustainability Plan FY2018 — prime contract sustainability clauses",
-              "type": "primary",
-              "url": "https://www.anl.gov/sites/www/files/2018-02/Argonne_SiteSustainabilityPlan_FY2018_0.pdf"
-            }
-          ]
+          "evidenceBasis": "Documented"
         },
         {
           "type": "ENT-4",
           "name": "Environmental Dependency",
           "mechanism": "Argonne National Laboratory is located in the Des Plaines Basin (WRI Aqueduct: High water stress, 40–80%) and requires water-based cooling consuming 56.7 million gallons/year, while Northern Illinois faces documented climate risks to grid infrastructure from heatwaves and flooding.",
-          "evidenceBasis": "Assessed",
-          "sources": [
-            {
-              "citation": "WRI Aqueduct classification via CDP disclosure — Des Plaines Basin (High, 40–80%)",
-              "type": "primary",
-              "url": "https://www.bms.com/assets/bms/us/en-us/pdf/bms-cdp-questions-questionnaire.pdf"
-            },
-            {
-              "citation": "Argonne climate risk publication — grid infrastructure vulnerability",
-              "type": "primary",
-              "url": "https://publications.anl.gov/anlpubs/2022/12/180058.pdf"
-            },
-            {
-              "citation": "CMAP regional risk assessment — flooding and infrastructure impacts",
-              "type": "primary",
-              "url": "https://cmap.illinois.gov/wp-content/uploads/dlm_uploads/Risk-based-Vulnerability-Assessment.pdf"
-            }
-          ]
+          "evidenceBasis": "Assessed"
         }
       ],
       "cc_count": 2
@@ -4897,40 +4941,19 @@
           "type": "ENT-1",
           "name": "Resource Demand",
           "mechanism": "Master Plant Development Agreement specifies 500MW total nuclear power capacity by 2035 dedicated to Google AI data centre operations.",
-          "evidenceBasis": "Documented",
-          "sources": [
-            {
-              "citation": "Kairos Power press release — 500 MW clean electricity generation partnership with Google",
-              "type": "primary",
-              "url": "https://kairospower.com/external_updates/google-and-kairos-power-partner-to-deploy-500-mw-of-clean-electricity-generation/"
-            }
-          ]
+          "evidenceBasis": "Documented"
         },
         {
           "type": "ENT-2",
           "name": "Environmental Enablement",
           "mechanism": "Master Plant Development Agreement allocates environmental attributes to Google under binding PPAs in support of Google's 24/7 carbon-free energy and net zero goals for AI data centre operations.",
-          "evidenceBasis": "Documented",
-          "sources": [
-            {
-              "citation": "Kairos Power press release — environmental attributes and 24/7 carbon-free commitments",
-              "type": "primary",
-              "url": "https://kairospower.com/external_updates/google-and-kairos-power-partner-to-deploy-500-mw-of-clean-electricity-generation/"
-            }
-          ]
+          "evidenceBasis": "Documented"
         },
         {
           "type": "ENT-4",
           "name": "Environmental Dependency",
           "mechanism": "NRC Environmental Report for Hermes 2 documents site-specific water consumption requirements (service water, potable water, decay heat removal, power generation makeup) totalling ~117 gpm for reactor operations in East Tennessee.",
-          "evidenceBasis": "Documented",
-          "sources": [
-            {
-              "citation": "NRC Environmental Report for Hermes 2 — Section 2.4 water use (Hermes 2 only; not fleet-wide)",
-              "type": "primary",
-              "url": "https://www.nrc.gov/docs/ML2319/ML23195A125.pdf"
-            }
-          ]
+          "evidenceBasis": "Documented"
         }
       ],
       "cc_count": 4
@@ -4995,19 +5018,7 @@
           "type": "ENT-1",
           "name": "Resource Demand",
           "mechanism": "Twenty-year PPA commits 1,121 MW of Clinton Clean Energy Center nuclear output to Meta AI infrastructure operations, with 30 MW of committed capacity uprates through 2029.",
-          "evidenceBasis": "Documented",
-          "sources": [
-            {
-              "citation": "Constellation Energy — Meta 20-year PPA announcement",
-              "type": "primary",
-              "url": "https://www.constellationenergy.com/news/2025/constellation-meta-sign-20-year-deal-for-clean-reliable-nuclear-energy-in-illinois.html"
-            },
-            {
-              "citation": "NRC Clinton 2024 Annual Radiological Environmental Operating Report",
-              "type": "primary",
-              "url": "https://www.nrc.gov/docs/ML2512/ML25122A164.pdf"
-            }
-          ]
+          "evidenceBasis": "Documented"
         }
       ],
       "cc_count": 4
@@ -5101,37 +5112,13 @@
           "type": "ENT-1",
           "name": "Resource Demand",
           "mechanism": "ABCI 3.0 commissions 6 MW electrical capacity and 5.2 MW cooling capacity across 144 racks operating 6,128 NVIDIA H200 GPUs, with measured PUE below 1.15 achieved through 32°C warm-water direct liquid cooling.",
-          "evidenceBasis": "Documented",
-          "sources": [
-            {
-              "citation": "Huang et al. — ABCI 3.0 architecture paper",
-              "type": "primary",
-              "url": "https://arxiv.org/html/2411.09134v1"
-            },
-            {
-              "citation": "AIST G-QuAT SC25 panel — ABCI 3.0 operational overview",
-              "type": "primary",
-              "url": "https://unit.aist.go.jp/g-quat/en/events/img/SC25/panels/04_ABCI3.pdf"
-            }
-          ]
+          "evidenceBasis": "Documented"
         },
         {
           "type": "ENT-4",
           "name": "Environmental Dependency",
           "mechanism": "Facility operational continuity at the Kashiwa site depends on Chiba Prefecture electrical transmission infrastructure with documented vulnerability to typhoon-induced tower collapse, evidenced by prolonged Chiba Prefecture blackouts following Typhoon Faxai (No. 15) in 2019; J-SHIS seismic hazard framework applies to site-specific assessment.",
-          "evidenceBasis": "Documented",
-          "sources": [
-            {
-              "citation": "World Bank — Strengthening Japan's Power System Resilience",
-              "type": "primary",
-              "url": "https://thedocs.worldbank.org/en/doc/eb847365035f52d6e3b2a8ef00aae974-0450022025/original/Strengthening-Japans-Power-System-Resilience.pdf"
-            },
-            {
-              "citation": "J-SHIS — Japan seismic hazard portal",
-              "type": "corroborating",
-              "url": "https://www.j-shis.bosai.go.jp/en/shm"
-            }
-          ]
+          "evidenceBasis": "Documented"
         }
       ],
       "cc_count": 0


### PR DESCRIPTION
## Summary
- Sync static fallback (`events-free.json`) with the WS-1.5 KV deployment.
- Sample events now carry `accessDate`, `captureStatus`, and `snapshotUrl` on every primary/corroborating source and on every ENT source.
- Non-sample events: `sources` stripped from each `environmentalNexusTags` entry (gating bug fix); `mechanism`, `type`, `name`, `evidenceBasis`, `vector` retained.
- Meta `cc_count` corrected to 103; `last_updated` set to 2026-04-19.

## Test plan
- [x] Live API `/api/events` returns 127 events with expected meta.
- [x] E01 (sample) free response: ENT keeps `sources` with `snapshotUrl`; `sources_primary[0]` carries `snapshotUrl`.
- [x] E11 (non-sample) free response: `sources_primary` absent; ENT has `mechanism` but no `sources`.
- [x] Live `/api/connections` returns 103 CCs; non-sample `evidence_detail` and `evidence_summary` stripped.
- [ ] Authenticated full-tier check (8.2): `sources_primary[0]` snapshot fields present on E10.
- [ ] Authenticated CC check (8.5): non-sample CC source carries `snapshotUrl` and `captureStatus`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)