### PR TITLE
blocs.html: update intro framing to ecosystem-anchor model

### DIFF
--- a/blocs.html
+++ b/blocs.html
@@ -1155,7 +1155,7 @@
         
         <!-- Blocs Intro -->
         <div class="blocs-intro">
-            <p>WEO assigns bloc membership based on demonstrated infrastructure alignment, not political rhetoric. Western and Eastern Blocs represent distinct coordination clusters — nations whose AI infrastructure decisions consistently align with bloc patterns.</p>
+            <p>WEO identifies two AI infrastructure ecosystems, each anchored by a principal actor with full-stack capability. Every nation is classified by which ecosystem its AI infrastructure primarily operates within. Classification reflects demonstrated infrastructure alignment — hardware dependencies, compute partnerships, and regulatory coordination — not political rhetoric.</p>
         </div>
         
         <!-- Register Status Banner -->


### PR DESCRIPTION
## Summary
- Updates the blocs page introductory paragraph to frame classification around two AI infrastructure ecosystems, each anchored by a principal actor with full-stack capability
- Replaces the "coordination clusters" framing with the ecosystem-anchor model
- Preserves the "not political rhetoric" qualifier

## Changes
- `blocs.html` line 1158: single paragraph text update, no structural or styling changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)