### PR TITLE
fix: reduce SCP scroll gradient width to prevent content overlap

### DIFF
--- a/blocs.html
+++ b/blocs.html
@@ -1293,6 +1293,14 @@
             border-left: 1px solid rgba(51, 65, 85, 0.3);
         }
 
+        /* Narrow scroll gradient for SCP table — the scp-table-wrap negative
+           margin cancels its own padding, leaving table content at x=0 of the
+           scroll container. 16px keeps the hint subtle; extra first-column
+           padding ensures actor names sit clear of the gradient. */
+        .scp-section .table-scroll-indicator { width: 16px; }
+        .scp-table thead th:first-child,
+        .scp-table td:first-child { padding-left: 20px; }
+
         /* Temporal disclaimer */
         .scp-disclaimer {
             margin-top: var(--weo-space-lg);


### PR DESCRIPTION
The SCP table scroll gradient indicators were 32px wide, overlapping the Actor column.

Root cause: `scp-table-wrap` uses `margin: 0 -2rem; padding: 0 2rem` for edge-to-edge bleed. The negative margin and padding cancel out, so the table content starts at x=0 of the `table-scroll-container` — exactly where the absolute-positioned left indicator begins.

Fix:
- Scope the indicator width to 16px within `.scp-section` (nation tables are unaffected)
- Increase first-column `padding-left` to 20px on both `th` and `td` so actor names begin at x=20px, safely past the 16px gradient