### PR TITLE
fix: correct gold star positioning to inline with actor name

### DIFF
--- a/index.html
+++ b/index.html
@@ -11477,7 +11477,7 @@ function generateCCSection(eventId, showFullContent) {
 
   function rowHTML(a, id) {
     var h = '<div class="scp-row" id="' + id + '">';
-    var namePrefix = a.sample ? '<span class="sample-star">' + WEO_ICON_STAR + '</span>' : '';
+    var namePrefix = a.sample ? '<span style="display:inline;vertical-align:-1px;margin-right:4px;">' + WEO_ICON_STAR + '</span>' : '';
     h += '<span class="scp-row-name" title="' + a.n + '">' + namePrefix + a.n + '</span>';
     h += '<div class="scp-row-bar">';
     a.dims.forEach(function(d, i) {


### PR DESCRIPTION
## Problem

The gold star for the United States sample actor in the SCP panel was rendering in the wrong position (top-right corner of the panel) because it was wrapped in `<span class="sample-star">`, which has `position: absolute` in the stylesheet — a rule designed for map marker overlays, not inline text.

## Fix

Replace the `.sample-star` wrapper with an inline span:

```diff
- var namePrefix = a.sample ? '<span class="sample-star">' + WEO_ICON_STAR + '</span>' : '';
+ var namePrefix = a.sample ? '<span style="display:inline;vertical-align:-1px;margin-right:4px;">' + WEO_ICON_STAR + '</span>' : '';
```

The star now sits in normal document flow, immediately before "United States" on the same line, inside the `.scp-row-name` span.

## Test plan

- [ ] Open SCP panel — gold star appears left of "United States" text, on the same row, inline
- [ ] No star visible outside the actor name row (no floating badge at top of panel)
- [ ] Other actors show no star
- [ ] Row expand/collapse still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)