### PR TITLE
Fix: Loop 12 post-entry corrections

### DIFF
--- a/events-free.json
+++ b/events-free.json
@@ -5237,8 +5237,8 @@
       "date": "2025-10-29",
       "location": "St. Joseph County, Indiana, United States",
       "scope": "United States (multi-site deployment; primary campus in Indiana)",
-      "description": "Amazon Web Services activated Project Rainier, deploying approximately 500,000 Trainium2 custom ASICs designed by Annapurna Labs as an EC2 UltraCluster of UltraServers. Primary campus in St. Joseph County, Indiana with $11 billion committed. Entirely non-GPU architecture dedicated exclusively to training and serving Anthropic's Claude AI models. NIPSCO GenCo established as ring-fenced power generation entity.",
-      "investment": "$11B (AWS Indiana campus commitment); ~500,000 Trainium2 custom ASICs; 2.2 GW designed IT load at full buildout; 2.4 GW NIPSCO GenCo ring-fenced power capacity",
+      "description": "Amazon Web Services activated Project Rainier, deploying approximately 500,000 Trainium2 custom ASICs designed by Annapurna Labs as an EC2 UltraCluster of UltraServers. Primary campus in St. Joseph County, Indiana with $11 billion committed. Entirely non-GPU architecture dedicated exclusively to training and serving Anthropic's Claude AI models.",
+      "investment": "$11B (AWS Indiana campus commitment); ~500,000 Trainium2 custom ASICs; 2.2 GW designed IT load at full buildout",
       "domain": "Energy/Infrastructure",
       "confidence": "A",
       "checkpoints": {
@@ -5252,19 +5252,13 @@
         {
           "type": "ENT-1",
           "name": "Resource Demand",
-          "mechanism": "The Rainier campus operates at 0.15 L/kWh water usage efficiency and implements seasonal cooling requiring no water use October–March, documenting measurable resource demand at the intersection of AI infrastructure and water systems.",
+          "mechanism": "The Rainier campus documents specific water consumption requirements for AI compute cooling at 0.15 L/kWh, with seasonal cooling water use April–September quantified in primary facility documentation.",
           "evidenceBasis": "Documented",
           "vector": "Water"
-        },
-        {
-          "type": "ENT-4",
-          "name": "Environmental Dependency",
-          "mechanism": "The Rainier campus in St. Joseph County, Indiana is confirmed outside FEMA and Indiana DNR flood hazard areas, within a jurisdiction ranked 17th globally on the ND-GAIN climate resilience index, documenting environmental dependency considerations in AI infrastructure siting.",
-          "evidenceBasis": "Assessed"
         }
       ],
       "source_count_primary": 4,
-      "source_count_corroborating": 3,
+      "source_count_corroborating": 0,
       "industry_primary": "Cloud, Data Centres & Connectivity Infrastructure",
       "cc_count": 2
     }


### PR DESCRIPTION
## Summary

- E157 (Project Rainier): removed NIPSCO content from description/investment, removed ENT-4 (inverted evidence), updated ENT-1 mechanism, cleared 3 corroborating sources (C1/C2 were ENT-4-only evidence, C3 was personal wiki), cleaned Basel Interconnectedness rationale
- CC-157-126-7 (Rainier ↔ Stargate): removed bilateral_statement and journalist-opinion sources (Time Magazine, The Register) — static fallback updated
- CC-151-99-7 (Meta-Constellation ↔ Amazon-Talen): reverted confidence CC-E → CC-A, removed elevation_rationale, removed Utility Dive journalist-characterisation source
- E153 (China Telecom Hunan): URL remediation — P1/P2/C1 now point to full paths instead of domain roots

KV deployments (events-free, events-full, connections) completed and verified via API spot checks.

## Test plan

- [x] 130 events / 107 CCs count verified via API
- [x] E157: 0 corroborating sources, ENT-1 only, no NIPSCO in description/investment/Basel rationale
- [x] CC-157-126-7: 2 sources, no bilateral_statement
- [x] CC-151-99-7: CC-A confidence, no elevation_rationale, 3 sources (no Utility Dive)
- [x] E153: full URL paths on P1 and C1
- [x] Unauthenticated connections: evidence_summary/detail stripped from non-sample CCs
- [x] Authenticated connections: full evidence data present

🤖 Generated with [Claude Code](https://claude.com/claude-code)