### PR TITLE
fix: reduce sample actor star to superscript accent size

### DIFF
--- a/index.html
+++ b/index.html
@@ -11477,7 +11477,7 @@ function generateCCSection(eventId, showFullContent) {
 
   function rowHTML(a, id) {
     var h = '<div class="scp-row" id="' + id + '">';
-    var nameSuffix = a.sample ? '<span style="display:inline-block;vertical-align:-1px;margin-left:5px;">' + WEO_ICON_STAR + '</span>' : '';
+    var nameSuffix = a.sample ? '<span style="display:inline-block;vertical-align:super;margin-left:3px;line-height:1;"><svg width="8" height="8" viewBox="0 0 24 24" fill="rgba(255, 215, 0, 0.25)" stroke="#FFD700" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg></span>' : '';
     h += '<span class="scp-row-name" title="' + a.n + '">' + a.n + nameSuffix + '</span>';
     h += '<div class="scp-row-bar">';
     a.dims.forEach(function(d, i) {


### PR DESCRIPTION
## Change

Replaces the 14×14 `WEO_ICON_STAR` with an inline 8×8 SVG positioned as a superscript accent, so it reads as a subtle marker rather than a prominent badge.

```diff
- var nameSuffix = a.sample ? '<span style="display:inline-block;vertical-align:-1px;margin-left:5px;">' + WEO_ICON_STAR + '</span>' : '';
+ var nameSuffix = a.sample ? '<span style="display:inline-block;vertical-align:super;margin-left:3px;line-height:1;"><svg width="8" height="8" ...></svg></span>' : '';
```

**Visual result:** `United States ✦` — tiny gold star sits in the upper-right of the name as a superscript accent, noticeable but not dominant. Uses inline SVG directly (not `WEO_ICON_STAR` constant, which is fixed at 14×14).

## Test plan

- [ ] SCP panel: "United States" has a small gold star superscript to its upper-right
- [ ] Star does not disrupt row height or name left-alignment
- [ ] No other actor rows show a star

🤖 Generated with [Claude Code](https://claude.com/claude-code)