### PR TITLE
fix: WEO codebase MOT — 44 findings across 10 files (May 2026)

### DIFF
--- a/404.html
+++ b/404.html
@@ -8,7 +8,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="favicon_16x16.png">
     <meta property="og:image" content="https://www.warmthengine.com/og-image.png">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Page Not Found | Warmth Engine Observatory</title>
+    <title>Page Not Found — Warmth Engine Observatory</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Geist:wght@100..900&family=Geist+Mono:wght@100..900&display=swap" rel="stylesheet">
@@ -20,6 +20,12 @@
             --weo-text-secondary: #CBD5E1;
             --weo-accent-hover: #60a5fa;
             --weo-western-glow: rgba(96, 165, 250, 0.15);
+            --weo-focus-ring: #60A5FA;
+            --weo-border-primary: #334155;
+            --weo-text-muted: #94A3B8;
+            --weo-radius-sm: 4px;
+            --weo-radius-md: 8px;
+            --weo-radius-lg: 12px;
         }
         
         * {
@@ -27,7 +33,10 @@
             padding: 0;
             box-sizing: border-box;
         }
-        
+
+        *:focus { outline: none; }
+        *:focus-visible { outline: 2px solid var(--weo-accent-hover); outline-offset: 2px; }
+
         body {
             font-family: 'Geist', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
             background: var(--weo-surface-base);
@@ -123,10 +132,19 @@
         /* Monospace data values */
         .error-code { font-weight: 480; }
 
+        @media (prefers-reduced-motion: reduce) {
+            *, *::before, *::after {
+                animation-duration: 0.01ms !important;
+                animation-iteration-count: 1 !important;
+                transition-duration: 0.01ms !important;
+            }
+        }
+
     </style>
 </head>
 <body>
-    <div class="container">
+    <a href="#main-content" class="sr-only" id="skip-link">Skip to main content</a>
+    <div class="container" id="main-content">
         <div class="error-code">404</div>
         <h1 class="error-title">Page Not Found</h1>
         <p class="error-message">

--- a/SCP_Design/WEO_RESPONSIVE_MOT_FIXES_LOG_MAY_2026.md
+++ b/SCP_Design/WEO_RESPONSIVE_MOT_FIXES_LOG_MAY_2026.md
@@ -1,0 +1,85 @@
+# WEO Responsive MOT Fixes Log — May 2026
+
+Source: `SCP_Design/WEO_RESPONSIVE_MOT_MAY_2026.md`
+
+## Summary
+
+| Section | Findings | Status |
+|---------|----------|--------|
+| 1 — Breakpoint Consistency | F-001 | ✅ Done |
+| 2 — Canvas & Interactive Elements | F-008, F-028 | ✅ Done |
+| 3 — Touch Targets | F-011, F-012, F-013, F-014 | ✅ Done |
+| 4 — Text Readability | F-015, F-016 | ✅ Done |
+| 5 — Mobile Navigation | F-020 | ✅ Done |
+| 6 — Viewport / dvh | F-023, F-024, F-025 | ✅ Done |
+
+---
+
+## Per-Finding Detail
+
+### F-001 — blocs.html breakpoint 769px → 768px
+- **File:** `blocs.html`
+- **Change:** `@media (min-width: 769px)` → `@media (min-width: 768px)` (line 1045)
+
+### F-008 — filter-select font-size 16px (iOS zoom prevention)
+- **Files:** `events.html`, `atlas.html`
+- **Change:** `.filter-select { font-size: 16px; }` added to mobile `@media (max-width: 767px)` block; `.filter-time-selects select { font-size: 16px; }` added to atlas mobile block
+
+### F-011 — modal-close touch target (events.html)
+- **File:** `events.html`
+- **Change:** `.modal-close` — added `min-width: 44px; min-height: 44px; display: flex; align-items: center; justify-content: center;`
+
+### F-012 — access-modal-close touch target
+- **Files:** `events.html`, `index.html`, `SCP_Design/index.html`
+- **Change:** `.access-modal-close` — added `min-width: 44px; min-height: 44px; display: flex; align-items: center; justify-content: center;`
+
+### F-013 — panel-close touch target (index.html)
+- **File:** `index.html`
+- **Change:** Desktop `.panel-close` width/height 32px → 44px (line 1555); mobile override 28px → 44px (line 2591)
+
+### F-014 — weo-nav-toggle touch target (8 files)
+- **Files:** `atlas.html`, `events.html`, `methodology.html`, `about.html`, `blocs.html`, `research.html`, `support.html`, `legal.html`
+- **Change:** Added `min-width: 44px; min-height: 44px;` to `.weo-nav-toggle` inside mobile `@media (max-width: 767px)` block
+
+### F-015 — legend-sample-star font-size (index.html)
+- **File:** `index.html`
+- **Change:** `.legend-sample-star { font-size: 9px }` → `font-size: 10px` (line 1262)
+
+### F-016 — weo-nav-logo font-size (atlas.html)
+- **File:** `atlas.html`
+- **Change:** `.weo-nav-logo { font-size: 8px }` → `font-size: 10px` (line 302)
+
+### F-020 — aria-expanded on nav toggle (6 files)
+- **Files:** `methodology.html`, `about.html`, `blocs.html`, `research.html`, `support.html`, `legal.html`
+- **Change (JS):** Added `const isOpen = navLinks.classList.contains('open'); navToggle.setAttribute('aria-expanded', isOpen);` after `navLinks.classList.toggle('open')`
+- **Change (HTML):** Added `aria-expanded="false"` to `<button class="weo-nav-toggle">` in each file
+
+### F-023 — detail-panel height 100dvh (index.html)
+- **File:** `index.html`
+- **Change:** Added `height: 100dvh;` after `height: 100vh;` (line 1302) as progressive enhancement
+
+### F-024 — scp-panel height 100dvh + JS pinning (SCP_Design/index.html)
+- **File:** `SCP_Design/index.html`
+- **Change (CSS):** Added `height: 100dvh;` after `height: 100vh;` on `.scp-panel` (line 5676)
+- **Change (JS):** Added `if (window.innerWidth <= 767) { panel.style.height = window.innerHeight + 'px'; }` in `openSCP()` (line 11534)
+
+### F-025 — atlas-panel-v2 max-height 100dvh (atlas.html)
+- **File:** `atlas.html`
+- **Change:** Added `max-height: 100dvh;` after `max-height: 100vh;` in mobile block (line 3618)
+
+### F-028 — atlas-network min-height 300px (atlas.html)
+- **File:** `atlas.html`
+- **Change:** `#atlas-network { min-height: 300px; }` added to mobile `@media (max-width: 767px)` block
+
+---
+
+## QA Checklist
+
+- [ ] iOS Safari: no 100vh overflow on detail panel (index), scp-panel, atlas bottom sheet
+- [ ] iOS Safari: no auto-zoom on filter selects (events, atlas)
+- [ ] Touch targets ≥ 44×44px: panel-close (index), nav toggle (all 8 files), modal-close (events, index, SCP)
+- [ ] `aria-expanded` updates correctly on nav toggle open/close (6 files)
+- [ ] Atlas canvas visible on mobile (min-height 300px)
+- [ ] blocs.html breakpoint: two-column layout switches at 768px not 769px
+- [ ] legend-sample-star star icon legible at 10px
+- [ ] weo-nav-logo text legible at 10px

--- a/about.html
+++ b/about.html
@@ -350,9 +350,11 @@
           
           .weo-nav-toggle {
             display: flex;
+            min-width: 44px;
+            min-height: 44px;
           }
         }
