### PR TITLE
style: adopt atlas surface-layering vocabulary across content pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -9,7 +9,7 @@
     <link rel="canonical" href="https://www.warmthengine.com/about.html">
     <meta property="og:url" content="https://www.warmthengine.com/about.html">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="weo-version" content="1.2.0">
+    <meta name="weo-version" content="1.3.0">
     <title>About — Warmth Engine Observatory</title>
     <meta name="description" content="About the Warmth Engine Observatory — Coordination Intelligence on AI infrastructure dynamics across geopolitical blocs.">
     <meta name="keywords" content="Warmth Engine Observatory, WEO, AI infrastructure coordination, geopolitical analysis, evidence-based observation, institutional-grade methodology, Basel framework, Keohane coordination">
@@ -282,6 +282,7 @@
           background: rgba(45, 212, 191, 0.1);
         }
 
+
         /* Mobile hamburger */
         .weo-nav-toggle {
           display: none;
@@ -353,6 +354,7 @@
             min-width: 44px;
             min-height: 44px;
           }
+
         }
 
         /* Header */
@@ -652,13 +654,16 @@
             display: flex;
             justify-content: space-between;
             align-items: center;
-            padding: var(--weo-space-md) 0;
+            padding: var(--weo-space-md) var(--weo-space-sm);
+            border-radius: var(--weo-radius-sm);
             cursor: pointer;
-            transition: color var(--weo-duration-fast) var(--weo-ease-out);
+            transition: color var(--weo-duration-fast) var(--weo-ease-out),
+                        background var(--weo-duration-fast) var(--weo-ease-out);
         }
-        
+
         .faq-question:hover {
             color: var(--weo-accent-primary);
+            background: rgba(45, 212, 191, 0.04);
         }
         
         .faq-question-text {
@@ -933,8 +938,8 @@
             <a href="/">Map</a>
             <a href="atlas.html">Atlas</a>
             <a href="events.html">Events</a>
-            <a href="methodology.html">Methodology</a>
             <a href="blocs.html">Blocs</a>
+            <a href="methodology.html">Methodology</a>
             <a href="research.html">Research</a>
             <a href="about.html" class="active">About</a>
             <a href="support.html">Support</a>
@@ -1242,7 +1247,7 @@
         
         <!-- Footer -->
         <footer class="page-footer">
-            <p class="footer-version">Methodology V1.3 · WEO v1.2.0</p>
+            <p class="footer-version">Methodology V1.4 · WEO v1.3.0</p>
             <p class="footer-text">© 2026 Warmth Engine Observatory</p>
             <p class="footer-links"><a href="legal.html">Privacy Policy & Terms of Service</a></p>
         </footer>

--- a/blocs.html
+++ b/blocs.html
@@ -541,9 +541,29 @@
         }
         
         .bloc-header:hover {
-            background: var(--weo-border-primary);
+            background: rgba(148, 163, 184, 0.08);
         }
-        
+
+        /* Expanded-state semantic tints — atlas .has-active pattern */
+        .bloc-section.expanded[data-bloc="western"] > .bloc-header {
+            background: rgba(96, 165, 250, 0.06);
+        }
+        .bloc-section.expanded[data-bloc="eastern"] > .bloc-header {
+            background: rgba(251, 146, 60, 0.06);
+        }
+        .bloc-section.expanded[data-bloc="cross"] > .bloc-header {
+            background: rgba(45, 212, 191, 0.06);
+        }
+        .bloc-section.expanded[data-bloc="western"] > .bloc-header:hover {
+            background: rgba(96, 165, 250, 0.10);
+        }
+        .bloc-section.expanded[data-bloc="eastern"] > .bloc-header:hover {
+            background: rgba(251, 146, 60, 0.10);
+        }
+        .bloc-section.expanded[data-bloc="cross"] > .bloc-header:hover {
+            background: rgba(45, 212, 191, 0.10);
+        }
+
         .bloc-header-left {
             display: flex;
             align-items: center;
@@ -816,9 +836,10 @@
             font-size: 0.8125rem;
             color: var(--weo-text-secondary);
             cursor: pointer;
-            transition: all var(--weo-duration-fast) var(--weo-ease-out);
+            transition: border-color var(--weo-duration-fast) var(--weo-ease-out),
+                        color var(--weo-duration-fast) var(--weo-ease-out);
         }
