### PR TITLE
fix: atlas mobile bottom sheet v2

### DIFF
--- a/atlas.html
+++ b/atlas.html
@@ -3547,6 +3547,8 @@
             }
             .atlas-panel-v2.state-full {
                 transform: translateY(0) !important;
+                top: env(safe-area-inset-top, 0px) !important;
+                border-radius: 0;
             }
             .atlas-panel-v2.state-peek,
             .atlas-panel-v2.state-half,
@@ -3556,6 +3558,9 @@
             .atlas-panel-v2.state-peek #atlas-panel-content > .atlas-panel-section {
                 visibility: hidden;
                 height: 0;
+                overflow: hidden;
+            }
+            .atlas-panel-v2.state-peek #atlas-panel-content {
                 overflow: hidden;
             }
             .atlas-panel-v2.state-peek .atlas-panel-action-footer {
@@ -6586,6 +6591,8 @@
                 if (!panel) return;
                 panel.classList.remove('state-peek', 'state-half', 'state-full');
                 panel.scrollTop = 0;
+                var panelContent = document.getElementById('atlas-panel-content');
+                if (panelContent) panelContent.scrollTop = 0;
                 if (newState === 'closed') {
                     sheetState = 'closed';
                     return;


### PR DESCRIPTION
Residual bottom-sheet fixes after v1 (PR #29).

- **B1**: `state-full` panel now starts below iOS status bar / Dynamic Island via `env(safe-area-inset-top)` — header and X button are reachable
- **B2**: `#atlas-panel-content.scrollTop` reset on every state transition (the inner scroll container, not just the outer panel)
- **B3**: `overflow: hidden` on `#atlas-panel-content` in peek state clips bleed-through above the sample badge

## Verification
- [ ] In state-full, header and X button visible below status bar / Dynamic Island
- [ ] Swipe to full → scroll → swipe back to peek: no grey ghost
- [ ] No text bleeds through in peek state above the sample badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)