### PR TITLE
fix(ui): add teal accent to SCP Actor Profiles button

### DIFF
--- a/index.html
+++ b/index.html
@@ -5860,7 +5860,9 @@
       margin-right: -56px;
       padding: 8px 20px;                                 /* F-004 fix: 4px grid */
       border-top: 1px solid rgba(51, 65, 85, 0.6);
+      border-left: 2px solid rgba(45, 212, 191, 0.4);
       border-radius: 0 0 var(--weo-radius-lg) var(--weo-radius-lg);
+      padding-left: 18px;
       color: var(--weo-text-muted);                      /* F-001 fix: use token */
       font-size: 12px;
       font-weight: 480;
@@ -5871,7 +5873,7 @@
     }
     .weo-status-actor-row:hover { background: var(--hover-overlay); color: var(--text-primary); }  /* F-003 fix */
     .weo-status-actor-row.active { color: var(--scp-aik); background: rgba(6, 182, 212, 0.06); border-top-color: rgba(6, 182, 212, 0.2); }  /* F-002 fix */
-    .weo-status-actor-row-icon { font-size: 11px; opacity: 0.6; }
+    .weo-status-actor-row-icon { font-size: 11px; opacity: 0.6; color: #2DD4BF; }
     .weo-status-actor-row-chev { font-size: 9px; opacity: 0.4; margin-left: auto; padding-right: 4px; }
     .weo-status-actor-row.active .weo-status-actor-row-icon { opacity: 0.9; }
     .weo-status-actor-row.active .weo-status-actor-row-chev { opacity: 0.6; }


### PR DESCRIPTION
## Summary
- **events.html (Change 1):** coverage popover text was already updated on `main` via PR #59 — no change needed here
- **index.html (Change 2):** visual accent on the Actor Profiles embedded trigger (`.weo-status-actor-row`):
  - Left border: `2px solid rgba(45, 212, 191, 0.4)` (soft teal)
  - `padding-left` adjusted to `18px` (from `20px`) to maintain 18px clearance between border and icon — no crowding
  - `◈` icon colour set to `#2DD4BF` via `.weo-status-actor-row-icon { color: #2DD4BF }` (renders at 0.6 opacity per existing rule — visually `rgba(45,212,191,0.6)`)

No changes to button position, size, click behaviour, or HTML structure.

## Test plan
- [ ] Open index.html locally (desktop viewport), confirm Actor Profiles row shows teal left border and teal `◈` icon
- [ ] Click the row — SCP panel opens as before
- [ ] Hover and active states still apply correctly (`.active` uses `--scp-aik` cyan for text/border-top — left border remains teal throughout)
- [ ] Mobile: Actor Profiles row is hidden on mobile (`display: none` in mobile breakpoint) — no mobile regression