### PR TITLE
fix: atlas mobile bottom sheet v3

### DIFF
--- a/atlas.html
+++ b/atlas.html
@@ -3547,7 +3547,7 @@
             }
             .atlas-panel-v2.state-full {
                 transform: translateY(0) !important;
-                top: env(safe-area-inset-top, 0px) !important;
+                padding-top: env(safe-area-inset-top, 0px);
                 border-radius: 0;
             }
             .atlas-panel-v2.state-peek,
@@ -3558,9 +3558,6 @@
             .atlas-panel-v2.state-peek #atlas-panel-content > .atlas-panel-section {
                 visibility: hidden;
                 height: 0;
-                overflow: hidden;
-            }
-            .atlas-panel-v2.state-peek #atlas-panel-content {
                 overflow: hidden;
             }
             .atlas-panel-v2.state-peek .atlas-panel-action-footer {


### PR DESCRIPTION
Corrections to v2 fixes (PR #30).

- **C1**: `state-full` now uses `padding-top: env(safe-area-inset-top, 0px)` instead of `top`. The `top` approach changed panel geometry between states, causing a grey flash during the swipe-down transition. `padding-top` keeps geometry identical across all states — only internal content offset changes.
- **C2**: Removed `overflow: hidden` from `#atlas-panel-content` in peek state. It broke `position: sticky` on the panel header in iOS Safari, producing the grey block delay. The outer panel already has `overflow-y: hidden` (A5, v1) which handles clipping.

## Verification
- [ ] Swipe down from full → peek: no grey delay
- [ ] Header and X button visible below Dynamic Island in full state
- [ ] No text bleed-through above sample badge in peek state

🤖 Generated with [Claude Code](https://claude.com/claude-code)