### PR TITLE
fix: move gold star to right of actor name for consistent left alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -11477,8 +11477,8 @@ function generateCCSection(eventId, showFullContent) {
 
   function rowHTML(a, id) {
     var h = '<div class="scp-row" id="' + id + '">';
-    var namePrefix = a.sample ? '<span style="display:inline;vertical-align:-1px;margin-right:4px;">' + WEO_ICON_STAR + '</span>' : '';
-    h += '<span class="scp-row-name" title="' + a.n + '">' + namePrefix + a.n + '</span>';
+    var nameSuffix = a.sample ? '<span style="display:inline-block;vertical-align:-1px;margin-left:5px;">' + WEO_ICON_STAR + '</span>' : '';
+    h += '<span class="scp-row-name" title="' + a.n + '">' + a.n + nameSuffix + '</span>';
     h += '<div class="scp-row-bar">';
     a.dims.forEach(function(d, i) {
       h += '<div class="scp-row-seg' + (d ? ' ' + DC[i] + '-m' : '') + '" data-di="' + i + '"></div>';


### PR DESCRIPTION
## Change

Moves the gold star indicator from before the actor name to after it in the SCP panel row.

**Before:** `★ United States` — star shifts "United States" rightward, misaligning it with all other actor names  
**After:** `United States ★` — all actor names left-align at the same position; star is a trailing indicator

```diff
- var namePrefix = a.sample ? '<span style="display:inline;vertical-align:-1px;margin-right:4px;">' + WEO_ICON_STAR + '</span>' : '';
- h += '<span class="scp-row-name" title="' + a.n + '">' + namePrefix + a.n + '</span>';
+ var nameSuffix = a.sample ? '<span style="display:inline-block;vertical-align:-1px;margin-left:5px;">' + WEO_ICON_STAR + '</span>' : '';
+ h += '<span class="scp-row-name" title="' + a.n + '">' + a.n + nameSuffix + '</span>';
```

## Test plan

- [ ] SCP panel: "United States" starts at the same left position as all other actor names
- [ ] Gold star appears immediately after "United States" text, inline, on the same row
- [ ] No star on any other actor row

🤖 Generated with [Claude Code](https://claude.com/claude-code)