### PR TITLE
style: apply teal tint to SCP button text and chevron

### DIFF
--- a/index.html
+++ b/index.html
@@ -5863,7 +5863,7 @@
       border-left: 2px solid rgba(45, 212, 191, 0.4);
       border-radius: 0 0 var(--weo-radius-lg) var(--weo-radius-lg);
       padding-left: 18px;
-      color: var(--weo-text-muted);                      /* F-001 fix: use token */
+      color: rgba(45, 212, 191, 0.7);
       font-size: 12px;
       font-weight: 480;
       letter-spacing: 0.02em;


### PR DESCRIPTION
## Summary
- Single CSS property change: `.weo-status-actor-row { color }` from `var(--weo-text-muted)` → `rgba(45, 212, 191, 0.7)`
- "Actor Profiles" text and "›" chevron inherit the teal tint from the row's base color
- `◈` icon unaffected — its explicit `color: #2DD4BF` rule (set in PR #60) takes precedence over inheritance
- Hover (`.weo-status-actor-row:hover`) and active (`.weo-status-actor-row.active`) state overrides remain in effect

## Test plan
- [ ] Open index.html (desktop viewport), confirm the Actor Profiles row reads as a cohesive teal element: diamond + text + chevron all teal-tinted
- [ ] Hover: row brightens to `--text-primary` as before
- [ ] Active (SCP panel open): row shifts to `--scp-aik` cyan as before