### PR TITLE
style: refine SCP button border weight and chevron size

### DIFF
--- a/index.html
+++ b/index.html
@@ -5860,7 +5860,7 @@
       margin-right: -56px;
       padding: 8px 20px;                                 /* F-004 fix: 4px grid */
       border-top: 1px solid rgba(51, 65, 85, 0.6);
-      border-left: 2px solid rgba(45, 212, 191, 0.4);
+      border-left: 3px solid rgba(45, 212, 191, 0.4);
       border-radius: 0 0 var(--weo-radius-lg) var(--weo-radius-lg);
       padding-left: 18px;
       color: rgba(45, 212, 191, 0.7);
@@ -5874,7 +5874,7 @@
     .weo-status-actor-row:hover { background: var(--hover-overlay); color: var(--text-primary); }  /* F-003 fix */
     .weo-status-actor-row.active { color: var(--scp-aik); background: rgba(6, 182, 212, 0.06); border-top-color: rgba(6, 182, 212, 0.2); }  /* F-002 fix */
     .weo-status-actor-row-icon { font-size: 11px; opacity: 0.6; color: #2DD4BF; }
-    .weo-status-actor-row-chev { font-size: 9px; opacity: 0.4; margin-left: auto; padding-right: 4px; }
+    .weo-status-actor-row-chev { font-size: 1.15em; opacity: 0.4; margin-left: auto; padding-right: 4px; }
     .weo-status-actor-row.active .weo-status-actor-row-icon { opacity: 0.9; }
     .weo-status-actor-row.active .weo-status-actor-row-chev { opacity: 0.6; }
 


### PR DESCRIPTION
## Summary
- `border-left`: `2px` → `3px` on `.weo-status-actor-row` — heavier teal accent stripe
- `.weo-status-actor-row-chev` `font-size`: `9px` → `1.15em` — chevron scales relative to the row's 12px base font (≈13.8px), visually balancing icon and text

No HTML changes. Position, structure, and click behaviour unchanged.

## Test plan
- [ ] Open index.html (desktop viewport) — Actor Profiles row has a slightly bolder left border and a slightly larger `›` chevron