-        
+
         .eu-toggle:hover {
             border-color: var(--weo-accent-primary);
             color: var(--weo-text-primary);

--- a/methodology.html
+++ b/methodology.html
@@ -504,7 +504,15 @@
             text-align: center;
             padding: var(--weo-space-lg);
             background: var(--weo-surface-base);
+            border: 1px solid transparent;
             border-radius: var(--weo-radius-md);
+            transition: background var(--weo-duration-fast) var(--weo-ease-out),
+                        border-color var(--weo-duration-fast) var(--weo-ease-out);
+        }
+
+        .dynamic-item:hover {
+            background: var(--weo-surface-raised);
+            border-color: var(--weo-border-primary);
         }
         
         .dynamic-icon {
@@ -536,8 +544,16 @@
         .event-type-item {
             padding: var(--weo-space-md);
             background: var(--weo-surface-base);
+            border: 1px solid transparent;
             border-radius: var(--weo-radius-md);
             text-align: center;
+            transition: background var(--weo-duration-fast) var(--weo-ease-out),
+                        border-color var(--weo-duration-fast) var(--weo-ease-out);
+        }
+
+        .event-type-item:hover {
+            background: var(--weo-surface-raised);
+            border-color: var(--weo-border-primary);
         }
         
         .event-type-name {
@@ -564,7 +580,15 @@
         .tier-item {
             padding: var(--weo-space-lg);
             background: var(--weo-surface-base);
+            border: 1px solid transparent;
             border-radius: var(--weo-radius-md);
+            transition: background var(--weo-duration-fast) var(--weo-ease-out),
+                        border-color var(--weo-duration-fast) var(--weo-ease-out);
+        }
+
+        .tier-item:hover {
+            background: var(--weo-surface-raised);
+            border-color: var(--weo-border-primary);
         }
         
         .tier-header {

--- a/research.html
+++ b/research.html
@@ -2,7 +2,7 @@
 <html lang="en-GB">
 <head>
     <meta charset="UTF-8">
-    <meta name="weo-version" content="1.2.0">
+    <meta name="weo-version" content="1.3.0">
     <link rel="icon" type="image/png" sizes="48x48" href="favicon_48x48.png">
     <link rel="icon" type="image/png" sizes="32x32" href="favicon_32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="favicon_16x16.png">
@@ -320,6 +320,7 @@
           background: rgba(245, 158, 11, 0.1);
         }
 
+
         /* Mobile hamburger */
         .weo-nav-toggle {
           display: none;
@@ -388,6 +389,7 @@
             min-width: 44px;
             min-height: 44px;
           }
+
         }
 
         /* Header */
@@ -438,6 +440,13 @@
             padding: var(--weo-space-xl);
             margin-bottom: var(--weo-space-lg);
             box-shadow: 0 4px 24px rgba(0, 0, 0, 0.5), 0 0 0 1px rgba(0, 0, 0, 0.2), inset 0 1px 0 rgba(255, 255, 255, 0.04), 0 -4px 16px -4px rgba(245, 158, 11, 0.12);
+            transition: border-color var(--weo-duration-fast) var(--weo-ease-out),
+                        box-shadow var(--weo-duration-fast) var(--weo-ease-out);
+        }
+
+        .publication-card:hover {
+            border-color: rgba(245, 158, 11, 0.4);
+            box-shadow: 0 4px 24px rgba(0, 0, 0, 0.5), 0 0 0 1px rgba(0, 0, 0, 0.2), inset 0 1px 0 rgba(255, 255, 255, 0.04), 0 -4px 16px -4px rgba(245, 158, 11, 0.20);
         }
         
         .publication-title {
@@ -590,6 +599,13 @@
             padding: var(--weo-space-lg);
             margin-bottom: var(--weo-space-md);
             box-shadow: 0 4px 24px rgba(0, 0, 0, 0.5), 0 0 0 1px rgba(0, 0, 0, 0.2), inset 0 1px 0 rgba(255, 255, 255, 0.03), 0 -4px 16px -4px rgba(96, 165, 250, 0.15);
+            transition: border-color var(--weo-duration-fast) var(--weo-ease-out),
+                        box-shadow var(--weo-duration-fast) var(--weo-ease-out);
+        }
+
+        .publication-card--weo:hover {
+            border-color: rgba(96, 165, 250, 0.4);
+            box-shadow: 0 4px 24px rgba(0, 0, 0, 0.5), 0 0 0 1px rgba(0, 0, 0, 0.2), inset 0 1px 0 rgba(255, 255, 255, 0.03), 0 -4px 16px -4px rgba(96, 165, 250, 0.22);
         }
         
         .publication-card--weo:last-of-type {
@@ -811,8 +827,8 @@
             <a href="/">Map</a>
             <a href="atlas.html">Atlas</a>
             <a href="events.html">Events</a>
-            <a href="methodology.html">Methodology</a>
             <a href="blocs.html">Blocs</a>
+            <a href="methodology.html">Methodology</a>
             <a href="research.html" class="active">Research</a>
             <a href="about.html">About</a>
             <a href="support.html">Support</a>
@@ -951,7 +967,7 @@
         
         <!-- Footer -->
         <footer class="page-footer">
-            <p class="footer-version">Methodology V1.3 · WEO v1.2.0</p>
+            <p class="footer-version">Methodology V1.4 · WEO v1.3.0</p>
             <p class="footer-text">© 2026 Warmth Engine Observatory</p>
             <p class="footer-links"><a href="legal.html">Privacy Policy & Terms of Service</a></p>
         </footer>

--- a/support.html
+++ b/support.html
@@ -2,7 +2,7 @@
 <html lang="en-GB">
 <head>
     <meta charset="UTF-8">
-    <meta name="weo-version" content="1.2.0">
+    <meta name="weo-version" content="1.3.0">
     <link rel="icon" type="image/png" sizes="48x48" href="favicon_48x48.png">
     <link rel="icon" type="image/png" sizes="32x32" href="favicon_32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="favicon_16x16.png">
@@ -250,6 +250,7 @@
           background: rgba(45, 212, 191, 0.1);
         }
 
