### PR TITLE
fix: viewport-fit=cover for Safari safe area

### DIFF
--- a/atlas.html
+++ b/atlas.html
@@ -6,7 +6,7 @@
     <link rel="icon" type="image/png" sizes="48x48" href="favicon_48x48.png">
     <link rel="icon" type="image/png" sizes="32x32" href="favicon_32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="favicon_16x16.png">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title>Interactive Atlas — Warmth Engine Observatory</title>
     <meta name="description" content="Interactive coordination atlas — network view of verified AI infrastructure events and their Coordination Connections. Brief 1: CHIPS Act family.">
     <meta name="keywords" content="Warmth Engine Observatory, WEO atlas, interactive network, coordination connections, CHIPS Act, event network, geopolitical coordination">


### PR DESCRIPTION
D1: adds viewport-fit=cover to viewport meta. Without this, env(safe-area-inset-top) returns 0px in iOS Safari regardless of device — fixes C1/B1 had zero effect on Safari. Chrome does not require the flag. No layout side-effects: Atlas top nav is not flush against the screen edge.