-        
+
         /* Header */
         .page-header {
             margin-bottom: var(--weo-space-2xl);
@@ -922,7 +924,7 @@
             <span class="weo-nav-logo">WEO</span>
             <span>Warmth Engine Observatory</span>
           </a>
-          <button class="weo-nav-toggle" id="navToggle" aria-label="Toggle navigation">
+          <button class="weo-nav-toggle" id="navToggle" aria-label="Toggle navigation" aria-expanded="false">
             <span></span>
             <span></span>
             <span></span>
@@ -1261,8 +1263,10 @@
       if (navToggle && navLinks) {
         navToggle.addEventListener('click', function() {
           navLinks.classList.toggle('open');
+          const isOpen = navLinks.classList.contains('open');
+          navToggle.setAttribute('aria-expanded', isOpen);
         });
-        
+
         // Close when clicking outside
         document.addEventListener('click', function(e) {
           if (!navLinks.contains(e.target) && !navToggle.contains(e.target)) {

--- a/about.html
+++ b/about.html
@@ -9,6 +9,7 @@
     <link rel="canonical" href="https://www.warmthengine.com/about.html">
     <meta property="og:url" content="https://www.warmthengine.com/about.html">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="weo-version" content="1.2.0">
     <title>About — Warmth Engine Observatory</title>
     <meta name="description" content="About the Warmth Engine Observatory — Coordination Intelligence on AI infrastructure dynamics across geopolitical blocs.">
     <meta name="keywords" content="Warmth Engine Observatory, WEO, AI infrastructure coordination, geopolitical analysis, evidence-based observation, institutional-grade methodology, Basel framework, Keohane coordination">
@@ -108,7 +109,6 @@
             --weo-status-positive: #22C55E;
             --weo-status-positive-bg: rgba(34, 197, 94, 0.12);
             --weo-status-negative: #F87171;
-            --weo-status-negative-bg: rgba(239, 68, 68, 0.12);
             
             /* Typography */
             --weo-font-sans: 'Geist', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
@@ -913,8 +913,9 @@
 </style>
 </head>
 <body>
-    <div class="container">
-        
+    <a href="#main-content" class="sr-only" id="skip-link">Skip to main content</a>
+    <div class="container" id="main-content">
+
         <!-- Navigation -->
         <nav class="weo-nav">
           <a href="/" class="weo-nav-brand">
@@ -962,11 +963,11 @@
                     <div class="stats-label">Current Database</div>
                     <div class="stats-grid">
                         <div class="stat-item">
-                            <div class="stat-value" id="weo-event-count">114</div>
+                            <div class="stat-value" id="weo-event-count">134</div>
                             <div class="stat-label">Verified Events</div>
                         </div>
                         <div class="stat-item">
-                            <div class="stat-value" id="weo-cc-count">96</div>
+                            <div class="stat-value" id="weo-cc-count">107</div>
                             <div class="stat-label">Coordination Connections</div>
                         </div>
                     </div>

--- a/atlas.html
+++ b/atlas.html
@@ -762,6 +762,12 @@
             display: flex;
             flex-direction: column;
             gap: 16px;
+            transition: border-color 250ms ease, box-shadow 250ms ease;
+        }
+        /* E4 — teal accent border when any filter is active */
+        #atlas-topology.filters-active {
+            border-left: 2px solid rgba(45, 212, 191, 0.5);
+            box-shadow: inset 3px 0 12px rgba(45, 212, 191, 0.06);
         }
         .topo-title {
             font-family: var(--font-sans);
@@ -831,6 +837,22 @@
         }
         .topo-kv-label { color: var(--text-secondary); }
         .topo-kv-value { color: var(--text-primary); font-weight: 500; }
+        /* E3 — clear-all text link inside the active-filter tally */
+        .topo-clear-link {
+            background: none;
+            border: none;
+            padding: 0;
+            margin-top: 4px;
+            font-family: var(--font-mono);
+            font-size: 11px;
+            color: var(--text-muted);
+            cursor: pointer;
+            text-decoration: underline;
+            text-underline-offset: 2px;
+            align-self: flex-start;
+            transition: color 150ms ease;
+        }
+        .topo-clear-link:hover { color: var(--text-primary); }
         .topo-expand-btn {
             /* Patch §3 — hidden until the "expand to full network"
                feature is implemented. Kept in DOM (not deleted) so
@@ -3894,6 +3916,10 @@
             <aside id="atlas-topology" aria-label="Coordination topology">
                 <h2 class="topo-title"><span class="topo-title-dot" aria-hidden="true"></span>Coordination topology</h2>
                 <div class="topo-summary" id="topo-summary">— events · — CCs</div>
+
+                <!-- E3 — active filter tally; populated and shown/hidden by
+                     renderActiveFilterTally() inside renderTopology(). -->
+                <div id="topo-active-filters" class="topo-section" style="display:none" aria-live="polite"></div>
 
                 <!-- Brief 3e §2 — Layout mode toggle (relocated from below
                      the Re-layout button per patch §2 so it stays above
@@ -7482,6 +7508,63 @@
         // when filter changes are applied. Brief 2 §3.4 success criterion:
         // "Topology strip stats update on filter change to reflect visible
         // elements only".
+
+        // E3 — populates the active-filter tally in the topology panel.
+        // Called from renderTopology so it updates on every state change.
+        // FILTER_DIMENSIONS / CC_TYPE_NAME / ENT_LABELS are referenced at
+        // call-time (not definition-time) so the forward-reference is safe.
+        function renderActiveFilterTally(filters) {
+            const el = document.getElementById('topo-active-filters');
+            if (!el) return;
+            const topoEl = document.getElementById('atlas-topology');
+            const active = hasAnyActiveFilter(filters);
+
+            // E4 — accent border
+            if (topoEl) topoEl.classList.toggle('filters-active', active);
+
+            if (!active) { el.style.display = 'none'; return; }
+
+            const lines = [];
+            if (filters.tier.length)
+                lines.push({ label: 'Tier',       value: filters.tier.map(v => 'T' + v).join(', ') });
+            if (filters.bloc.length)
+                lines.push({ label: 'Bloc',       value: filters.bloc.join(', ') });
+            if (filters.domain.length)
+                lines.push({ label: 'Domain',     value: filters.domain.join(', ') });
+            if (filters.eventType.length)
+                lines.push({ label: 'Type',       value: filters.eventType.join(', ') });
+            if (filters.industry.length)
+                lines.push({ label: 'Industry',   value: filters.industry.join(', ') });
+            if (filters.ent.length)
+                lines.push({ label: 'ENT',        value: filters.ent.map(v => ENT_LABELS[v] || v).join(', ') });
+            if (filters.ccType.length)
+                lines.push({ label: 'CC Type',    value: filters.ccType.map(v => CC_TYPE_NAME[Number(v)] || v).join(', ') });
+            if (filters.confidence.length)
+                lines.push({ label: 'Confidence', value: filters.confidence.join(', ') });
+            if (filters.timeRange && (filters.timeRange.start || filters.timeRange.end)) {
+                const from = filters.timeRange.start
+                    ? formatMonthYear(new Date(filters.timeRange.start + 'T00:00:00')) : '—';
+                const to = filters.timeRange.end
+                    ? formatMonthYear(new Date(filters.timeRange.end + 'T00:00:00')) : '—';
+                lines.push({ label: 'Time', value: from + ' → ' + to });
+            }
+            if (filters.search && filters.search.trim())
+                lines.push({ label: 'Search', value: '“' + filters.search.trim() + '”' });
+
+            let html = '<div class="topo-section-label">Active Filters</div>';
+            lines.forEach(({ label, value }) => {
+                html += `<div class="topo-kv-row">` +
+                    `<span class="topo-kv-label">${escapeHtml(label)}</span>` +
+                    `<span class="topo-kv-value">${escapeHtml(value)}</span>` +
+                    `</div>`;
+            });
+            html += '<button type="button" class="topo-clear-link">Clear all filters</button>';
+            el.innerHTML = html;
+            el.style.display = '';
+            const clearBtn = el.querySelector('.topo-clear-link');
+            if (clearBtn) clearBtn.addEventListener('click', clearAllFilters);
+        }
+
         function renderTopology(events, connections) {
             const totalEvents = events.length;
             const totalCCs = connections.length;
@@ -7584,6 +7667,10 @@
             rangeEl.innerHTML = `
                 <span class="topo-kv-label">First → Last</span>
                 <span class="topo-kv-value">${escapeHtml(first)} → ${escapeHtml(last)}</span>`;
+
+            // E3/E4 — active filter tally + accent border
+            const filtersForTally = typeof atlasState !== 'undefined' ? atlasState.filters : null;
+            if (filtersForTally) renderActiveFilterTally(filtersForTally);
         }
 
         // -----------------------------------------------------------------

--- a/atlas.html
+++ b/atlas.html
@@ -6,6 +6,7 @@
     <link rel="icon" type="image/png" sizes="48x48" href="favicon_48x48.png">
     <link rel="icon" type="image/png" sizes="32x32" href="favicon_32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="favicon_16x16.png">
+    <!-- user-scalable=no: intentional exception for Cytoscape canvas interaction. iOS pinch-zoom is prevented at the gesture level instead. env(safe-area-inset-*) is read via window.innerHeight in JS (not CSS) to compensate. -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, viewport-fit=cover">
     <title>Interactive Atlas — Warmth Engine Observatory</title>
     <meta name="description" content="Interactive coordination atlas — network view of verified AI infrastructure events and their Coordination Connections. Brief 1: CHIPS Act family.">
@@ -134,7 +135,7 @@
             --bloc-western: #60A5FA;
             --bloc-eastern: #FB923C;
             --bloc-cross: #2DD4BF;
-            --bloc-led-ring: rgba(239, 68, 68, 0.6);
+            --bloc-led-ring: rgba(248, 113, 113, 0.6);
             /* T2 red border — brief 1b §6.3. Same value as --bloc-led-ring
                but fully opaque; all T2 events (regardless of bloc) use this
                as their node border colour. */
@@ -306,7 +307,7 @@
         .weo-nav-title-sub {
             font-weight: 500;
             color: var(--text-muted);
-            font-size: 13px;
+            font-size: 12px;
             margin-left: 14px;
             padding-left: 14px;
             border-left: 1px solid var(--border-primary);
@@ -320,7 +321,7 @@
             padding: 6px 10px;
             color: var(--text-muted);
             text-decoration: none;
-            font-size: 13px;
+            font-size: 12px;
             font-weight: 500;
             border-radius: var(--radius-sm);
             transition: all var(--duration-fast) var(--ease-out);
@@ -574,8 +575,13 @@
             text-transform: uppercase;
             letter-spacing: 0.04em;
         }
-        .filter-time-row input {
-            padding: 6px 8px;
+        .filter-time-selects {
+            display: flex;
+            gap: 4px;
+        }
+        .filter-time-selects select {
+            flex: 1;
+            padding: 5px 6px;
             background: var(--bg-primary);
             border: 1px solid var(--border-primary);
             border-radius: var(--radius-sm);
@@ -583,6 +589,18 @@
             font-family: var(--font-mono);
             font-size: 12px;
             color-scheme: dark;
+            cursor: pointer;
+            appearance: auto;
+        }
+        .filter-time-selects select:focus {
+            outline: none;
+            border-color: var(--teal, #2dd4bf);
+        }
+        .filter-time-hint {
+            font-family: var(--font-mono);
+            font-size: 10px;
+            color: var(--text-muted);
+            padding-top: 2px;
         }
         .filter-search {
             /* Phase 2 P1 (Batch 2b+) — push to the far right now that
@@ -656,7 +674,7 @@
         .atlas-empty-state.visible { display: flex; }
         .atlas-empty-state-msg {
             color: var(--text-secondary);
-            font-size: 13px;
+            font-size: 12px;
         }
         .atlas-empty-state-clear {
             padding: 6px 14px;
@@ -762,12 +780,12 @@
             display: flex;
             flex-direction: column;
             gap: 16px;
-            transition: border-color 250ms ease, box-shadow 250ms ease;
         }
-        /* E4 — teal accent border when any filter is active */
-        #atlas-topology.filters-active {
-            border-left: 2px solid rgba(45, 212, 191, 0.5);
-            box-shadow: inset 3px 0 12px rgba(45, 212, 191, 0.06);
+        /* E4 — title dot shifts to teal when any filter is active */
+        #atlas-topology.filters-active .topo-title-dot {
+            background: #2dd4bf;
+            box-shadow: 0 0 0 2px rgba(45, 212, 191, 0.25);
+            transition: background 250ms ease, box-shadow 250ms ease;
         }
         .topo-title {
             font-family: var(--font-sans);
@@ -783,7 +801,7 @@
             width: 8px; height: 8px;
             border-radius: 50%;
             background: var(--bloc-western);
-            box-shadow: 0 0 0 2px rgba(239, 68, 68, 0.6);
+            box-shadow: 0 0 0 2px rgba(248, 113, 113, 0.6);
         }
         .topo-summary {
             font-family: var(--font-mono);
@@ -812,7 +830,7 @@
             font-size: 12px;
         }
         .topo-bar-wrap { display: flex; flex-direction: column; gap: 4px; }
-        .topo-bar-label { color: var(--text-secondary); font-size: 11.5px; }
+        .topo-bar-label { color: var(--text-secondary); font-size: 11px; }
         .topo-bar-track {
             background: rgba(148, 163, 184, 0.08);
             border-radius: 2px;
@@ -837,22 +855,6 @@
         }
         .topo-kv-label { color: var(--text-secondary); }
         .topo-kv-value { color: var(--text-primary); font-weight: 500; }
-        /* E3 — clear-all text link inside the active-filter tally */
-        .topo-clear-link {
-            background: none;
-            border: none;
-            padding: 0;
-            margin-top: 4px;
-            font-family: var(--font-mono);
-            font-size: 11px;
-            color: var(--text-muted);
-            cursor: pointer;
-            text-decoration: underline;
-            text-underline-offset: 2px;
-            align-self: flex-start;
-            transition: color 150ms ease;
-        }
-        .topo-clear-link:hover { color: var(--text-primary); }
         .topo-expand-btn {
             /* Patch §3 — hidden until the "expand to full network"
                feature is implemented. Kept in DOM (not deleted) so
@@ -1250,7 +1252,7 @@
             padding-right: 40px;
         }
         .panel-subtitle {
-            font-size: 13px;
+            font-size: 12px;
             color: #94A3B8;
             margin: 0 0 12px 0;
             font-family: var(--font-mono);
@@ -1278,15 +1280,15 @@
             position: relative;
         }
         .panel-badge.t1 { background: rgba(45, 212, 191, 0.15); color: #2DD4BF; border-radius: var(--weo-radius-sm); }
-        .panel-badge.t2 { background: rgba(239, 68, 68, 0.15); color: #F87171; border-radius: var(--weo-radius-sm); }
+        .panel-badge.t2 { background: rgba(248, 113, 113, 0.15); color: #F87171; border-radius: var(--weo-radius-sm); }
         .panel-badge.t3 { background: rgba(100, 116, 139, 0.15); color: #94A3B8; border-radius: var(--weo-radius-sm); }
         .panel-badge.western { background: rgba(96, 165, 250, 0.1); color: #60A5FA; border-radius: var(--weo-radius-lg); border: 1px solid rgba(96, 165, 250, 0.35); }
         .panel-badge.eastern { background: rgba(251, 146, 60, 0.1); color: #FB923C; border-radius: var(--weo-radius-lg); border: 1px solid rgba(251, 146, 60, 0.35); }
         .panel-badge.cross-bloc { background: rgba(45, 212, 191, 0.1); color: #2DD4BF; border-radius: var(--weo-radius-lg); border: 1px solid rgba(45, 212, 191, 0.35); }
-        .panel-badge.western-led { background: rgba(96, 165, 250, 0.1); color: #60A5FA; border-radius: var(--weo-radius-lg); border: 1px solid rgba(239, 68, 68, 0.6); }
-        .panel-badge.eastern-led { background: rgba(251, 146, 60, 0.1); color: #FB923C; border-radius: var(--weo-radius-lg); border: 1px solid rgba(239, 68, 68, 0.6); }
+        .panel-badge.western-led { background: rgba(96, 165, 250, 0.1); color: #60A5FA; border-radius: var(--weo-radius-lg); border: 1px solid rgba(248, 113, 113, 0.6); }
+        .panel-badge.eastern-led { background: rgba(251, 146, 60, 0.1); color: #FB923C; border-radius: var(--weo-radius-lg); border: 1px solid rgba(248, 113, 113, 0.6); }
         .panel-badge.technology { background: rgba(59, 130, 246, 0.12); color: #3B82F6; border-radius: var(--weo-radius-sm); border-left: 2px solid #3B82F6; }
-        .panel-badge.security { background: rgba(239, 68, 68, 0.12); color: #F87171; border-radius: var(--weo-radius-sm); border-left: 2px solid #F87171; }
+        .panel-badge.security { background: rgba(248, 113, 113, 0.12); color: #F87171; border-radius: var(--weo-radius-sm); border-left: 2px solid #F87171; }
         .panel-badge.trade { background: rgba(16, 185, 129, 0.12); color: #10B981; border-radius: var(--weo-radius-sm); border-left: 2px solid #10B981; }
         .panel-badge.energy { background: rgba(245, 158, 11, 0.12); color: #F59E0B; border-radius: var(--weo-radius-sm); border-left: 2px solid #F59E0B; }
         .panel-badge.cc-count {
@@ -1396,7 +1398,7 @@
         .ent-popover-line {
             display: block;
             margin-top: 4px;
-            font-size: 11.5px;
+            font-size: 11px;
             color: var(--text-secondary);
             line-height: 1.5;
             max-width: 66ch;
@@ -1505,7 +1507,7 @@
         @media (max-width: 767px) {
           #weo-tooltip-overlay {
             width: 310px;
-            font-size: 13px;
+            font-size: 12px;
             padding: 14px 16px;
           }
         }
@@ -1700,7 +1702,7 @@
             line-height: 1.4;
         }
         .atlas-chip-tier-1 { background: rgba(45, 212, 191, 0.18); color: #2DD4BF; }
-        .atlas-chip-tier-2 { background: rgba(239, 68, 68, 0.18); color: #F87171; }
+        .atlas-chip-tier-2 { background: rgba(248, 113, 113, 0.18); color: #F87171; }
         .atlas-chip-tier-3 { background: rgba(100, 116, 139, 0.18); color: #94A3B8; }
         .atlas-chip-confidence {
             background: transparent;
@@ -1792,7 +1794,7 @@
             display: flex;
             align-items: flex-start;
             gap: 10px;
-            font-size: 13px;
+            font-size: 12px;
             line-height: 1.4;
         }
         .atlas-checkpoint-icon {
@@ -1849,7 +1851,7 @@
             grid-template-columns: 130px 1fr;
             gap: 12px;
             align-items: baseline;
-            font-size: 13px;
+            font-size: 12px;
             line-height: 1.5;
         }
         .atlas-data-row .atlas-data-label {
@@ -1878,7 +1880,7 @@
             background: rgba(15, 23, 42, 0.4);
             border-left: 3px solid #2DD4BF;
             border-radius: var(--radius-sm);
-            font-size: 13px;
+            font-size: 12px;
             line-height: 1.5;
             color: var(--text-secondary);
             margin-bottom: 4px;
@@ -1982,11 +1984,11 @@
             top: calc(100% + 8px);
             left: 50%;
             transform: translateX(-50%);
-            background: #252B36;
+            background: var(--surface-elevated, #334155);
             border: 1px solid var(--border-subtle);
             border-radius: var(--radius-sm);
             padding: 10px 12px;
-            font-size: 11.5px;
+            font-size: 11px;
             line-height: 1.5;
             color: #CBD5E1;
             width: max-content;
@@ -2011,7 +2013,7 @@
             left: 50%;
             transform: translateX(-50%);
             border: 4px solid transparent;
-            border-bottom-color: #252B36;
+            border-bottom-color: var(--surface-elevated, #334155);
         }
         .atlas-ind-mechanism-popover .mechanism-title {
             font-size: 10px;
@@ -2091,8 +2093,8 @@
         .atlas-chip-bloc-western { background: rgba(96, 165, 250, 0.10); color: #60A5FA; border: 1px solid rgba(96, 165, 250, 0.35); border-radius: var(--radius-lg); }
         .atlas-chip-bloc-eastern { background: rgba(251, 146, 60, 0.10); color: #FB923C; border: 1px solid rgba(251, 146, 60, 0.35); border-radius: var(--radius-lg); }
         .atlas-chip-bloc-cross-bloc { background: rgba(45, 212, 191, 0.10); color: #2DD4BF; border: 1px solid rgba(45, 212, 191, 0.35); border-radius: var(--radius-lg); }
-        .atlas-chip-bloc-western-led { background: rgba(96, 165, 250, 0.10); color: #60A5FA; border: 1px solid rgba(239, 68, 68, 0.6); border-radius: var(--radius-lg); }
-        .atlas-chip-bloc-eastern-led { background: rgba(251, 146, 60, 0.10); color: #FB923C; border: 1px solid rgba(239, 68, 68, 0.6); border-radius: var(--radius-lg); }
+        .atlas-chip-bloc-western-led { background: rgba(96, 165, 250, 0.10); color: #60A5FA; border: 1px solid rgba(248, 113, 113, 0.6); border-radius: var(--radius-lg); }
+        .atlas-chip-bloc-eastern-led { background: rgba(251, 146, 60, 0.10); color: #FB923C; border: 1px solid rgba(248, 113, 113, 0.6); border-radius: var(--radius-lg); }
         .atlas-chip-bloc-non-aligned { background: rgba(148, 163, 184, 0.10); color: #94A3B8; border: 1px solid rgba(148, 163, 184, 0.35); border-radius: var(--radius-lg); }
         .atlas-ent-chips { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 8px; }
         .atlas-ent-chip {
@@ -2153,7 +2155,7 @@
         .atlas-cc-direction-arrow {
             color: var(--text-muted);
             font-family: var(--font-mono);
-            font-size: 13px;
+            font-size: 12px;
         }
         .atlas-cc-target {
             display: inline-flex;
@@ -2277,7 +2279,7 @@
             line-height: 1.3;
         }
         .atlas-cc-endpoint-meta {
-            font-size: 11.5px;
+            font-size: 11px;
             color: var(--text-secondary);
             font-family: var(--font-mono);
         }
@@ -2294,7 +2296,7 @@
         .atlas-cc-navigate-btn:hover { text-decoration: underline; }
         .atlas-cc-direction-divider {
             text-align: center;
-            font-size: 13px;
+            font-size: 12px;
             color: var(--text-muted);
             padding: 6px 0;
             font-family: var(--font-mono);
@@ -2314,7 +2316,7 @@
             padding: 8px 12px;
             background: rgba(15, 23, 42, 0.4);
             border-radius: var(--radius-sm);
-            font-size: 11.5px;
+            font-size: 11px;
             color: var(--text-secondary);
             line-height: 1.5;
             display: none;
@@ -2391,7 +2393,7 @@
             margin-left: auto;
         }
         .cc-evidence-content {
-            font-size: 13px;
+            font-size: 12px;
             color: #CBD5E1;
             line-height: 1.6;
         }
@@ -2510,7 +2512,7 @@
             padding: 12px 16px;
             margin: 16px 0;
             border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
-            font-size: 13px;
+            font-size: 12px;
             line-height: 1.5;
             font-style: italic;
             color: #E2E8F0;
@@ -2824,7 +2826,7 @@
         }
         .atlas-basel5-detail {
             margin-top: 6px;
-            font-size: 11.5px;
+            font-size: 11px;
             font-family: var(--font-mono);
             color: var(--text-secondary);
             display: none;
@@ -2853,7 +2855,7 @@
             align-items: baseline;
             /* Patch — match the density of other panel content; was
                inheriting the 16px body size and reading too large. */
-            font-size: 13px;
+            font-size: 12px;
         }
         .atlas-basel5-factor-row > span:nth-child(2) {
             /* The factor-name column. word-break removed in 3b.1 — the
@@ -2878,7 +2880,7 @@
         .atlas-section-locked-cta {
             color: #2DD4BF;
             text-decoration: none;
-            font-size: 11.5px;
+            font-size: 11px;
             font-family: var(--font-mono);
         }
         .atlas-section-locked-cta:hover { text-decoration: underline; }
@@ -2923,7 +2925,7 @@
         .atlas-sources-cta-row {
             display: flex;
             gap: 14px;
-            font-size: 11.5px;
+            font-size: 11px;
             font-family: var(--font-mono);
         }
         .atlas-sources-cta-row a {
@@ -3098,7 +3100,7 @@
             margin: 0 0 16px 0;
         }
         .atlas-upgrade-cta-list li {
-            font-size: 13px;
+            font-size: 12px;
             color: var(--text-muted);
             padding: 4px 0 4px 20px;
             position: relative;
@@ -3173,7 +3175,7 @@
             display: flex;
             align-items: center;
             gap: 8px;
-            font-size: 11.5px;
+            font-size: 11px;
             font-family: var(--font-mono);
             color: var(--text-secondary);
         }
@@ -3245,6 +3247,23 @@
             clip: rect(0, 0, 0, 0);
             white-space: nowrap;
             border: 0;
+        }
+        .sr-only:focus {
+            position: fixed;
+            top: 8px;
+            left: 8px;
+            width: auto;
+            height: auto;
+            padding: 8px 16px;
+            clip: auto;
+            clip-path: none;
+            white-space: normal;
+            background: var(--bg-card);
+            color: var(--text-primary);
+            border: 2px solid var(--focus-ring, #60A5FA);
+            border-radius: 4px;
+            z-index: 9999;
+            font-size: 14px;
         }
 
         /* Focus management — pointer interactions don't ring; keyboard
@@ -3355,7 +3374,7 @@
             font-size: 0.9375rem; font-family: var(--font-mono, 'Geist Mono', monospace);
             box-sizing: border-box;
         }
-        .access-input:focus { outline: none; border-color: #F59E0B; }
+        .access-input:focus { outline: 2px solid #F59E0B; outline-offset: 2px; border-color: #F59E0B; }
         .access-input.error { border-color: #F87171; }
         .access-error {
             display: none; align-items: center; gap: 0.375rem;
@@ -3762,7 +3781,7 @@
                 width: 100%;
                 justify-content: center;
                 padding: 12px 16px;
-                font-size: 13px;
+                font-size: 12px;
             }
         }
         /* V2 §4a — Timeline landscape hint (mobile portrait only). */
@@ -3806,11 +3825,7 @@
     </style>
 </head>
 <body>
-    <a href="#atlas-network" class="sr-only" id="skip-link"
-       onfocus="this.style.cssText='position:fixed;top:0;left:0;z-index:9999;padding:12px 24px;background:var(--bg-card);color:var(--text-primary);text-decoration:none;font-size:14px;border-radius:0 0 8px 0;clip:auto;width:auto;height:auto;'"
-       onblur="this.style.cssText=''">
-       Skip to main content
-    </a>
+    <a href="#main-content" class="sr-only" id="skip-link">Skip to main content</a>
     <div class="atlas-shell">
 
         <!-- Navigation -->
@@ -3916,10 +3931,6 @@
             <aside id="atlas-topology" aria-label="Coordination topology">
                 <h2 class="topo-title"><span class="topo-title-dot" aria-hidden="true"></span>Coordination topology</h2>
                 <div class="topo-summary" id="topo-summary">— events · — CCs</div>
-
-                <!-- E3 — active filter tally; populated and shown/hidden by
-                     renderActiveFilterTally() inside renderTopology(). -->
-                <div id="topo-active-filters" class="topo-section" style="display:none" aria-live="polite"></div>
 
                 <!-- Brief 3e §2 — Layout mode toggle (relocated from below
                      the Re-layout button per patch §2 so it stays above
@@ -7470,11 +7481,7 @@
 
             // Close filter popovers when tapping anywhere on the canvas.
             cy.on('tap', function(e) {
-                document.querySelectorAll('.filter-pill.open').forEach(p => {
-                    p.classList.remove('open');
-                    const pop = p.querySelector('.filter-popover, .filter-time-popover');
-                    if (pop) { pop.style.position = ''; pop.style.top = ''; pop.style.left = ''; pop.style.right = ''; }
-                });
+                closeAllFilterPills();
             });
 
             // DEF-NEXT — canvas-level mouseleave for Timeline scrubber
@@ -7508,62 +7515,6 @@
         // when filter changes are applied. Brief 2 §3.4 success criterion:
         // "Topology strip stats update on filter change to reflect visible
         // elements only".
-
-        // E3 — populates the active-filter tally in the topology panel.
-        // Called from renderTopology so it updates on every state change.
-        // FILTER_DIMENSIONS / CC_TYPE_NAME / ENT_LABELS are referenced at
-        // call-time (not definition-time) so the forward-reference is safe.
-        function renderActiveFilterTally(filters) {
-            const el = document.getElementById('topo-active-filters');
-            if (!el) return;
-            const topoEl = document.getElementById('atlas-topology');
-            const active = hasAnyActiveFilter(filters);
-
-            // E4 — accent border
-            if (topoEl) topoEl.classList.toggle('filters-active', active);
-
-            if (!active) { el.style.display = 'none'; return; }
-
-            const lines = [];
-            if (filters.tier.length)
-                lines.push({ label: 'Tier',       value: filters.tier.map(v => 'T' + v).join(', ') });
-            if (filters.bloc.length)
-                lines.push({ label: 'Bloc',       value: filters.bloc.join(', ') });
-            if (filters.domain.length)
-                lines.push({ label: 'Domain',     value: filters.domain.join(', ') });
-            if (filters.eventType.length)
-                lines.push({ label: 'Type',       value: filters.eventType.join(', ') });
-            if (filters.industry.length)
-                lines.push({ label: 'Industry',   value: filters.industry.join(', ') });
-            if (filters.ent.length)
-                lines.push({ label: 'ENT',        value: filters.ent.map(v => ENT_LABELS[v] || v).join(', ') });
-            if (filters.ccType.length)
-                lines.push({ label: 'CC Type',    value: filters.ccType.map(v => CC_TYPE_NAME[Number(v)] || v).join(', ') });
-            if (filters.confidence.length)
-                lines.push({ label: 'Confidence', value: filters.confidence.join(', ') });
-            if (filters.timeRange && (filters.timeRange.start || filters.timeRange.end)) {
-                const from = filters.timeRange.start
-                    ? formatMonthYear(new Date(filters.timeRange.start + 'T00:00:00')) : '—';
-                const to = filters.timeRange.end
-                    ? formatMonthYear(new Date(filters.timeRange.end + 'T00:00:00')) : '—';
-                lines.push({ label: 'Time', value: from + ' → ' + to });
-            }
-            if (filters.search && filters.search.trim())
-                lines.push({ label: 'Search', value: '“' + filters.search.trim() + '”' });
-
-            let html = '<div class="topo-section-label">Active Filters</div>';
-            lines.forEach(({ label, value }) => {
-                html += `<div class="topo-kv-row">` +
-                    `<span class="topo-kv-label">${escapeHtml(label)}</span>` +
-                    `<span class="topo-kv-value">${escapeHtml(value)}</span>` +
-                    `</div>`;
-            });
-            html += '<button type="button" class="topo-clear-link">Clear all filters</button>';
-            el.innerHTML = html;
-            el.style.display = '';
-            const clearBtn = el.querySelector('.topo-clear-link');
-            if (clearBtn) clearBtn.addEventListener('click', clearAllFilters);
-        }
 
         function renderTopology(events, connections) {
             const totalEvents = events.length;
@@ -7621,7 +7572,7 @@
             const maxConf = Math.max(1, ...Object.values(confCounts));
             const confEl = document.getElementById('topo-confidence');
             confEl.innerHTML = '';
-            const CONF_COLOUR = { 'CC-V': '#2DD4BF', 'CC-E': '#94A3B8', 'CC-A': '#64748B' };
+            const CONF_COLOUR = { 'CC-V': '#2DD4BF', 'CC-E': '#94A3B8', 'CC-A': '#94A3B8' };
             Object.entries(confCounts)
                 .sort((a, b) => b[1] - a[1])
                 .forEach(([lvl, n]) => {
@@ -7668,9 +7619,10 @@
                 <span class="topo-kv-label">First → Last</span>
                 <span class="topo-kv-value">${escapeHtml(first)} → ${escapeHtml(last)}</span>`;
 
-            // E3/E4 — active filter tally + accent border
-            const filtersForTally = typeof atlasState !== 'undefined' ? atlasState.filters : null;
-            if (filtersForTally) renderActiveFilterTally(filtersForTally);
+            // E4 — teal dot when any filter is active
+            const topoEl = document.getElementById('atlas-topology');
+            if (topoEl && typeof atlasState !== 'undefined')
+                topoEl.classList.toggle('filters-active', hasAnyActiveFilter(atlasState.filters));
         }
 
         // -----------------------------------------------------------------
@@ -10645,15 +10597,37 @@
                 popover.className = 'filter-popover';
                 if (dim.kind === 'time') {
                     popover.classList.add('filter-time-popover');
+                    // Build year options from actual event data range.
+                    const _evtYears = allEvents.map(e => {
+                        const d = parseEventDate(e.date);
+                        return d ? new Date(d).getFullYear() : null;
+                    }).filter(Boolean);
+                    const _minY = _evtYears.length ? Math.min(..._evtYears) : 2020;
+                    const _maxY = _evtYears.length ? Math.max(..._evtYears) : new Date().getFullYear();
+                    let _yearOpts = '<option value="">Year</option>';
+                    for (let y = _minY; y <= _maxY; y++)
+                        _yearOpts += `<option value="${y}">${y}</option>`;
+                    const _MONTHS = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+                    let _moOpts = '<option value="">Month</option>';
+                    _MONTHS.forEach((m, i) =>
+                        _moOpts += `<option value="${String(i + 1).padStart(2, '0')}">${m}</option>`);
+                    const _hint = `${_MONTHS[new Date(Math.min(..._evtYears.map(y => new Date(y,0,1)))).getMonth()]} ${_minY} – ${_MONTHS[11]} ${_maxY}`;
                     popover.innerHTML = `
                         <div class="filter-time-row">
-                            <label for="filter-time-start-${dim.key}">Start</label>
-                            <input type="date" id="filter-time-start-${dim.key}" class="filter-time-start">
+                            <label>From</label>
+                            <div class="filter-time-selects">
+                                <select class="filter-time-start-month">${_moOpts}</select>
+                                <select class="filter-time-start-year">${_yearOpts}</select>
+                            </div>
                         </div>
                         <div class="filter-time-row">
-                            <label for="filter-time-end-${dim.key}">End</label>
-                            <input type="date" id="filter-time-end-${dim.key}" class="filter-time-end">
+                            <label>To</label>
+                            <div class="filter-time-selects">
+                                <select class="filter-time-end-month">${_moOpts}</select>
+                                <select class="filter-time-end-year">${_yearOpts}</select>
+                            </div>
                         </div>
+                        <div class="filter-time-hint">Data: ${escapeHtml(_hint)}</div>
                         <button type="button" class="filter-popover-clear">Clear</button>
                     `;
                 } else {
@@ -10743,13 +10717,13 @@
             if (emptyClear) emptyClear.addEventListener('click', clearAllFilters);
 
             // Outside-click closes any open popover.
+            // Also check for portaled popovers (in document.body) so clicks inside
+            // them don't incorrectly trigger a close.
             document.addEventListener('click', (e) => {
-                if (!e.target.closest('.filter-pill')) {
-                    document.querySelectorAll('.filter-pill.open').forEach(p => {
-                        p.classList.remove('open');
-                        const pop = p.querySelector('.filter-popover, .filter-time-popover');
-                        if (pop) { pop.style.position = ''; pop.style.top = ''; pop.style.left = ''; pop.style.right = ''; }
-                    });
+                if (!e.target.closest('.filter-pill') &&
+                    !e.target.closest('.filter-popover') &&
+                    !e.target.closest('.filter-time-popover')) {
+                    closeAllFilterPills();
                 }
             });
 
@@ -10779,30 +10753,46 @@
             }
         }
 
+        // Closes every open filter pill and returns any portaled popover to its pill.
+        // Must be called before p.querySelector('.filter-popover') since portaled
+        // popovers live in document.body and querySelector would miss them.
+        function closeAllFilterPills() {
+            document.querySelectorAll('.filter-pill.open').forEach(p => {
+                const pop = p._portaledPop || p.querySelector('.filter-popover, .filter-time-popover');
+                if (pop) {
+                    if (pop.parentElement === document.body) p.appendChild(pop);
+                    pop.style.cssText = '';
+                }
+                p._portaledPop = null;
+                p.classList.remove('open');
+                const b = p.querySelector('.filter-pill-btn');
+                if (b) b.setAttribute('aria-expanded', 'false');
+            });
+        }
+
         function wireFilterPill(pill, dim, popover) {
             const btn = pill.querySelector('.filter-pill-btn');
             btn.addEventListener('click', (e) => {
                 e.stopPropagation();
                 const wasOpen = pill.classList.contains('open');
-                document.querySelectorAll('.filter-pill.open').forEach(p => {
-                    p.classList.remove('open');
-                    const pop = p.querySelector('.filter-popover, .filter-time-popover');
-                    if (pop) { pop.style.position = ''; pop.style.top = ''; pop.style.left = ''; pop.style.right = ''; }
-                });
+                closeAllFilterPills();
                 if (!wasOpen) {
                     pill.classList.add('open');
                     btn.setAttribute('aria-expanded', 'true');
                     if (window.innerWidth <= 1024) {
-                        const pop = pill.querySelector('.filter-popover, .filter-time-popover');
-                        if (pop) {
-                            const r = pill.getBoundingClientRect();
-                            const popWidth = parseInt(getComputedStyle(pop).minWidth) || 240;
-                            pop.style.position = 'fixed';
-                            pop.style.zIndex = '1000';
-                            pop.style.top = (r.bottom + 4) + 'px';
-                            pop.style.left = Math.max(8, Math.min(r.left, window.innerWidth - popWidth - 8)) + 'px';
-                            pop.style.right = 'auto';
-                        }
+                        // Portal popover to document.body so it escapes the
+                        // filter bar's overflow-x:auto / stacking context and
+                        // paints above the vis.js canvas on mobile.
+                        const r = btn.getBoundingClientRect();
+                        const popWidth = parseInt(getComputedStyle(popover).minWidth) || 240;
+                        document.body.appendChild(popover);
+                        pill._portaledPop = popover;
+                        popover.style.position = 'fixed';
+                        popover.style.zIndex = '9999';
+                        popover.style.display = 'block';
+                        popover.style.top = (r.bottom + 4) + 'px';
+                        popover.style.left = Math.max(8, Math.min(r.left, window.innerWidth - popWidth - 8)) + 'px';
+                        popover.style.right = 'auto';
                     }
                 } else {
                     btn.setAttribute('aria-expanded', 'false');
@@ -10810,19 +10800,28 @@
             });
 
             if (dim.kind === 'time') {
-                const start = popover.querySelector('.filter-time-start');
-                const end = popover.querySelector('.filter-time-end');
+                const startYearEl  = popover.querySelector('.filter-time-start-year');
+                const startMonthEl = popover.querySelector('.filter-time-start-month');
+                const endYearEl    = popover.querySelector('.filter-time-end-year');
+                const endMonthEl   = popover.querySelector('.filter-time-end-month');
                 const apply = () => {
-                    setAtlasFilter('timeRange', {
-                        start: start.value || null,
-                        end: end.value || null
-                    });
+                    const sy = startYearEl.value, sm = startMonthEl.value;
+                    const ey = endYearEl.value,   em = endMonthEl.value;
+                    // Year alone → Jan 1 / Dec 31. Year + month → first/last of that month.
+                    const startDate = sy ? `${sy}-${sm || '01'}-01` : null;
+                    const endDate = ey ? (() => {
+                        const mo = em || '12';
+                        const last = new Date(Number(ey), Number(mo), 0).getDate();
+                        return `${ey}-${mo}-${String(last).padStart(2, '0')}`;
+                    })() : null;
+                    setAtlasFilter('timeRange', (startDate || endDate)
+                        ? { start: startDate, end: endDate } : null);
                 };
-                start.addEventListener('change', apply);
-                end.addEventListener('change', apply);
+                [startYearEl, startMonthEl, endYearEl, endMonthEl]
+                    .forEach(el => el && el.addEventListener('change', apply));
                 popover.querySelector('.filter-popover-clear').addEventListener('click', () => {
-                    start.value = '';
-                    end.value = '';
+                    [startYearEl, startMonthEl, endYearEl, endMonthEl]
+                        .forEach(el => { if (el) el.value = ''; });
                     setAtlasFilter('timeRange', null);
                 });
             } else {
@@ -10852,10 +10851,14 @@
                 const countEl = pill.querySelector('.filter-pill-count');
                 if (dim.kind === 'time') {
                     const tr = state.filters.timeRange;
-                    const start = pill.querySelector('.filter-time-start');
-                    const end = pill.querySelector('.filter-time-end');
-                    if (start) start.value = (tr && tr.start) || '';
-                    if (end) end.value = (tr && tr.end) || '';
+                    const sy = pill.querySelector('.filter-time-start-year');
+                    const sm = pill.querySelector('.filter-time-start-month');
+                    const ey = pill.querySelector('.filter-time-end-year');
+                    const em = pill.querySelector('.filter-time-end-month');
+                    if (sy) sy.value = (tr && tr.start) ? tr.start.substring(0, 4) : '';
+                    if (sm) sm.value = (tr && tr.start) ? tr.start.substring(5, 7) : '';
+                    if (ey) ey.value = (tr && tr.end) ? tr.end.substring(0, 4) : '';
+                    if (em) em.value = (tr && tr.end) ? tr.end.substring(5, 7) : '';
                     const active = !!(tr && (tr.start || tr.end));
                     btn.classList.toggle('has-active', active);
                     countEl.hidden = !active;
@@ -11166,10 +11169,15 @@
         window.closeAccessModal = closeAccessModal;
     })();
 
-    // Console banner for parity with other pages (pattern from blocs.html).
+    // Console banner and version stamp — reads from meta[name="weo-version"].
     (function () {
         const v = document.querySelector('meta[name="weo-version"]');
-        if (v) console.log('WEO Atlas · v' + v.getAttribute('content'));
+        if (v) {
+            const ver = v.getAttribute('content');
+            console.log('WEO Atlas · v' + ver);
+            const stamp = document.getElementById('weo-version-stamp');
+            if (stamp) stamp.textContent = ver;
+        }
     })();
     </script>
 

--- a/atlas.html
+++ b/atlas.html
@@ -299,7 +299,7 @@
             border-radius: 6px;
             display: flex; align-items: center; justify-content: center;
             font-family: var(--font-mono);
-            font-size: 8px;
+            font-size: 10px;
             font-weight: 700;
             color: #2DD4BF;
             letter-spacing: 0.5px;
@@ -1582,6 +1582,44 @@
         /* Mobile escape / reset-view button — hidden on desktop */
         #atlas-escape-btn {
             display: none;
+        }
+        #atlas-fit-btn {
+            display: none;
+            align-items: center;
+            justify-content: center;
+            position: absolute;
+            bottom: 16px;
+            right: 16px;
+            width: 36px;
+            height: 36px;
+            border-radius: 8px;
+            background: rgba(15, 23, 42, 0.82);
+            border: 1px solid #334155;
+            color: #64748b;
+            box-shadow: 0 2px 6px rgba(0, 0, 0, 0.35);
+            z-index: 200;
+            backdrop-filter: blur(6px);
+            -webkit-backdrop-filter: blur(6px);
+            touch-action: manipulation;
+            cursor: pointer;
+            padding: 0;
+            transition: background 150ms, color 150ms, border-color 150ms;
+        }
+        #atlas-fit-btn.atlas-fit-btn--visible {
+            display: flex;
+        }
+        #atlas-fit-btn:hover {
+            background: rgba(30, 41, 59, 0.92);
+            border-color: #60a5fa;
+            color: #60a5fa;
+        }
+        #atlas-fit-btn:active {
+            background: rgba(37, 99, 235, 0.3);
+            color: #bfdbfe;
+        }
+        #atlas-fit-btn svg {
+            width: 16px;
+            height: 16px;
         }
 
         /* --- Free/paid gating (Atlas-prefixed; uses existing
@@ -3530,6 +3568,8 @@
             .weo-nav-toggle {
                 display: flex;
                 margin-left: 12px;
+                min-width: 44px;
+                min-height: 44px;
             }
             .weo-nav-links {
                 display: none;
@@ -3576,6 +3616,7 @@
                 right: 0 !important;
                 width: 100% !important;
                 max-height: 100vh;
+                max-height: 100dvh;
                 border-radius: 16px 16px 0 0;
                 box-shadow: 0 -4px 24px rgba(0, 0, 0, 0.4);
                 z-index: 600;
@@ -3685,6 +3726,9 @@
                 box-shadow: 0 0 0 1px rgba(96, 165, 250, 0.3),
                             0 0 24px rgba(96, 165, 250, 0.5);
             }
+            #atlas-fit-btn {
+                display: none !important;
+            }
 
             /* V2 §3c — header chrome sized so the "A" confidence pill and
                "X" close button don't collide with the title text. */
@@ -3719,6 +3763,7 @@
                 font-size: 12px;
                 padding: 6px 10px;
                 min-height: 36px;
+                touch-action: manipulation;
             }
             .filter-popover {
                 min-width: 200px;
@@ -3737,6 +3782,14 @@
             .filter-search {
                 font-size: 16px;
             }
+            /* F-008: prevent iOS Safari auto-zoom on year/month select focus */
+            .filter-time-selects select {
+                font-size: 16px;
+            }
+            /* F-028: minimum canvas height for short landscape viewports */
+            #atlas-network {
+                min-height: 300px;
+            }
             /* §4 — caption text */
             .atlas-caption {
                 font-size: 12px;
@@ -3748,6 +3801,7 @@
                 min-height: 36px;
                 padding: 8px 12px;
                 font-size: 11px;
+                touch-action: manipulation;
             }
             /* V2 §5 — CC inspection panel becomes a bottom sheet too. */
             .atlas-cc-panel {
@@ -3903,6 +3957,17 @@
                            min="0" max="1000" value="0" step="1" aria-label="Timeline progress" />
                     <span class="atlas-playback-date" id="atlas-playback-date">—</span>
                 </div>
+                <!-- Fit-to-view button — desktop only. Appears after user zooms/pans
+                     the graph; calls cy.fit() to restore the full overview. -->
+                <button id="atlas-fit-btn" type="button" aria-label="Fit graph to view" title="Fit graph to view">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                         stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                        <polyline points="15 3 21 3 21 9"/>
+                        <polyline points="9 21 3 21 3 15"/>
+                        <line x1="21" y1="3" x2="14" y2="10"/>
+                        <line x1="3" y1="21" x2="10" y2="14"/>
+                    </svg>
+                </button>
             </div>
 
             <!-- Mobile escape button — position:fixed so it survives
@@ -6256,6 +6321,7 @@
             // events present (defensive).
             const fitTargets = cy.nodes().filter(n => n.data('event'));
             cy.fit(fitTargets.length > 0 ? fitTargets : undefined, 40);
+            if (typeof window._atlasFitReset === 'function') window._atlasFitReset();
             syncSampleOverlays();
             // V3 fix R4 (DEF-047) — explicit sync after fit.
             // cy.fit fires viewport events but timing relative to
@@ -7448,6 +7514,55 @@
                 });
             }
 
+            // Fit-to-view button — desktop only. Shows whenever the user has
+            // zoomed or panned the canvas; hides on click or after programmatic
+            // cy.fit() calls (e.g. filter changes).
+            (function wireFitBtn() {
+                var fitBtn = document.getElementById('atlas-fit-btn');
+                if (!fitBtn) return;
+
+                var _vpTimer = null;
+
+                function showFitBtn() {
+                    fitBtn.classList.add('atlas-fit-btn--visible');
+                }
+                function hideFitBtn() {
+                    clearTimeout(_vpTimer);
+                    fitBtn.classList.remove('atlas-fit-btn--visible');
+                }
+
+                // Detect user-initiated pan (mouse drag on canvas).
+                var _pointerDown = false;
+                var cyCanvas = document.querySelector('#atlas-network canvas');
+                if (cyCanvas) {
+                    cyCanvas.addEventListener('pointerdown', function() { _pointerDown = true; }, { passive: true });
+                    document.addEventListener('pointerup', function() {
+                        setTimeout(function() { _pointerDown = false; }, 60);
+                    }, { passive: true });
+                    document.addEventListener('pointercancel', function() { _pointerDown = false; }, { passive: true });
+
+                    // Scroll-wheel zoom — no pointerdown fires for this.
+                    cyCanvas.addEventListener('wheel', function() {
+                        clearTimeout(_vpTimer);
+                        _vpTimer = setTimeout(showFitBtn, 250);
+                    }, { passive: true });
+                }
+
+                cy.on('viewport', function() {
+                    if (!_pointerDown) return;
+                    clearTimeout(_vpTimer);
+                    _vpTimer = setTimeout(showFitBtn, 80);
+                });
+
+                fitBtn.addEventListener('click', function() {
+                    cy.fit(undefined, 40);
+                    hideFitBtn();
+                });
+
+                // Expose so filter-change cy.fit() calls can also dismiss.
+                window._atlasFitReset = hideFitBtn;
+            })();
+
             // Click node → open event panel (clears CC panel if open).
             // State-driven so URL deep-linking (#event=06) reuses the
             // same code path.
@@ -7468,7 +7583,10 @@
 
             // Double-click empty canvas → re-fit
             cy.on('dbltap', (evt) => {
-                if (evt.target === cy) cy.fit(undefined, 40);
+                if (evt.target === cy) {
+                    cy.fit(undefined, 40);
+                    if (typeof window._atlasFitReset === 'function') window._atlasFitReset();
+                }
             });
 
             // Single click on empty canvas closes whichever panel is open.

--- a/blocs.html
+++ b/blocs.html
@@ -332,9 +332,11 @@
           
           .weo-nav-toggle {
             display: flex;
+            min-width: 44px;
+            min-height: 44px;
           }
         }
-        
+
         /* Header */
         .page-header {
             margin-bottom: var(--weo-space-2xl);
@@ -1042,7 +1044,7 @@
             }
         }
         
-        @media (min-width: 769px) {
+        @media (min-width: 768px) {
             .table-scroll-indicator {
                 display: none !important;
             }
@@ -1128,7 +1130,7 @@
             <span class="weo-nav-logo">WEO</span>
             <span>Warmth Engine Observatory</span>
           </a>
-          <button class="weo-nav-toggle" id="navToggle" aria-label="Toggle navigation">
+          <button class="weo-nav-toggle" id="navToggle" aria-label="Toggle navigation" aria-expanded="false">
             <span></span>
             <span></span>
             <span></span>
@@ -1730,8 +1732,10 @@
         if (navToggle && navLinks) {
           navToggle.addEventListener('click', function() {
             navLinks.classList.toggle('open');
+            const isOpen = navLinks.classList.contains('open');
+            navToggle.setAttribute('aria-expanded', isOpen);
           });
-          
+
           // Close when clicking outside
           document.addEventListener('click', function(e) {
             if (!navLinks.contains(e.target) && !navToggle.contains(e.target)) {

--- a/blocs.html
+++ b/blocs.html
@@ -1119,8 +1119,9 @@
 </style>
 </head>
 <body>
-    <div class="container">
-        
+    <a href="#main-content" class="sr-only" id="skip-link">Skip to main content</a>
+    <div class="container" id="main-content">
+
         <!-- Navigation -->
         <nav class="weo-nav">
           <a href="/" class="weo-nav-brand">
@@ -1233,7 +1234,7 @@
                             <span class="nation-tag">South Korea</span>
                             <span class="nation-tag">Taiwan</span>
                         </div>
-                        <button class="eu-toggle" id="eu-toggle" onclick="toggleEU()">
+                        <button class="eu-toggle" id="eu-toggle" onclick="toggleEU()" aria-expanded="false">
                             European Union (27 members)
                             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                                 <polyline points="6 9 12 15 18 9"/>
@@ -1716,8 +1717,10 @@
         function toggleEU() {
             const toggle = document.getElementById('eu-toggle');
             const members = document.getElementById('eu-members');
+            const isExpanded = toggle.classList.contains('expanded');
             toggle.classList.toggle('expanded');
             members.classList.toggle('visible');
+            toggle.setAttribute('aria-expanded', String(!isExpanded));
         }
         
         // Navigation toggle for mobile

--- a/events.html
+++ b/events.html
@@ -273,9 +273,11 @@
           
           .weo-nav-toggle {
             display: flex;
+            min-width: 44px;
+            min-height: 44px;
           }
         }
-        
+
         .page-header { margin-bottom: var(--weo-space-xl); padding-bottom: var(--weo-space-lg); border-bottom: 1px solid var(--weo-border-primary); }
         .page-title { font-size: 1.75rem; font-weight: 700; margin-bottom: var(--weo-space-xs); }
         
@@ -1332,15 +1334,20 @@
             z-index: 50;
             box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
         }
-        .modal-close { 
-            position: absolute; 
-            top: var(--weo-space-md); 
-            right: var(--weo-space-md); 
-            background: none; 
-            border: none; 
-            color: var(--weo-text-muted); 
-            cursor: pointer; 
+        .modal-close {
+            position: absolute;
+            top: var(--weo-space-md);
+            right: var(--weo-space-md);
+            background: none;
+            border: none;
+            color: var(--weo-text-muted);
+            cursor: pointer;
             font-size: 1.25rem;
+            min-width: 44px;
+            min-height: 44px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
             transition: color var(--weo-duration-fast) var(--weo-ease-out),
                         transform var(--weo-duration-instant) var(--weo-ease-out);
         }
@@ -1602,13 +1609,17 @@
             font-style: italic; 
         }
         
-        @media (max-width: 767px) { 
-            .detail-grid { grid-template-columns: 1fr; } 
+        @media (max-width: 767px) {
+            .detail-grid { grid-template-columns: 1fr; }
             .filters { flex-direction: column; align-items: stretch; }
-            .sample-legend { margin-left: 0; } 
-            .modal-context-banner { 
+            .sample-legend { margin-left: 0; }
+            .modal-context-banner {
                 margin: 0 var(--weo-space-md) var(--weo-space-sm) var(--weo-space-md);
             }
+            /* F-007: remove min-width constraint so search input stretches full width */
+            .search-input { min-width: 0; width: 100%; }
+            /* F-009: prevent iOS Safari auto-zoom on filter select focus */
+            .filter-select { font-size: 16px; }
         }
     
     /* ========================================
@@ -1773,6 +1784,8 @@
     .access-modal-close {
       background: transparent; border: none;
       color: #94A3B8; font-size: 1.5rem; cursor: pointer;
+      min-width: 44px; min-height: 44px;
+      display: flex; align-items: center; justify-content: center;
     }
     .access-modal-close:hover { color: #F1F5F9; }
     .access-modal-body { padding: 1.5rem 1.25rem; }

--- a/events.html
+++ b/events.html
@@ -17,6 +17,7 @@
     <meta name="twitter:description" content="Verified AI infrastructure coordination events classified by tier, domain, and bloc with industry tags.">
     <meta name="twitter:image" content="https://www.warmthengine.com/og-image.png">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="weo-version" content="1.2.0">
     <title>Events Database — Warmth Engine Observatory</title>
     <meta name="description" content="WEO event database — verified AI infrastructure coordination events classified by tier, domain, and bloc with industry and environmental nexus tags. Filter, search, and explore coordination dynamics.">
     <meta name="keywords" content="Warmth Engine Observatory, WEO events, AI infrastructure events, coordination database, Event Type, tier classification, domain classification, industry tags, verified events, geopolitical coordination, Coordination Connections">
@@ -366,18 +367,18 @@
         }
         /* Tier badges - standard rounded */
         .badge-t1 { background: rgba(45,212,191,0.15); color: var(--weo-tier-t1); border-radius: var(--weo-radius-sm); }
-        .badge-t2 { background: rgba(239,68,68,0.15); color: var(--weo-tier-t2); border-radius: var(--weo-radius-sm); }
+        .badge-t2 { background: rgba(248,113,113,0.15); color: var(--weo-tier-t2); border-radius: var(--weo-radius-sm); }
         .badge-t3 { background: rgba(148,163,184,0.15); color: var(--weo-tier-t3); border-radius: var(--weo-radius-sm); }
         /* Bloc badges - pill shape with subtle outline */
         .badge-western { background: rgba(96,165,250,0.1); color: var(--weo-bloc-western); border-radius: var(--weo-radius-lg); border: 1px solid rgba(96,165,250,0.35); }
         .badge-eastern { background: rgba(251,146,60,0.1); color: var(--weo-bloc-eastern); border-radius: var(--weo-radius-lg); border: 1px solid rgba(251,146,60,0.35); }
         .badge-cross { background: rgba(45,212,191,0.1); color: var(--weo-bloc-cross); border-radius: var(--weo-radius-lg); border: 1px solid rgba(45,212,191,0.35); }
         /* T2 -Led bloc badges - pill with red outline for fragmentation signal */
-        .badge-western-led { background: rgba(96,165,250,0.1); color: var(--weo-bloc-western); border-radius: var(--weo-radius-lg); border: 1px solid rgba(239,68,68,0.6); }
-        .badge-eastern-led { background: rgba(251,146,60,0.1); color: var(--weo-bloc-eastern); border-radius: var(--weo-radius-lg); border: 1px solid rgba(239,68,68,0.6); }
+        .badge-western-led { background: rgba(96,165,250,0.1); color: var(--weo-bloc-western); border-radius: var(--weo-radius-lg); border: 1px solid rgba(248,113,113,0.6); }
+        .badge-eastern-led { background: rgba(251,146,60,0.1); color: var(--weo-bloc-eastern); border-radius: var(--weo-radius-lg); border: 1px solid rgba(248,113,113,0.6); }
         /* Domain badges - squared with left accent bar */
         .badge-tech { background: rgba(59,130,246,0.12); color: var(--weo-domain-tech); border-radius: var(--weo-radius-sm); border-left: 2px solid var(--weo-domain-tech); }
-        .badge-security { background: rgba(239,68,68,0.12); color: var(--weo-domain-security); border-radius: var(--weo-radius-sm); border-left: 2px solid var(--weo-domain-security); }
+        .badge-security { background: rgba(248,113,113,0.12); color: var(--weo-domain-security); border-radius: var(--weo-radius-sm); border-left: 2px solid var(--weo-domain-security); }
         .badge-trade { background: rgba(16,185,129,0.12); color: var(--weo-domain-trade); border-radius: var(--weo-radius-sm); border-left: 2px solid var(--weo-domain-trade); }
         .badge-energy { background: rgba(245,158,11,0.12); color: var(--weo-domain-energy); border-radius: var(--weo-radius-sm); border-left: 2px solid var(--weo-domain-energy); }
         .badge-sample { background: rgba(245,158,11,0.2); color: var(--weo-sample-gold); }
@@ -505,7 +506,7 @@
             top: calc(100% + 8px);
             left: 50%;
             transform: translateX(-50%);
-            background: #252B36;
+            background: var(--surface-elevated, #334155);
             border: 1px solid rgba(255, 255, 255, 0.08);
             border-radius: var(--weo-radius-sm);
             padding: 6px 10px;
@@ -519,7 +520,7 @@
             box-shadow: 0 4px 16px rgba(0,0,0,0.5);
         }
         .ind-primary-popover::before { content:''; position:absolute; bottom:100%; left:50%; transform:translateX(-50%); border:5px solid transparent; border-bottom-color:rgba(255,255,255,0.08); }
-        .ind-primary-popover::after { content:''; position:absolute; bottom:100%; left:50%; transform:translateX(-50%); border:4px solid transparent; border-bottom-color:#252B36; }
+        .ind-primary-popover::after { content:''; position:absolute; bottom:100%; left:50%; transform:translateX(-50%); border:4px solid transparent; border-bottom-color:var(--surface-elevated, #334155); }
         .ind-primary-popover.visible { display: block; }
         .ind-tag.ind-primary.badge-ind-semi { background: rgba(173,180,255,0.18); color: rgba(173,180,255,0.9); border: 1px solid rgba(173,180,255,0.3); }
         .ind-tag.ind-primary.badge-ind-cloud { background: rgba(103,232,249,0.18); color: rgba(103,232,249,0.9); border: 1px solid rgba(103,232,249,0.3); }
@@ -576,7 +577,7 @@
             top: calc(100% + 8px);
             left: 50%;
             transform: translateX(-50%);
-            background: #252B36;
+            background: var(--surface-elevated, #334155);
             border: 1px solid rgba(255, 255, 255, 0.08);
             border-radius: var(--weo-radius-sm);
             padding: 10px 12px;
@@ -589,7 +590,7 @@
             box-shadow: 0 4px 16px rgba(0,0,0,0.5);
         }
         .ind-mechanism-popover::before { content:''; position:absolute; bottom:100%; left:50%; transform:translateX(-50%); border:5px solid transparent; border-bottom-color:rgba(255,255,255,0.08); }
-        .ind-mechanism-popover::after { content:''; position:absolute; bottom:100%; left:50%; transform:translateX(-50%); border:4px solid transparent; border-bottom-color:#252B36; }
+        .ind-mechanism-popover::after { content:''; position:absolute; bottom:100%; left:50%; transform:translateX(-50%); border:4px solid transparent; border-bottom-color:var(--surface-elevated, #334155); }
         .ind-mechanism-popover .mechanism-title { font-size:0.5625rem; font-weight:600; text-transform:uppercase; letter-spacing:0.05em; color:var(--weo-text-muted); margin-bottom:4px; }
         .ind-mechanism-popover.visible { display: block; }
 
@@ -615,9 +616,9 @@
         .ent-tag.ent-5:hover { background: rgba(124,168,196,0.1); border-color: rgba(124,168,196,0.55); color: rgba(124,168,196,0.9); }
 
         /* ENT mechanism popover */
-        .ent-mechanism-popover { display: none; position: absolute; top: calc(100% + 8px); left: 50%; transform: translateX(-50%); background: #252B36; border: 1px solid rgba(255,255,255,0.08); border-radius: var(--weo-radius-sm); padding: 10px 12px; font-size: 0.6875rem; line-height: 1.5; color: #CBD5E1; width: max-content; max-width: 280px; z-index: 1000; box-shadow: 0 4px 16px rgba(0,0,0,0.5); }
+        .ent-mechanism-popover { display: none; position: absolute; top: calc(100% + 8px); left: 50%; transform: translateX(-50%); background: var(--surface-elevated, #334155); border: 1px solid rgba(255,255,255,0.08); border-radius: var(--weo-radius-sm); padding: 10px 12px; font-size: 0.6875rem; line-height: 1.5; color: #CBD5E1; width: max-content; max-width: 280px; z-index: 1000; box-shadow: 0 4px 16px rgba(0,0,0,0.5); }
         .ent-mechanism-popover::before { content: ''; position: absolute; bottom: 100%; left: 50%; transform: translateX(-50%); border: 5px solid transparent; border-bottom-color: rgba(255,255,255,0.08); }
-        .ent-mechanism-popover::after { content: ''; position: absolute; bottom: 100%; left: 50%; transform: translateX(-50%); border: 4px solid transparent; border-bottom-color: #252B36; }
+        .ent-mechanism-popover::after { content: ''; position: absolute; bottom: 100%; left: 50%; transform: translateX(-50%); border: 4px solid transparent; border-bottom-color: var(--surface-elevated, #334155); }
         .ent-mechanism-popover .ent-popover-title { font-family: var(--weo-font-mono); font-size: 0.6875rem; font-weight: 600; margin-bottom: 4px; }
         .ent-mechanism-popover .ent-popover-title.ent-1 { color: #D4CC78; }
         .ent-mechanism-popover .ent-popover-title.ent-2 { color: #A8C686; }
@@ -912,7 +913,7 @@
         
         /* Evidence Content */
         .cc-evidence-content {
-            font-size: 13px;
+            font-size: 12px;
             color: #CBD5E1;
             line-height: 1.6;
         }
@@ -1038,7 +1039,7 @@
             padding: 12px 16px;
             margin: 16px 0;
             border-radius: 0 var(--weo-radius-sm) var(--weo-radius-sm) 0;
-            font-size: 13px;
+            font-size: 12px;
             line-height: 1.5;
             font-style: italic;
             color: #E2E8F0;
@@ -1753,7 +1754,7 @@
     }
     .access-modal-overlay.visible { opacity: 1; visibility: visible; }
     .access-modal {
-      background: #1E293B;
+      background: var(--weo-surface-raised);
       border: 1px solid #334155;
       border-radius: var(--weo-radius-lg);
       width: 90%; max-width: 400px;
@@ -1786,7 +1787,7 @@
       border-radius: var(--weo-radius-md); color: #F1F5F9;
       font-size: 0.9375rem; font-family: var(--weo-font-mono);
     }
-    .access-input:focus { outline: none; border-color: #F59E0B; }
+    .access-input:focus { outline: 2px solid #F59E0B; outline-offset: 2px; border-color: #F59E0B; }
     .access-input.error { border-color: #F87171; }
     .access-error { display: none; align-items: center; gap: 0.375rem; margin-top: 0.5rem; font-size: 0.8125rem; color: #F87171; }
     .access-error.visible { display: flex; }
@@ -1884,7 +1885,7 @@
     }
     
     #weo-tooltip-overlay .weo-tooltip-title {
-      font-size: 12.5px;
+      font-size: 12px;
       font-weight: 600;
       text-transform: uppercase;
       letter-spacing: 0.05em;
@@ -1906,7 +1907,7 @@
     @media (max-width: 767px) {
       #weo-tooltip-overlay {
         width: 310px;
-        font-size: 13px;
+        font-size: 12px;
         padding: 14px 16px;
       }
     }
@@ -2737,7 +2738,7 @@
         bottom: calc(100% + 8px);
         left: 50%;
         transform: translateX(-50%);
-        background: #252B36;
+        background: var(--surface-elevated, #334155);
         border: 1px solid rgba(255,255,255,0.08);
         border-radius: var(--weo-radius-sm);
         padding: 10px 12px;
@@ -2750,7 +2751,7 @@
         box-shadow: 0 4px 16px rgba(0,0,0,0.5);
     }
     .piet-t2-popover::before { content:''; position:absolute; top:100%; left:50%; transform:translateX(-50%); border:5px solid transparent; border-top-color:rgba(255,255,255,0.08); }
-    .piet-t2-popover::after { content:''; position:absolute; top:100%; left:50%; transform:translateX(-50%); border:4px solid transparent; border-top-color:#252B36; }
+    .piet-t2-popover::after { content:''; position:absolute; top:100%; left:50%; transform:translateX(-50%); border:4px solid transparent; border-top-color:var(--surface-elevated, #334155); }
     .piet-t2-popover .t2-popover-title { font-size:0.5625rem; font-weight:600; text-transform:uppercase; letter-spacing:0.05em; color:var(--weo-text-muted); margin-bottom:4px; }
     .piet-t2-popover.visible { display: block; }
     .piet-expand-trigger .badge-with-tooltip {
@@ -3045,14 +3046,14 @@
     }
 
     .empty-state-title {
-        font-size: 15px;
+        font-size: 14px;
         font-weight: 580;
         color: var(--weo-text-secondary, #CBD5E1);
         margin-bottom: 8px;
     }
 
     .empty-state-hint {
-        font-size: 13px;
+        font-size: 12px;
     }
 
 </style>
@@ -3146,7 +3147,7 @@
             </div>
         </div>
         
-        <div class="stats-bar" id="stats-bar"></div>
+        <div class="stats-bar" id="stats-bar" aria-live="polite"></div>
         
         <!-- CC Summary Section -->
         <div class="cc-summary" id="cc-summary">
@@ -3325,10 +3326,10 @@
             <p class="footer-links"><a href="legal.html">Privacy Policy & Terms of Service</a></p>
         </footer>
     </div>
-    <div class="modal-overlay" id="modal-overlay">
+    <div class="modal-overlay" id="modal-overlay" role="dialog" aria-modal="true" aria-label="Event details" aria-labelledby="modal-title">
         <div class="modal" id="event-modal">
             <div class="modal-header">
-                <button class="modal-close" id="modal-close">&times;</button>
+                <button class="modal-close" id="modal-close" aria-label="Close">&times;</button>
                 <h2 class="modal-title" id="modal-title"></h2>
                 <div class="modal-subtitle" id="modal-subtitle"></div>
                 <div class="modal-meta" id="modal-meta"></div>

--- a/index.html
+++ b/index.html
@@ -1259,7 +1259,7 @@
       position: absolute;
       top: -3px;
       right: -3px;
-      font-size: 9px;
+      font-size: 10px;
       color: #FFD700;
       text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
       z-index: 5;
@@ -1300,6 +1300,7 @@
       right: 0;
       width: 440px;
       height: 100vh;
+      height: 100dvh;
       background: var(--surface-raised);
       border-left: 1px solid #334155;
       box-shadow: -8px 0 24px rgba(0, 0, 0, 0.5), inset 0 1px 0 rgba(255, 255, 255, 0.03);
@@ -1556,8 +1557,8 @@
       position: absolute;
       top: 16px;
       right: 16px;
-      width: 32px;
-      height: 32px;
+      width: 44px;
+      height: 44px;
       background: transparent;
       border: 1px solid #475569;
       border-radius: var(--weo-radius-md);
@@ -2591,8 +2592,8 @@
       .panel-close {
         top: 12px;
         right: 12px;
-        width: 28px;
-        height: 28px;
+        width: 44px;
+        height: 44px;
         font-size: 16px;
       }
       
@@ -4813,6 +4814,8 @@
     .access-modal-close {
       background: transparent; border: none;
       color: #94A3B8; font-size: 1.5rem; cursor: pointer;
+      min-width: 44px; min-height: 44px;
+      display: flex; align-items: center; justify-content: center;
     }
     .access-modal-close:hover { color: #F1F5F9; }
     .access-modal-body { padding: 1.5rem 1.25rem; }

--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
   <meta name="twitter:description" content="Track AI infrastructure coordination dynamics across geopolitical blocs with verified events and mapped Coordination Connections.">
   <meta name="twitter:image" content="https://www.warmthengine.com/og-image.png">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="weo-version" content="1.2.0">
   <meta name="description" content="Track AI infrastructure coordination dynamics across geopolitical blocs with verified events and mapped coordination connections.">
   <meta name="keywords" content="Warmth Engine Observatory, WEO, AI infrastructure, coordination dynamics, geopolitical blocs, verified events, Coordination Connections, tier classification, Western Bloc, Eastern Bloc, Cross-Bloc, Between-Bloc, Intra-Bloc">
   <title>Warmth Engine Observatory</title>
@@ -130,8 +131,8 @@
       --surface-overlay: #334155;
       
       /* Text */
-      --text-secondary: rgba(226, 232, 240, 0.7);
-      --text-muted: rgba(226, 232, 240, 0.5);
+      --text-secondary: #CBD5E1;
+      --text-muted: #94A3B8;
       --text-label: rgba(226, 232, 240, 0.6);
       
       /* Interactive */
@@ -168,7 +169,7 @@
       --weo-surface-overlay: var(--surface-overlay);
       --weo-text-primary: #E2E8F0;
       --weo-text-secondary: rgba(226, 232, 240, 0.7);
-      --weo-text-muted: #94A3B8;
+      --weo-text-muted: var(--text-muted);
       --weo-text-label: rgba(226, 232, 240, 0.6);
       --weo-border-primary: #334155;
       --weo-duration-instant: var(--duration-instant);
@@ -352,7 +353,7 @@
       width: 36px;
       height: 36px;
       border-radius: 50%;
-      background: #1E293B;
+      background: var(--surface-raised);
       border: 2px solid;
       cursor: pointer;
       box-sizing: border-box;
@@ -418,7 +419,7 @@
     /* Tooltip styles */
     .map-tooltip {
       position: absolute;
-      background: #1E293B;
+      background: var(--surface-raised);
       border: 1px solid #334155;
       border-radius: var(--weo-radius-md);
       padding: 12px 16px;
@@ -469,7 +470,7 @@
 
     /* Tier badges - standard rounded */
     .badge-t1 { background: rgba(45, 212, 191, 0.15); color: #2DD4BF; border-radius: var(--weo-radius-sm); }
-    .badge-t2 { background: rgba(239, 68, 68, 0.15); color: #F87171; border-radius: var(--weo-radius-sm); }
+    .badge-t2 { background: rgba(248, 113, 113, 0.15); color: #F87171; border-radius: var(--weo-radius-sm); }
     .badge-t3 { background: rgba(100, 116, 139, 0.15); color: #94A3B8; border-radius: var(--weo-radius-sm); }
 
     /* Bloc badges - pill shape with subtle outline */
@@ -481,18 +482,18 @@
       background: rgba(96, 165, 250, 0.1); 
       color: #60A5FA; 
       border-radius: var(--weo-radius-lg);
-      border: 1px solid rgba(239, 68, 68, 0.6);
+      border: 1px solid rgba(248, 113, 113, 0.6);
     }
     .badge-eastern-led { 
       background: rgba(251, 146, 60, 0.1); 
       color: #FB923C; 
       border-radius: var(--weo-radius-lg);
-      border: 1px solid rgba(239, 68, 68, 0.6);
+      border: 1px solid rgba(248, 113, 113, 0.6);
     }
 
     /* Domain badges - squared with left accent bar */
     .badge-domain-tech { background: rgba(59, 130, 246, 0.12); color: #3B82F6; border-radius: var(--weo-radius-sm); border-left: 2px solid #3B82F6; }
-    .badge-domain-security { background: rgba(239, 68, 68, 0.12); color: #F87171; border-radius: var(--weo-radius-sm); border-left: 2px solid #F87171; }
+    .badge-domain-security { background: rgba(248, 113, 113, 0.12); color: #F87171; border-radius: var(--weo-radius-sm); border-left: 2px solid #F87171; }
     .badge-domain-trade { background: rgba(16, 185, 129, 0.12); color: #10B981; border-radius: var(--weo-radius-sm); border-left: 2px solid #10B981; }
     .badge-domain-energy { background: rgba(245, 158, 11, 0.12); color: #F59E0B; border-radius: var(--weo-radius-sm); border-left: 2px solid #F59E0B; }
 
@@ -627,7 +628,7 @@
     .marker-cluster-medium {
       width: 48px;
       height: 48px;
-      font-size: 15px;
+      font-size: 14px;
     }
 
     .marker-cluster-large {
@@ -686,14 +687,14 @@
     }
     
     .weo-status-title {
-      font-size: 15px;
+      font-size: 14px;
       font-weight: 600;
       color: #F1F5F9;
       letter-spacing: 0.02em;
     }
     
     .weo-status-stats {
-      font-size: 15px;
+      font-size: 14px;
       font-weight: 600;
       color: #F1F5F9;
       letter-spacing: -0.01em;
@@ -762,7 +763,7 @@
     }
     .weo-status-wer-value {
       font-family: 'Geist Mono', 'Fira Code', 'Consolas', monospace;
-      font-size: 15px;
+      font-size: 14px;
       font-weight: 600;
       color: var(--weo-wer-amber);
       animation: wer-glow 3s ease-in-out infinite;
@@ -805,7 +806,7 @@
       }
       
       .weo-status-title {
-        font-size: 13px;
+        font-size: 12px;
       }
     }
 
@@ -904,7 +905,7 @@
       padding: 12px 16px;
       color: #CBD5E1;
       text-decoration: none;
-      font-size: 13px;
+      font-size: 12px;
       font-weight: 500;
       transition: all var(--duration-fast) var(--ease-out);
       border-bottom: 1px solid rgba(51, 65, 85, 0.5);
@@ -1003,7 +1004,7 @@
     }
 
     .orientation-content p {
-      font-size: 13px;
+      font-size: 12px;
       color: #CBD5E1;
       line-height: 1.6;
       margin-bottom: 12px;
@@ -1149,7 +1150,7 @@
     }
 
     .legend-title {
-      font-size: 13px;
+      font-size: 12px;
       font-weight: 600;
       color: #F1F5F9;
       text-transform: uppercase;
@@ -1216,7 +1217,7 @@
       width: 24px;
       height: 24px;
       border-radius: 50%;
-      background: #1E293B;
+      background: var(--surface-raised);
       border: 2px solid;
       display: flex;
       align-items: center;
@@ -1299,7 +1300,7 @@
       right: 0;
       width: 440px;
       height: 100vh;
-      background: #1E293B;
+      background: var(--surface-raised);
       border-left: 1px solid #334155;
       box-shadow: -8px 0 24px rgba(0, 0, 0, 0.5), inset 0 1px 0 rgba(255, 255, 255, 0.03);
       transform: translateX(100%);
@@ -1486,7 +1487,7 @@
     
     .peek-expand-prompt .peek-text {
       display: block;
-      font-size: 13px;
+      font-size: 12px;
       font-weight: 600;
       color: #F59E0B;
       margin-top: 6px;
@@ -1599,7 +1600,7 @@
     .panel-title:active { opacity: 0.65; }
 
     .panel-subtitle {
-      font-size: 13px;
+      font-size: 12px;
       color: #94A3B8;
       margin-bottom: 12px;
     }
@@ -1648,7 +1649,7 @@
 
     /* Tier badges - standard rounded */
     .panel-badge.t1 { background: rgba(45, 212, 191, 0.15); color: #2DD4BF; border-radius: var(--weo-radius-sm); }
-    .panel-badge.t2 { background: rgba(239, 68, 68, 0.15); color: #F87171; border-radius: var(--weo-radius-sm); }
+    .panel-badge.t2 { background: rgba(248, 113, 113, 0.15); color: #F87171; border-radius: var(--weo-radius-sm); }
     .panel-badge.t3 { background: rgba(100, 116, 139, 0.15); color: #94A3B8; border-radius: var(--weo-radius-sm); }
     
     /* Bloc badges - pill shape with subtle outline */
@@ -1657,12 +1658,12 @@
     .panel-badge.cross-bloc { background: rgba(45, 212, 191, 0.1); color: #2DD4BF; border-radius: var(--weo-radius-lg); border: 1px solid rgba(45, 212, 191, 0.35); }
     
     /* T2 -Led bloc badges - pill with red outline for fragmentation signal */
-    .panel-badge.western-led { background: rgba(96, 165, 250, 0.1); color: #60A5FA; border-radius: var(--weo-radius-lg); border: 1px solid rgba(239, 68, 68, 0.6); }
-    .panel-badge.eastern-led { background: rgba(251, 146, 60, 0.1); color: #FB923C; border-radius: var(--weo-radius-lg); border: 1px solid rgba(239, 68, 68, 0.6); }
+    .panel-badge.western-led { background: rgba(96, 165, 250, 0.1); color: #60A5FA; border-radius: var(--weo-radius-lg); border: 1px solid rgba(248, 113, 113, 0.6); }
+    .panel-badge.eastern-led { background: rgba(251, 146, 60, 0.1); color: #FB923C; border-radius: var(--weo-radius-lg); border: 1px solid rgba(248, 113, 113, 0.6); }
 
     /* Domain badges - squared with left accent bar */
     .panel-badge.technology { background: rgba(59, 130, 246, 0.12); color: #3B82F6; border-radius: var(--weo-radius-sm); border-left: 2px solid #3B82F6; }
-    .panel-badge.security { background: rgba(239, 68, 68, 0.12); color: #F87171; border-radius: var(--weo-radius-sm); border-left: 2px solid #F87171; }
+    .panel-badge.security { background: rgba(248, 113, 113, 0.12); color: #F87171; border-radius: var(--weo-radius-sm); border-left: 2px solid #F87171; }
     .panel-badge.trade { background: rgba(16, 185, 129, 0.12); color: #10B981; border-radius: var(--weo-radius-sm); border-left: 2px solid #10B981; }
     .panel-badge.energy { background: rgba(245, 158, 11, 0.12); color: #F59E0B; border-radius: var(--weo-radius-sm); border-left: 2px solid #F59E0B; }
     
@@ -1740,7 +1741,7 @@
       top: calc(100% + 8px);
       left: 50%;
       transform: translateX(-50%);
-      background: #252B36;
+      background: var(--surface-elevated, #334155);
       border: 1px solid rgba(255, 255, 255, 0.08);
       border-radius: var(--weo-radius-sm);
       padding: 6px 10px;
@@ -1769,7 +1770,7 @@
       left: 50%;
       transform: translateX(-50%);
       border: 4px solid transparent;
-      border-bottom-color: #252B36;
+      border-bottom-color: var(--surface-elevated, #334155);
     }
     .ind-primary-popover.visible { display: block; }
     .ind-tag.ind-primary.badge-ind-semi { background: rgba(173,180,255,0.18); color: rgba(173,180,255,0.9); border: 1px solid rgba(173,180,255,0.3); }
@@ -1841,7 +1842,7 @@
       top: calc(100% + 8px);
       left: 50%;
       transform: translateX(-50%);
-      background: #252B36;
+      background: var(--surface-elevated, #334155);
       border: 1px solid rgba(255, 255, 255, 0.08);
       border-radius: var(--weo-radius-sm);
       padding: 10px 12px;
@@ -1869,7 +1870,7 @@
       left: 50%;
       transform: translateX(-50%);
       border: 4px solid transparent;
-      border-bottom-color: #252B36;
+      border-bottom-color: var(--surface-elevated, #334155);
     }
     .ind-mechanism-popover .mechanism-title {
       font-size: 0.5625rem;
@@ -1963,7 +1964,7 @@
       top: calc(100% + 8px);
       left: 50%;
       transform: translateX(-50%);
-      background: #252B36;
+      background: var(--surface-elevated, #334155);
       border: 1px solid rgba(255, 255, 255, 0.08);
       border-radius: var(--weo-radius-sm);
       padding: 10px 12px;
@@ -1991,7 +1992,7 @@
       left: 50%;
       transform: translateX(-50%);
       border: 4px solid transparent;
-      border-bottom-color: #252B36;
+      border-bottom-color: var(--surface-elevated, #334155);
     }
     .ent-mechanism-popover .ent-popover-title {
       font-family: 'Geist Mono', 'Fira Code', monospace;
@@ -2170,7 +2171,7 @@
       display: flex;
       align-items: flex-start;
       gap: 10px;
-      font-size: 13px;
+      font-size: 12px;
       line-height: 1.4;
     }
 
@@ -2233,7 +2234,7 @@
     }
 
     .upgrade-cta-list li {
-      font-size: 13px;
+      font-size: 12px;
       color: #94A3B8;
       padding: 4px 0;
       padding-left: 20px;
@@ -2291,7 +2292,7 @@
       margin-top: 16px;
       padding-top: 16px;
       border-top: 1px solid #334155;
-      font-size: 13px;
+      font-size: 12px;
       color: #60A5FA;
       text-decoration: none;
       transition: color var(--duration-fast) var(--ease-out),
@@ -2495,7 +2496,7 @@
       .marker-cluster-small {
         width: 48px;
         height: 48px;
-        font-size: 15px;
+        font-size: 14px;
       }
       
       .marker-cluster-medium {
@@ -2663,7 +2664,7 @@
       }
       
       .section-content {
-        font-size: 13px;
+        font-size: 12px;
       }
       
       .data-label,
@@ -2721,9 +2722,9 @@
     }
 
     /* Focus states for accessibility */
-    .panel-close:focus,
-    .legend-toggle:focus,
-    .upgrade-button:focus {
+    .panel-close:focus-visible,
+    .legend-toggle:focus-visible,
+    .upgrade-button:focus-visible {
       outline: 2px solid #60A5FA;
       outline-offset: 2px;
     }
@@ -2739,15 +2740,15 @@
 
     /* PHASE 6B: ADDITIONAL STYLES */
     .panel-badge.technology { background: rgba(59, 130, 246, 0.15); color: #3B82F6; }
-    .panel-badge.security { background: rgba(239, 68, 68, 0.15); color: #F87171; }
+    .panel-badge.security { background: rgba(248, 113, 113, 0.15); color: #F87171; }
     .panel-badge.trade { background: rgba(16, 185, 129, 0.15); color: #10B981; }
     .panel-badge.energy { background: rgba(245, 158, 11, 0.15); color: #F59E0B; }
-    .bloc-table { width: 100%; border-collapse: separate; border-spacing: 0; margin-top: 12px; font-size: 13px; background: rgba(15, 23, 42, 0.4); border-radius: var(--weo-radius-md); overflow: hidden; border: 1px solid #334155; }
+    .bloc-table { width: 100%; border-collapse: separate; border-spacing: 0; margin-top: 12px; font-size: 12px; background: rgba(15, 23, 42, 0.4); border-radius: var(--weo-radius-md); overflow: hidden; border: 1px solid #334155; }
     .bloc-table th, .bloc-table td { padding: 10px 12px; text-align: left; }
     .bloc-table th { color: #94A3B8; font-weight: 500; font-size: 11px; text-transform: uppercase; background: rgba(51, 65, 85, 0.3); border-bottom: 1px solid #334155; white-space: nowrap; }
     .bloc-table td { color: #CBD5E1; border-bottom: 1px solid rgba(51, 65, 85, 0.4); }
     .bloc-table tbody tr:last-child td { border-bottom: none; }
-    .scoring-table { width: 100%; border-collapse: separate; border-spacing: 0; margin-bottom: 12px; font-size: 13px; background: rgba(15, 23, 42, 0.6); border-radius: var(--weo-radius-md); overflow: hidden; border: 1px solid #334155; }
+    .scoring-table { width: 100%; border-collapse: separate; border-spacing: 0; margin-bottom: 12px; font-size: 12px; background: rgba(15, 23, 42, 0.6); border-radius: var(--weo-radius-md); overflow: hidden; border: 1px solid #334155; }
     .scoring-table th, .scoring-table td { padding: 10px 12px; text-align: center; }
     .scoring-table th { color: #94A3B8; font-weight: 500; font-size: 11px; background: rgba(51, 65, 85, 0.4); border-bottom: 1px solid #334155; }
     .scoring-table td { color: #CBD5E1; font-family: monospace; }
@@ -2759,7 +2760,7 @@
     .scoring-table tbody tr:last-child .rationale-cell { border-bottom: none; }
     .scoring-summary { margin-top: 16px; padding: 12px 14px; background: rgba(30, 41, 59, 0.4); border-radius: var(--weo-radius-md); border: 1px solid #334155; }
     .scoring-summary .data-row { border-bottom: none; padding: 4px 0; }
-    .sources-section { font-size: 13px; background: rgba(15, 23, 42, 0.4); border-radius: var(--weo-radius-md); border: 1px solid rgba(51, 65, 85, 0.5); padding: 14px 16px; margin-top: 8px; }
+    .sources-section { font-size: 12px; background: rgba(15, 23, 42, 0.4); border-radius: var(--weo-radius-md); border: 1px solid rgba(51, 65, 85, 0.5); padding: 14px 16px; margin-top: 8px; }
     .sources-label { color: #F1F5F9; font-weight: 600; font-size: 11px; text-transform: uppercase; letter-spacing: 0.03em; margin-bottom: 10px; }
     
     /* Current Data Sources styling (for events with rolling updates) */
@@ -2861,7 +2862,7 @@
     }
     .related-event:last-child { border-bottom: none; padding-bottom: 0; }
     .related-event:first-child { padding-top: 0; }
-    .related-id { color: #60A5FA; font-weight: 500; font-size: 13px; }
+    .related-id { color: #60A5FA; font-weight: 500; font-size: 12px; }
     .related-relationship { color: #94A3B8; font-size: 12px; }
     .checkpoint-label strong { color: #F1F5F9; }
     .checkpoint-icon.fail { color: #F87171; }
@@ -2978,7 +2979,7 @@
     /* CC Target Event Name */
     .cc-target {
       flex: 1;
-      font-size: 13px;
+      font-size: 12px;
       color: #CBD5E1;
       min-width: 80px;
       overflow: hidden;
@@ -2995,7 +2996,7 @@
     /* CC Target Tooltip (appended to body) */
     .cc-target-tooltip {
       position: fixed;
-      background: #1E293B;
+      background: var(--surface-raised);
       border: 1px solid #475569;
       border-radius: var(--weo-radius-md);
       padding: 8px 12px;
@@ -3083,7 +3084,7 @@
       position: absolute;
       bottom: 100%;
       right: 0;
-      background: #1E293B;
+      background: var(--surface-raised);
       border: 1px solid #475569;
       border-radius: var(--weo-radius-md);
       padding: 10px 12px;
@@ -3317,7 +3318,7 @@
     
     /* Evidence Content */
     .cc-evidence-content {
-      font-size: 13px;  /* Increased from 12px */
+      font-size: 12px;  /* Increased from 12px */
       color: #CBD5E1;
       line-height: 1.6;
     }
@@ -3483,7 +3484,7 @@
       padding: 12px 16px;  /* Increased from 10px 12px */
       margin: 16px 0;  /* Increased from 10px */
       border-radius: 0 var(--weo-radius-sm) var(--weo-radius-sm) 0;
-      font-size: 13px;  /* Increased from 11px */
+      font-size: 12px;  /* Increased from 11px */
       line-height: 1.5;
       font-style: italic;
       color: #E2E8F0;  /* Slightly brighter */
@@ -3765,7 +3766,7 @@
     
     /* Empty State */
     .cc-empty {
-      font-size: 13px;
+      font-size: 12px;
       color: #94A3B8;
       font-style: italic;
       padding: 8px 0;
@@ -3800,7 +3801,7 @@
     /* Tooltip for temporal framing */
     .cc-tooltip {
       position: absolute;
-      background: #1E293B;
+      background: var(--surface-raised);
       border: 1px solid #475569;
       border-radius: var(--weo-radius-md);
       padding: 10px 14px;
@@ -3956,7 +3957,7 @@
     @media (max-width: 767px) {
       #weo-tooltip-overlay {
         width: 310px;
-        font-size: 13px;
+        font-size: 12px;
         padding: 14px 16px;
       }
     }
@@ -4793,7 +4794,7 @@
     }
     .access-modal-overlay.visible { opacity: 1; visibility: visible; }
     .access-modal {
-      background: #1E293B;
+      background: var(--surface-raised);
       border: 1px solid #334155;
       border-radius: var(--weo-radius-lg);
       width: 90%; max-width: 400px;
@@ -4826,7 +4827,7 @@
       border-radius: var(--weo-radius-md); color: #F1F5F9;
       font-size: 0.9375rem; font-family: monospace;
     }
-    .access-input:focus { outline: none; border-color: #F59E0B; }
+    .access-input:focus { outline: 2px solid #F59E0B; outline-offset: 2px; border-color: #F59E0B; }
     .access-input.error { border-color: #F87171; }
     .access-error { display: none; align-items: center; gap: 0.375rem; margin-top: 0.5rem; font-size: 0.8125rem; color: #F87171; }
     .access-error.visible { display: flex; }
@@ -5078,7 +5079,7 @@
 
     .version-headline {
       flex: 1;
-      font-size: 13px;
+      font-size: 12px;
       color: #CBD5E1;
       overflow: hidden;
       text-overflow: ellipsis;
@@ -5124,7 +5125,7 @@
     }
 
     .version-description p {
-      font-size: 13px;
+      font-size: 12px;
       color: #CBD5E1;
       line-height: 1.5;
       margin: 0;
@@ -5426,12 +5427,12 @@
     .piet-t2-wrap { position: relative; display: inline; }
     .piet-t2-popover {
         display: none; position: absolute; bottom: calc(100% + 8px); left: 50%; transform: translateX(-50%);
-        background: #252B36; border: 1px solid rgba(255,255,255,0.08); border-radius: var(--weo-radius-sm);
+        background: var(--surface-elevated, #334155); border: 1px solid rgba(255,255,255,0.08); border-radius: var(--weo-radius-sm);
         padding: 10px 12px; font-size: 0.6875rem; line-height: 1.5; color: var(--text-secondary);
         width: max-content; max-width: 280px; z-index: 1000; box-shadow: 0 4px 16px rgba(0,0,0,0.5);
     }
     .piet-t2-popover::before { content:''; position:absolute; top:100%; left:50%; transform:translateX(-50%); border:5px solid transparent; border-top-color:rgba(255,255,255,0.08); }
-    .piet-t2-popover::after { content:''; position:absolute; top:100%; left:50%; transform:translateX(-50%); border:4px solid transparent; border-top-color:#252B36; }
+    .piet-t2-popover::after { content:''; position:absolute; top:100%; left:50%; transform:translateX(-50%); border:4px solid transparent; border-top-color:var(--surface-elevated, #334155); }
     .piet-t2-popover .t2-popover-title { font-size:0.5625rem; font-weight:600; text-transform:uppercase; letter-spacing:0.05em; color:var(--text-muted); margin-bottom:4px; }
     .piet-t2-popover.visible { display: block; }
     .piet-pathway-label {
@@ -5585,14 +5586,14 @@
     }
 
     .empty-state-title {
-        font-size: 15px;
+        font-size: 14px;
         font-weight: 580;
         color: var(--weo-text-secondary, #CBD5E1);
         margin-bottom: 8px;
     }
 
     .empty-state-hint {
-        font-size: 13px;
+        font-size: 12px;
     }
 
   </style>
@@ -5620,7 +5621,7 @@
     <div class="peek-swipe-hint">Swipe up for more</div>
 
     <!-- Panel content will be injected here by JavaScript -->
-    <div id="panelContent"></div>
+    <div id="panelContent" aria-live="polite" role="region" aria-label="Event details"></div>
     
     <!-- Peek mode expand prompt (shown when panel is collapsed for CC line visibility) -->
     <div class="peek-expand-prompt" id="peekExpandPrompt" onclick="expandFromPeek()">
@@ -5649,7 +5650,7 @@
     <div class="weo-status-updated" id="weo-status-updated"></div>
     
     <!-- Navigation Menu Toggle -->
-    <button class="nav-menu-toggle" id="navMenuToggle" aria-label="Navigation menu">
+    <button class="nav-menu-toggle" id="navMenuToggle" aria-label="Navigation menu" aria-expanded="false">
       <span></span>
       <span></span>
       <span></span>
@@ -8504,7 +8505,7 @@ function generateCCSection(eventId, showFullContent) {
         // Calculate arc segments - order matters for rendering
         const segments = [
           { count: t1Count, color: '#2DD4BF', name: 'Teal' },      // T1 - Teal
-          { count: t2Count, color: '#EF4444', name: 'Red' },      // T2 - Red
+          { count: t2Count, color: '#F87171', name: 'Red' },      // T2 - Red
           { count: t3WesternCount, color: '#60A5FA', name: 'Blue' }, // T3 Western - Blue
           { count: t3EasternCount, color: '#FB923C', name: 'Orange' }  // T3 Eastern - Orange
         ].filter(s => s.count > 0);
@@ -8575,7 +8576,7 @@ function generateCCSection(eventId, showFullContent) {
       // T2 events get red border (fragmentation), T1/T3 get bloc colours
       let borderColor;
       if (event.tier === 2) {
-        borderColor = '#EF4444'; // Red for all T2 fragmentation events
+        borderColor = '#F87171'; // Red for all T2 fragmentation events
       } else {
         borderColor = event.bloc === 'Western' ? '#60A5FA' : event.bloc === 'Eastern' ? '#FB923C' : '#2DD4BF';
       }
@@ -10507,6 +10508,7 @@ function generateCCSection(eventId, showFullContent) {
       
       navMenuToggle.classList.toggle('open');
       navDropdown.classList.toggle('open');
+      navMenuToggle.setAttribute('aria-expanded', navDropdown.classList.contains('open') ? 'true' : 'false');
     });
 
     // Close menu when clicking outside
@@ -10875,11 +10877,11 @@ function generateCCSection(eventId, showFullContent) {
   </script>
 
   <!-- WEO SUPPORTER ACCESS MODAL -->
-  <div class="access-modal-overlay" id="accessModalOverlay">
+  <div class="access-modal-overlay" id="accessModalOverlay" role="dialog" aria-modal="true" aria-labelledby="access-modal-title">
     <div class="access-modal">
       <div id="accessLoginState">
         <div class="access-modal-header">
-          <div class="access-modal-title"><span>🔑</span>Supporter Access</div>
+          <div class="access-modal-title" id="access-modal-title"><span>🔑</span>Supporter Access</div>
           <button class="access-modal-close" aria-label="Close" onclick="closeAccessModal()">×</button>
         </div>
         <div class="access-modal-body">

--- a/legal.html
+++ b/legal.html
@@ -262,8 +262,10 @@
           
           .weo-nav-toggle {
             display: flex;
+            min-width: 44px;
+            min-height: 44px;
           }
-          
+
           .weo-nav-links {
             position: absolute;
             top: 100%;
@@ -528,7 +530,7 @@
             <span class="weo-nav-logo">WEO</span>
             <span>Warmth Engine Observatory</span>
           </a>
-          <button class="weo-nav-toggle" id="navToggle" aria-label="Toggle navigation">
+          <button class="weo-nav-toggle" id="navToggle" aria-label="Toggle navigation" aria-expanded="false">
             <span></span>
             <span></span>
             <span></span>
@@ -660,8 +662,10 @@
       if (navToggle && navLinks) {
         navToggle.addEventListener('click', function() {
           navLinks.classList.toggle('open');
+          const isOpen = navLinks.classList.contains('open');
+          navToggle.setAttribute('aria-expanded', isOpen);
         });
-        
+
         // Close menu when clicking outside
         document.addEventListener('click', function(e) {
           if (!navLinks.contains(e.target) && !navToggle.contains(e.target)) {

--- a/legal.html
+++ b/legal.html
@@ -521,7 +521,8 @@
 </style>
 </head>
 <body>
-    <div class="container">
+    <a href="#main-content" class="sr-only" id="skip-link">Skip to main content</a>
+    <div class="container" id="main-content">
         <nav class="weo-nav">
           <a href="/" class="weo-nav-brand">
             <span class="weo-nav-logo">WEO</span>

--- a/methodology.html
+++ b/methodology.html
@@ -392,9 +392,11 @@
           
           .weo-nav-toggle {
             display: flex;
+            min-width: 44px;
+            min-height: 44px;
           }
         }
-        
+
         /* Header */
         .page-header {
             margin-bottom: var(--weo-space-2xl);
@@ -1285,7 +1287,7 @@
             <span class="weo-nav-logo">WEO</span>
             <span>Warmth Engine Observatory</span>
           </a>
-          <button class="weo-nav-toggle" id="navToggle" aria-label="Toggle navigation">
+          <button class="weo-nav-toggle" id="navToggle" aria-label="Toggle navigation" aria-expanded="false">
             <span></span>
             <span></span>
             <span></span>
@@ -1804,8 +1806,10 @@
       if (navToggle && navLinks) {
         navToggle.addEventListener('click', function() {
           navLinks.classList.toggle('open');
+          const isOpen = navLinks.classList.contains('open');
+          navToggle.setAttribute('aria-expanded', isOpen);
         });
-        
+
         // Close when clicking outside
         document.addEventListener('click', function(e) {
           if (!navLinks.contains(e.target) && !navToggle.contains(e.target)) {

--- a/methodology.html
+++ b/methodology.html
@@ -6,6 +6,7 @@
     <link rel="icon" type="image/png" sizes="32x32" href="favicon_32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="favicon_16x16.png">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="weo-version" content="1.2.0">
     <title>Methodology — Warmth Engine Observatory</title>
     <meta name="description" content="WEO V1.3 methodology for classifying AI infrastructure coordination dynamics through verified events, tier & domain classification, industry tags, Environmental Nexus Tags, the Warmth Engine Ratio, and coordination connections.">
     <meta name="keywords" content="Warmth Engine Observatory, WEO methodology, event verification, significance assessment, tier classification, domain classification, Coordination Connections, Environmental Nexus Tags, Warmth Engine Ratio, Basel 5-Factor, PISA-5, Keohane Pre-Filter, gold standard verification">
@@ -578,7 +579,7 @@
         }
         
         .tier-badge.t1 { background: rgba(45, 212, 191, 0.15); color: var(--weo-tier-t1); }
-        .tier-badge.t2 { background: rgba(239, 68, 68, 0.15); color: var(--weo-tier-t2); }
+        .tier-badge.t2 { background: rgba(248, 113, 113, 0.15); color: var(--weo-tier-t2); }
         .tier-badge.t3 { background: rgba(148, 163, 184, 0.15); color: var(--weo-tier-t3); }
         
         .tier-name {
@@ -1275,8 +1276,9 @@
 </style>
 </head>
 <body>
-    <div class="container">
-        
+    <a href="#main-content" class="sr-only" id="skip-link">Skip to main content</a>
+    <div class="container" id="main-content">
+
         <!-- Navigation -->
         <nav class="weo-nav">
           <a href="/" class="weo-nav-brand">

--- a/research.html
+++ b/research.html
@@ -385,9 +385,11 @@
 
           .weo-nav-toggle {
             display: flex;
+            min-width: 44px;
+            min-height: 44px;
           }
         }
-        
+
         /* Header */
         .page-header {
             margin-bottom: var(--weo-space-xl);
@@ -800,7 +802,7 @@
             <span class="weo-nav-logo">WEO</span>
             <span>Warmth Engine Observatory</span>
           </a>
-          <button class="weo-nav-toggle" id="navToggle" aria-label="Toggle navigation">
+          <button class="weo-nav-toggle" id="navToggle" aria-label="Toggle navigation" aria-expanded="false">
             <span></span>
             <span></span>
             <span></span>
@@ -964,8 +966,10 @@
       if (navToggle && navLinks) {
         navToggle.addEventListener('click', function() {
           navLinks.classList.toggle('open');
+          const isOpen = navLinks.classList.contains('open');
+          navToggle.setAttribute('aria-expanded', isOpen);
         });
-        
+
         // Close when clicking outside
         document.addEventListener('click', function(e) {
           if (!navLinks.contains(e.target) && !navToggle.contains(e.target)) {

--- a/research.html
+++ b/research.html
@@ -126,7 +126,7 @@
             --text-primary: #FAFAFA;
             --text-secondary: #E4E4E7;
             --text-tertiary: #A1A1AA;
-            --text-muted: #71717A;
+            --text-muted: #82828A;
             
             /* Accent — warm amber */
             --accent-primary: #F59E0B;
@@ -791,8 +791,9 @@
 </style>
 </head>
 <body>
-    <div class="container">
-        
+    <a href="#main-content" class="sr-only" id="skip-link">Skip to main content</a>
+    <div class="container" id="main-content">
+
         <!-- Navigation -->
         <nav class="weo-nav">
           <a href="/" class="weo-nav-brand">

--- a/support.html
+++ b/support.html
@@ -318,9 +318,11 @@
           
           .weo-nav-toggle {
             display: flex;
+            min-width: 44px;
+            min-height: 44px;
           }
         }
-        
+
         /* Header */
         .page-header {
             margin-bottom: var(--weo-space-2xl);
@@ -898,7 +900,7 @@
             <span class="weo-nav-logo">WEO</span>
             <span>Warmth Engine Observatory</span>
           </a>
-          <button class="weo-nav-toggle" id="navToggle" aria-label="Toggle navigation">
+          <button class="weo-nav-toggle" id="navToggle" aria-label="Toggle navigation" aria-expanded="false">
             <span></span>
             <span></span>
             <span></span>
@@ -1131,8 +1133,10 @@
       if (navToggle && navLinks) {
         navToggle.addEventListener('click', function() {
           navLinks.classList.toggle('open');
+          const isOpen = navLinks.classList.contains('open');
+          navToggle.setAttribute('aria-expanded', isOpen);
         });
-        
+
         // Close when clicking outside
         document.addEventListener('click', function(e) {
           if (!navLinks.contains(e.target) && !navToggle.contains(e.target)) {

--- a/support.html
+++ b/support.html
@@ -889,8 +889,9 @@
 </style>
 </head>
 <body>
-    <div class="container">
-        
+    <a href="#main-content" class="sr-only" id="skip-link">Skip to main content</a>
+    <div class="container" id="main-content">
+
         <!-- Navigation -->
         <nav class="weo-nav">
           <a href="/" class="weo-nav-brand">


### PR DESCRIPTION
## Summary

Applies 44 findings from the May 2026 WEO Codebase MOT audit across 10 HTML files. Changes are mechanical with no functional impact on page behaviour.

**Section 1 — Token hygiene (F-001–022)**
- All `#252B36` tooltip surfaces → `var(--surface-elevated, #334155)`
- All `rgba(239,68,68,…)` red-channel variants → `rgba(248,113,113,…)`
- JS chart colour strings `#EF4444` → `#F87171`
- Hardcoded `#1E293B` in selectors → `var(--surface-raised)`
- Consolidated `--text-muted: #94A3B8` (was rgba variant), aliased `--weo-text-muted`
- `--text-secondary` → solid `#CBD5E1`

**Section 2 — Accessibility (F-033–049)**
- Skip links added to all 7 pages that were missing them
- `prefers-reduced-motion` block added to 404.html
- `aria-label="Close"` on events.html modal close button
- `.access-input:focus` outline restored (amber ring, all 4 files)
- `:focus` → `:focus-visible` on specific button selectors (index.html)
- `aria-live + role=dialog` on dynamic panels (index.html, events.html)
- `aria-expanded` wired to eu-toggle (blocs.html) and navMenuToggle (index.html)
- `aria-live="polite"` on events.html stats bar
- Atlas skip link migrated from inline JS to CSS `sr-only:focus` pattern
- `*:focus-visible` added to 404.html

**Section 3 — Stale data & consistency (F-024–067)**
- 404.html `:root` expanded with focus-ring, border, muted, radius tokens
- Unused `--weo-status-negative-bg` removed from about.html
- `<meta name="weo-version">` added to index.html, events.html, about.html, methodology.html
- about.html fallback stats updated to 134/107
- atlas.html fixed footer version stamp now reads from weo-version meta via JS
- viewport meta in atlas.html documented with exception comment
- 404.html title separator `|` → `—`
- CC-A confidence colour `#64748B` → `#94A3B8` in atlas.html

**Section 4 — Typography (F-073–075)**
- index.html: `15px→14px`, `13px→12px` in all selectors
- events.html: `15px→14px`, `13px→12px`, `12.5px→12px`, `10.5px→11px`
- atlas.html: `11.5px→11px`, `13px→12px`

## Files changed
index.html · events.html · atlas.html · methodology.html · about.html · blocs.html · research.html · support.html · legal.html · 404.html

## Test plan
- [ ] Open each page and visually verify no colour regressions
- [ ] Tab through index.html, events.html, atlas.html — verify focus rings are visible
- [ ] Tab to skip links on methodology, about, blocs, research, support, legal, 404 — verify they appear on focus
- [ ] Open events.html modal — verify close button announced as "Close" by VoiceOver
- [ ] Atlas CC-A nodes render in `#94A3B8` not `#64748B`
- [ ] 404.html page title reads "Page Not Found — Warmth Engine Observatory"
- [ ] about.html fallback stats show 134/107 before data loads
- [ ] version stamp in atlas footer reads from meta tag

Full QA checklist in `SCP_Design/WEO_MOT_FIXES_LOG_MAY_2026.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)