+
         /* Mobile hamburger */
         .weo-nav-toggle {
           display: none;
@@ -321,6 +322,7 @@
             min-width: 44px;
             min-height: 44px;
           }
+
         }
 
         /* Header */
@@ -442,11 +444,23 @@
             border-radius: var(--weo-radius-md);
             padding: var(--weo-space-lg);
             position: relative;
+            transition: background var(--weo-duration-fast) var(--weo-ease-out),
+                        border-color var(--weo-duration-fast) var(--weo-ease-out);
         }
-        
+
+        .tier-card:hover {
+            background: var(--weo-surface-raised);
+            border-color: rgba(148, 163, 184, 0.3);
+        }
+
         .tier-card.featured {
             border-color: var(--weo-sample-gold);
             background: linear-gradient(135deg, var(--weo-sample-bg) 0%, var(--weo-surface-base) 100%);
+        }
+
+        .tier-card.featured:hover {
+            border-color: var(--weo-sample-gold);
+            background: linear-gradient(135deg, rgba(252, 211, 77, 0.10) 0%, var(--weo-surface-base) 100%);
         }
         
         .tier-badge {
@@ -631,9 +645,10 @@
             font-weight: 600;
             padding: var(--weo-space-sm) var(--weo-space-lg);
             border-radius: var(--weo-radius-md);
-            transition: all var(--weo-duration-fast) var(--weo-ease-out);
+            transition: background var(--weo-duration-fast) var(--weo-ease-out),
+                        transform var(--weo-duration-fast) var(--weo-ease-out);
         }
