### PR TITLE
style: differentiate SCP designation group headers from actor rows

### DIFF
--- a/blocs.html
+++ b/blocs.html
@@ -1318,14 +1318,17 @@
 
         /* Designation group header rows (rendered by JS) */
         .scp-designation-row td {
-            padding: 10px 10px 3px;
-            font-size: 0.625rem;
-            font-weight: 700;
-            letter-spacing: 0.09em;
+            padding: 16px 10px 6px;
+            font-size: 0.7rem;
+            font-weight: 600;
+            letter-spacing: 0.05em;
             text-transform: uppercase;
-            color: var(--weo-text-tertiary);
+            color: #94A3B8;
             background: transparent;
-            border-bottom: none !important;
+            border-bottom: 1px solid rgba(51, 65, 85, 0.4) !important;
+        }
+        .scp-designation-row:first-child td {
+            padding-top: 8px;
         }
         .scp-designation-row:hover {
             background: transparent !important;


### PR DESCRIPTION
## Summary

Updates `.scp-designation-row` CSS to clearly distinguish designation group headers (PRINCIPAL AI ACTORS, AI INFRASTRUCTURE KEYSTONES, etc.) from actor data rows — matching the visual treatment used in the index.html SCP panel.

**Changes:**
- `color: #94A3B8` — muted slate, same token used by index.html SCP section headers
- `font-size: 0.7rem` (was 0.625rem)
- `font-weight: 600` (was 700)
- `letter-spacing: 0.05em` (was 0.09em — too wide)
- `padding-top: 16px` — breathing room above each group; reduced to 8px for the first row (PAA) via `:first-child`
- `border-bottom: 1px solid rgba(51, 65, 85, 0.4)` — subtle separator between the header label and the first actor in each group

CSS-only change; no JS or HTML structure modified.

## Test plan
- [ ] Open blocs.html → Actor Capability Profiles section
- [ ] Verify group headers are visually distinct from actor rows (muted, smaller, with bottom border)
- [ ] Verify first header (Principal AI Actors) has less top padding than subsequent headers
- [ ] Verify no regression to other sections of the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)