### PR TITLE
fix(ui): relocate Data Currency statement into Coverage Confidence panel

### DIFF
--- a/events.html
+++ b/events.html
@@ -3257,14 +3257,12 @@
                     <div class="cov-info-popover" id="cov-info-popover">WEO's documentation-based verification standard applies consistently across all blocs. Coverage distribution reflects how AI infrastructure coordination is documented across different jurisdictions and institutional cultures: multilateral frameworks, regulatory disclosure conventions, and infrastructure deployment practices generate varying levels of publicly discoverable documentation. Cross-language verification workflows extend source reach beyond English-language documentation, but event counts in any bloc or domain represent conservative lower bounds on AI infrastructure coordination activity, bounded by documentation accessibility rather than event occurrence.</div>
                     Coverage confidence reflects WEO's assessment of documentation accessibility per domain and bloc, based on methodology analysis and observed discovery patterns. Event counts update with the database; confidence designations are reviewed at methodology milestones. <span class="cov-info-trigger" onclick="document.getElementById('cov-info-popover').classList.toggle('visible')">Why does coverage vary?</span>
                 </div>
+                <div style="margin-top: 16px; padding-top: 14px; border-top: 1px solid rgba(51, 65, 85, 0.5);">
+                    <div style="font-size: 12px; font-weight: 580; color: #94A3B8; letter-spacing: 0.04em; text-transform: uppercase; margin-bottom: 8px;">Data Currency and Corrections</div>
+                    <p style="margin: 0 0 10px 0; font-size: 13.5px; line-height: 1.65; color: #CBD5E1;">Event data is verified against primary and corroborating sources at the time of entry and during periodic corpus-wide audits. Source authorities may revise published figures after initial release, and operational metrics — capacity, participation, investment — evolve after implementation. Where corrections are identified through internal audit, source revision, or external reporting, events are updated with documented correction histories.</p>
+                    <p style="margin: 0; font-size: 12.5px; color: #94A3B8;">Users identifying potential inaccuracies are invited to contact <a href="mailto:warmthengine@proton.me" style="color: #60A5FA; text-decoration: none;">warmthengine@proton.me</a> with the event ID and supporting evidence.</p>
+                </div>
             </div>
-        </div>
-
-        <!-- Data Currency Statement -->
-        <div style="margin: 20px 0 24px 0; padding: 16px 20px; font-size: 13.5px; line-height: 1.65; color: #CBD5E1; border-left: 2px solid #334155;">
-            <div style="font-size: 12px; font-weight: 580; color: #94A3B8; letter-spacing: 0.04em; text-transform: uppercase; margin-bottom: 8px;">Data Currency and Corrections</div>
-            <p style="margin: 0 0 10px 0;">Event data is verified against primary and corroborating sources at the time of entry and during periodic corpus-wide audits. Source authorities may revise published figures after initial release, and operational metrics — capacity, participation, investment — evolve after implementation. Where corrections are identified through internal audit, source revision, or external reporting, events are updated with documented correction histories.</p>
-            <p style="margin: 0; font-size: 12.5px; color: #94A3B8;">Users identifying potential inaccuracies are invited to contact <a href="mailto:warmthengine@proton.me" style="color: #60A5FA; text-decoration: none;">warmthengine@proton.me</a> with the event ID and supporting evidence.</p>
         </div>
 
         <div class="filters">


### PR DESCRIPTION
Moves the Data Currency and Corrections block from its standalone position (between the Coverage panel and filters) into the expanded cov-panel-content, after the footer text. Uses a border-top separator instead of the previous border-left treatment, fitting the horizontal panel context.