-        
+
         .kofi-button:hover {
             background: #E54542;
             transform: translateY(-1px);
@@ -646,7 +661,7 @@
         }
         
         .kofi-button.secondary:hover {
-            background: var(--weo-border-primary);
+            background: rgba(148, 163, 184, 0.08);
             color: var(--weo-text-primary);
         }
         
@@ -909,8 +924,8 @@
             <a href="/">Map</a>
             <a href="atlas.html">Atlas</a>
             <a href="events.html">Events</a>
-            <a href="methodology.html">Methodology</a>
             <a href="blocs.html">Blocs</a>
+            <a href="methodology.html">Methodology</a>
             <a href="research.html">Research</a>
             <a href="about.html">About</a>
             <a href="support.html" class="active">Support</a>
@@ -1118,7 +1133,7 @@
         
         <!-- Footer -->
         <footer class="page-footer">
-            <p class="footer-version">Methodology V1.3 · WEO v1.2.0</p>
+            <p class="footer-version">Methodology V1.4 · WEO v1.3.0</p>
             <p class="footer-text">© 2026 Warmth Engine Observatory</p>
             <p class="footer-links"><a href="legal.html">Privacy Policy & Terms of Service</a></p>
         </footer>


### PR DESCRIPTION
## Summary

Ports atlas.html's interactive surface patterns (hover-responsive backgrounds, semantic tinting, scoped transitions) to 5 content pages. CSS-only — no HTML changes, no layout impact.

### methodology.html (FIX 1–3)
- `.dynamic-item`, `.event-type-item`, `.tier-item`: `border: 1px solid transparent` at rest (no layout jump); hover raises surface to `--weo-surface-raised` and reveals `--weo-border-primary`

### about.html (FIX 4)
- `.faq-question`: adds horizontal padding + `border-radius`; teal-tinted background (`rgba(45,212,191,0.04)`) joins existing colour transition on hover

### blocs.html (FIX 5, 8)
- `.bloc-header:hover`: replaces `var(--weo-border-primary)` (border token as surface) with `rgba(148,163,184,0.08)` neutral overlay
- Expanded-state semantic tints: Western (blue 0.06), Eastern (orange 0.06), Cross-Bloc (teal 0.06); deeper on hover (0.10)
- `.eu-toggle`: `transition: all` → scoped to `border-color` + `color`

### support.html (FIX 6, 9)
- `.tier-card:hover`: raised surface + lighter border
- `.tier-card.featured:hover`: gold border held, gradient warms to `rgba(252,211,77,0.10)`
- `.kofi-button`: `transition: all` → `background` + `transform`
- `.kofi-button.secondary:hover`: replaces border token as surface with `rgba(148,163,184,0.08)`

### research.html (FIX 7)
- `.publication-card:hover`: amber border `rgba(245,158,11,0.4)`, underglow `0.12→0.20`
- `.publication-card--weo:hover`: blue border `rgba(96,165,250,0.4)`, underglow `0.15→0.22`

## Test plan
- [ ] methodology.html — hover dynamic-item, event-type-item, tier-item: smooth surface lift, no layout shift
- [ ] about.html — hover FAQ question: teal background + text colour change together
- [ ] blocs.html — hover collapsed header: neutral grey; expand then hover: semantic tint; EU toggle transitions cleanly
- [ ] support.html — hover tier cards (neutral lift); featured card (gold gradient warms); Ko-fi buttons transition smoothly
- [ ] research.html — hover publication cards: amber/blue border + underglow intensifies
- [ ] `@media (prefers-reduced-motion)` suppresses all new transitions (no new keyframes added)
- [ ] Mobile: no sticky hover states on iOS Safari