### PR TITLE
fix: show SCP participants expanded by default

### DIFF
--- a/index.html
+++ b/index.html
@@ -11391,7 +11391,7 @@ function generateCCSection(eventId, showFullContent) {
   var statusActorRow = document.getElementById('statusActorRow');
 
   var isOpen = false;
-  var partsExpanded = false;
+  var partsExpanded = true;
   var activeDim = -1;
   var rendered = false;
   var listenersAttached = false;


### PR DESCRIPTION
## Change

Changes the initial state of the Participants section from collapsed to expanded when the SCP panel opens.

```diff
- var partsExpanded = false;
+ var partsExpanded = true;
```

`render()` already applies `partsExpanded` to the DOM after building the HTML, so this single change propagates correctly. The toggle still works — clicking "▼ 7 Participants" collapses/expands as before; it just starts open.

## Test plan

- [ ] Open SCP panel — all 7 Participant rows visible immediately, toggle shows ▼
- [ ] Click toggle — participants collapse, arrow flips to ►
- [ ] Click toggle again — participants expand again
- [ ] Re-opening the panel resets to expanded (expected, since `partsExpanded` resets on re-render)

🤖 Generated with [Claude Code](https://claude.com/claude-code)