### PR TITLE
Fix: atlas.html footer Updated date now populates dynamically

### DIFF
--- a/atlas.html
+++ b/atlas.html
@@ -4479,10 +4479,10 @@
             const degVals = Object.values(globalDegree);
             maxDegree = degVals.length ? Math.max.apply(null, degVals) : 0;
 
-            if (eventsPayload && eventsPayload.last_updated) {
+            if (eventsPayload && eventsPayload.meta && eventsPayload.meta.last_updated) {
                 const el = document.getElementById('weo-last-updated');
                 if (el) {
-                    let dateStr = eventsPayload.last_updated;
+                    let dateStr = eventsPayload.meta.last_updated;
                     try {
                         const d = new Date(dateStr + 'T00:00:00Z');
                         if (!isNaN(d)) {


### PR DESCRIPTION
## Summary
- The footer `Updated —` on atlas.html was always showing `—` because the code checked `eventsPayload.last_updated` (top-level) but the API response nests it under `eventsPayload.meta.last_updated`
- Fix: read from `eventsPayload.meta.last_updated` so the date populates dynamically from the same API payload that events.html and index.html use

🤖 Generated with [Claude Code](https://claude.com/claude-code)