### PR TITLE
fix: restore supporter access validation broken by SCP migration

### DIFF
--- a/index.html
+++ b/index.html
@@ -10967,7 +10967,7 @@ function generateCCSection(eventId, showFullContent) {
           cache: 'no-store'
         });
         const data = await res.json();
-        if (data.meta && data.meta.tier === 'full') {
+        if (data.metadata && data.metadata.tier === 'full') {
           localStorage.setItem(WEO_AUTH_KEY, 'true');
           localStorage.setItem(WEO_PASSWORD_KEY, password);
           grantAccess(); closeAccessModal();


### PR DESCRIPTION
## Root cause

`checkAccess()` validates the password by calling `GET /api/events` with `X-WEO-Password` and checking the response body for `data.meta.tier === 'full'`. But the events API returns `metadata` (not `meta`) as the top-level key — so `data.meta` is always `undefined`, the check always fails, and every valid password is rejected as "Invalid access code."

Confirmed by inspecting the live API response:
```
{ "metadata": { ..., "tier": "full" }, "events": [...] }
```
`data.meta` → `undefined` → condition never truthy.

## Fix

```diff
- if (data.meta && data.meta.tier === 'full') {
+ if (data.metadata && data.metadata.tier === 'full') {
```

One word. No other auth-path code references `data.meta`.

## Test plan

- [ ] Enter valid password → access granted, modal closes, body gains `weo-authenticated`
- [ ] Enter invalid password → "Invalid access code." shown
- [ ] After login, SCP panel re-renders with full-tier actor data (`window._scpReloadActors` fires via `grantAccess`)
- [ ] Logout and re-login round-trips correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)