### PR TITLE
fix(ui): split Tier Classification and Bloc Analysis into separate locked sections

### DIFF
--- a/events.html
+++ b/events.html
@@ -5489,14 +5489,23 @@ const openModal = (id) => {
             </div>
         `;
 
-        // Brief 4 §3.8 — Methodology locked-state. Significance
-        // Assessment is now a sibling section (above), so this covers
-        // tier rationale + bloc analysis only.
+        // Brief 4 §3.8 — Tier Classification and Bloc Analysis locked-state.
+        // Each section is separate to match atlas.html.
         html += `
             <div class="detail-section">
-                <div class="detail-section-title">Methodology</div>
+                <div class="detail-section-title">Tier Classification</div>
                 <div class="panel-section-locked">
-                    Tier rationale and bloc analysis details available with Analyst access.<br>
+                    Tier Classification available with Analyst access.<br>
+                    <a href="support.html">Subscribe →</a>
+                </div>
+            </div>
+        `;
+
+        html += `
+            <div class="detail-section">
+                <div class="detail-section-title">Bloc Analysis</div>
+                <div class="panel-section-locked">
+                    Bloc Analysis available with Analyst access.<br>
                     <a href="support.html">Subscribe →</a>
                 </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -9538,15 +9538,19 @@ function generateCCSection(eventId, showFullContent) {
         '<a href="support.html">Subscribe →</a>' +
         '</div></div>';
 
-      // Brief 4 §3.8 — Methodology locked-state for free non-sample.
-      // Significance Assessment is now a sibling section, so this covers
-      // tier rationale + bloc analysis only (Basel-5 reference removed
-      // from the placeholder copy).
+      // Brief 4 §3.8 — Tier Classification and Bloc Analysis locked-state
+      // for free non-sample. Each section is separate to match atlas.html.
       const methodologyLockedHtml =
         '<div class="panel-section">' +
-        '<div class="section-title">Methodology</div>' +
+        '<div class="section-title">Tier Classification</div>' +
         '<div class="panel-section-locked">' +
-        'Tier rationale and bloc analysis details available with Analyst access.<br>' +
+        'Tier Classification available with Analyst access.<br>' +
+        '<a href="support.html">Subscribe →</a>' +
+        '</div></div>' +
+        '<div class="panel-section">' +
+        '<div class="section-title">Bloc Analysis</div>' +
+        '<div class="panel-section-locked">' +
+        'Bloc Analysis available with Analyst access.<br>' +
         '<a href="support.html">Subscribe →</a>' +
         '</div></div>';
       


### PR DESCRIPTION
## Summary
- index.html and events.html previously grouped Tier Classification and Bloc Analysis under a single "Methodology" locked section
- Atlas.html already treats each as its own collapsible section with standalone locked copy
- This aligns all three pages: each section now shows its own "available with Analyst access. Subscribe →" message

## Files changed
- `index.html` — split `methodologyLockedHtml` into two panel sections
- `events.html` — split single "Methodology" detail section into two separate sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)