### PR TITLE
fix(mobile): replace 3-state bottom sheet with 2-state (peek/full)

### DIFF
--- a/index.html
+++ b/index.html
@@ -2332,13 +2332,9 @@
         transform: translateY(0);
       }
 
-      /* Three-state bottom sheet */
+      /* Two-state bottom sheet (peek / full) */
       .detail-panel.state-peek {
           transform: translateY(calc(100% - 160px));
-      }
-
-      .detail-panel.state-half {
-          transform: translateY(50%);
       }
 
       .detail-panel.state-full {
@@ -2346,7 +2342,6 @@
       }
 
       .detail-panel.state-peek,
-      .detail-panel.state-half,
       .detail-panel.state-full {
           transition: transform 300ms cubic-bezier(0.33, 1, 0.68, 1);
       }
@@ -2362,12 +2357,6 @@
           display: none;
       }
 
-      /* Half: limit visible content */
-      .detail-panel.state-half .panel-body {
-          max-height: calc(50vh - 160px);
-          overflow-y: auto;
-      }
-
       /* Swipe hint */
       .peek-swipe-hint {
           display: none;
@@ -2379,8 +2368,7 @@
           text-shadow: 0 0 8px rgba(96, 165, 250, 0.5);
       }
 
-      .detail-panel.state-peek .peek-swipe-hint,
-      .detail-panel.state-half .peek-swipe-hint {
+      .detail-panel.state-peek .peek-swipe-hint {
           display: block;
           animation: scp-swipe-hint-bounce 2s ease-in-out infinite;
       }
@@ -10923,34 +10911,31 @@ function generateCCSection(eventId, showFullContent) {
 
 <script>
 // ========================================
-// THREE-STATE MOBILE BOTTOM SHEET
-// Completely self-contained. Does not modify existing functions.
-// Only activates on mobile viewports (<= 767px).
+// TWO-STATE MOBILE BOTTOM SHEET (peek / full)
+// Matches atlas.html pattern. Self-contained, mobile-only.
 // ========================================
 (function() {
     'use strict';
 
     var panelState = 'closed';
+    var touchStartY = 0;
+    var touchStartTime = 0;
+    var dragActive = false;
+    var dragStartTranslate = 0;
+    var EASING = 'transform 300ms cubic-bezier(0.33, 1, 0.68, 1)';
 
-    function isMobile() {
-        return window.innerWidth <= 767;
-    }
-
-    function getPanel() {
-        return document.getElementById('detailPanel');
-    }
+    function isMobile() { return window.innerWidth <= 767; }
 
     function translateForState(state) {
         var h = window.innerHeight;
-        if (state === 'full')  return 0;
-        if (state === 'half')  return h * 0.5;
-        if (state === 'peek')  return h - 160;
+        if (state === 'full') return 0;
+        if (state === 'peek') return h - 160;
         return h; // closed
     }
 
     window.setPanelState = function(newState) {
         if (!isMobile()) return;
-        var panel = getPanel();
+        var panel = document.getElementById('detailPanel');
         if (!panel) return;
         var content = document.getElementById('panelContent');
 
@@ -10958,123 +10943,102 @@ function generateCCSection(eventId, showFullContent) {
         if (content) content.scrollTop = 0;
 
         panel.classList.remove('state-peek', 'state-half', 'state-full');
-        panel.style.transition = '';
 
         if (newState === 'closed') {
-            panelState = 'closed';
-            var h = window.innerHeight;
-            panel.style.transform = 'translateY(' + h + 'px)';
+            panel.style.transition = EASING;
+            panel.style.transform = 'translateY(' + window.innerHeight + 'px)';
             panel.style.height = '';
             panel.style.maxHeight = '';
+            panelState = 'closed';
             return;
         }
 
         panel.style.height    = window.innerHeight + 'px';
         panel.style.maxHeight = 'none';
         panel.classList.add('state-' + newState);
-        panelState = newState;
+        if (newState === 'full') panel.classList.add('swipe-hint-used');
 
-        if (newState === 'full') {
-            panel.classList.add('swipe-hint-used');
-        }
-
+        var target = translateForState(newState);
         requestAnimationFrame(function() {
-            panel.style.transform = 'translateY(' + translateForState(newState) + 'px)';
+            panel.style.transition = EASING;
+            panel.style.transform = 'translateY(' + target + 'px)';
+            panelState = newState;
         });
     };
 
-    window.getPanelState = function() {
-        return panelState;
-    };
+    window.getPanelState = function() { return panelState; };
 
-    var panel = getPanel();
+    var panel = document.getElementById('detailPanel');
     if (!panel) return;
 
-    var _dragStartY     = 0;
-    var _dragStartTime  = 0;
-    var _dragging       = false;
-    var _startTranslate = 0;
-
     panel.addEventListener('touchstart', function(e) {
-        if (!isMobile()) return;
-        if (panelState === 'closed') return;
-        _dragStartY    = e.touches[0].clientY;
-        _dragStartTime = Date.now();
-        _dragging      = false;
+        if (!isMobile() || panelState === 'closed') return;
+        touchStartY = e.touches[0].clientY;
+        touchStartTime = Date.now();
+        dragActive = false;
     }, { passive: true });
 
     panel.addEventListener('touchmove', function(e) {
-        if (!isMobile()) return;
-        e.stopPropagation();
-        if (panelState === 'closed') return;
+        if (!isMobile() || panelState === 'closed') return;
+        var deltaY = e.touches[0].clientY - touchStartY;
+        var content = document.getElementById('panelContent');
+        var contentScrolled = (content && content.scrollTop > 0) || panel.scrollTop > 0;
 
-        var deltaY = e.touches[0].clientY - _dragStartY;
+        // In full state: upward swipes and scrolled content pass to native scroll
+        if (panelState === 'full' && (deltaY < 0 || contentScrolled)) return;
 
-        // Let native scroll handle upward motion when content is scrolled
-        if (panel.scrollTop > 0 && deltaY < 0) return;
-
-        // Dead-zone — ignore micro-movements
-        if (!_dragging && Math.abs(deltaY) < 10) return;
-
-        if (!_dragging) {
-            _dragging       = true;
-            _startTranslate = translateForState(panelState);
-            // Remove state classes so .state-peek .panel-body { height:0 } doesn't clip during drag
+        if (!dragActive) {
+            if (Math.abs(deltaY) < 8) return;
+            dragActive = true;
+            dragStartTranslate = translateForState(panelState);
+            if (content) content.scrollTop = 0;
+            panel.scrollTop = 0;
             panel.classList.remove('state-peek', 'state-half', 'state-full');
             panel.style.transition = 'none';
             panel.style.height     = window.innerHeight + 'px';
             panel.style.maxHeight  = 'none';
-            panel.scrollTop        = 0;
         }
 
-        var newTranslate = Math.max(0, _startTranslate + deltaY);
-        panel.style.transform = 'translateY(' + newTranslate + 'px)';
+        var t = Math.max(0, dragStartTranslate + deltaY);
+        panel.style.transform = 'translateY(' + t + 'px)';
         e.preventDefault();
     }, { passive: false });
 
-    panel.addEventListener('touchend', function(e) {
-        if (!isMobile()) return;
-        if (!_dragging) { _dragging = false; return; }
-        _dragging = false;
-        finishDrag(e.changedTouches[0].clientY);
-    }, { passive: true });
+    function finishDrag(e) {
+        if (!isMobile() || !dragActive) return;
+        dragActive = false;
+
+        var deltaY = touchStartY - e.changedTouches[0].clientY; // positive = up
+        var elapsed = Date.now() - touchStartTime;
+        var vel = elapsed > 0 ? Math.abs(deltaY) / elapsed : 0;
+        var isGesture = Math.abs(deltaY) > 50 || (vel > 0.5 && Math.abs(deltaY) > 20);
+
+        var targetState;
+        if (isGesture && deltaY > 0) {
+            targetState = 'full';
+        } else if (isGesture && deltaY < 0) {
+            targetState = panelState === 'full' ? 'peek' : 'closed';
+        } else {
+            targetState = panelState;
+        }
+
+        window.setPanelState(targetState);
+        if (targetState === 'closed' && typeof closePanel === 'function') closePanel();
+    }
+
+    panel.addEventListener('touchend', finishDrag, { passive: true });
 
     panel.addEventListener('touchcancel', function() {
-        if (!_dragging) return;
-        _dragging = false;
+        if (!isMobile() || !dragActive) return;
+        dragActive = false;
         window.setPanelState(panelState);
     }, { passive: true });
 
-    function finishDrag(endY) {
-        var deltaY   = endY - _dragStartY;
-        var elapsed  = Date.now() - _dragStartTime;
-        var velocity = Math.abs(deltaY) / Math.max(1, elapsed);
-
-        var isFlick = velocity > 0.5 && Math.abs(deltaY) > 20;
-        var isSwipe = Math.abs(deltaY) > 60;
-
-        var targetState = panelState;
-
-        if ((isSwipe || isFlick) && deltaY < 0) {
-            if (panelState === 'peek')      targetState = 'half';
-            else if (panelState === 'half') targetState = 'full';
-        } else if ((isSwipe || isFlick) && deltaY > 0) {
-            if (panelState === 'full')      targetState = 'half';
-            else if (panelState === 'half') targetState = 'peek';
-            else if (panelState === 'peek') targetState = 'closed';
-        }
-
-        if (targetState === 'closed') {
-            window.setPanelState('closed');
-            if (typeof closePanel === 'function') closePanel();
-        } else {
-            window.setPanelState(targetState);
-        }
-    }
-
-    panel.addEventListener('click', function() {
-        if (!isMobile()) return;
-        if (panelState === 'peek') window.setPanelState('half');
+    // Tap on the peek strip → full
+    panel.addEventListener('click', function(e) {
+        if (!isMobile() || panelState !== 'peek') return;
+        if (e.target.closest('.panel-close')) return;
+        window.setPanelState('full');
     });
 })();
 </script>


### PR DESCRIPTION
## Summary

- Removes the half-state stop from the mobile event data panel — swipe up now goes directly from peek to full, matching the atlas.html pattern
- Fixes the scroll-blocking bug: in full state, upward swipes and any swipe while content is scrolled now pass through to native scroll instead of being swallowed by the drag handler
- Tap on the peek strip also expands directly to full (previously went to half)

## Root cause

The 3-state handler had a chicken-and-egg scroll guard: it only handed off to native scroll if `panel.scrollTop > 0`, but it also reset `scrollTop = 0` at drag start and called `e.preventDefault()` before native scroll could build any position. Result: scroll was swallowed, panel didn't move — gesture did nothing.

## What changed (`index.html`)

- **CSS**: removed `state-half` transform, transition, panel-body, and swipe-hint rules
- **JS IIFE**: rewrote bottom sheet to 2-state (peek/full) matching atlas.html — correct scroll guard (`panelState === 'full' && (deltaY < 0 || contentScrolled)`), simplified finishDrag, easing applied via inline transition

## Test plan

- [ ] Tap a map marker on mobile → panel appears in peek mode (header visible, body hidden, swipe hint shown)
- [ ] Swipe up on peek panel → goes directly to full in one smooth motion
- [ ] Scroll content in full panel → native scroll works, panel stays put
- [ ] Swipe down from full → returns to peek
- [ ] Swipe down from peek → panel closes
- [ ] Tap peek strip → expands to full

🤖 Generated with [Claude Code](https://claude.com/claude-code)