### PR TITLE
fix: align SCP scroll gradients flush at container edges with content padding

### DIFF
--- a/blocs.html
+++ b/blocs.html
@@ -1130,8 +1130,6 @@
         .scp-table-wrap {
             overflow-x: auto;
             -webkit-overflow-scrolling: touch;
-            margin: 0 calc(-1 * var(--weo-space-xl));
-            padding: 0 var(--weo-space-xl);
         }
 
         .scp-table {
@@ -1293,10 +1291,8 @@
             border-left: 1px solid rgba(51, 65, 85, 0.3);
         }
 
-        /* Narrow scroll gradient for SCP table — the scp-table-wrap negative
-           margin cancels its own padding, leaving table content at x=0 of the
-           scroll container. 16px keeps the hint subtle; extra first-column
-           padding ensures actor names sit clear of the gradient. */
+        /* SCP scroll gradient: narrower than nation tables so it stays subtle;
+           first-column padding keeps actor names clear of the 16px gradient. */
         .scp-section .table-scroll-indicator { width: 16px; }
         .scp-table thead th:first-child,
         .scp-table td:first-child { padding-left: 20px; }
@@ -1350,11 +1346,6 @@
 
         /* Responsive */
         @media (max-width: 768px) {
-            .scp-table-wrap {
-                margin: 0 calc(-1 * var(--weo-space-lg));
-                padding: 0 var(--weo-space-sm);
-            }
-
             .scp-legend {
                 gap: var(--weo-space-sm);
             }


### PR DESCRIPTION
The SCP table scroll gradients were misaligned because `scp-table-wrap` used a negative-margin bleed pattern (`margin: 0 -2rem; padding: 0 2rem`). This caused the scroll wrapper to extend wider than the section content, and the `table-scroll-container` indicators at `left: 0` / `right: 0` landed in the middle of the visible table area rather than at its edges.

Fix matches the events.html reference pattern:
- Remove negative margin and compensating padding from `.scp-table-wrap` — the container now aligns with the parent section content width (matches badge panel above)
- Remove the mobile responsive override that tweaked those same margins
- Indicators at `left: 0` / `right: 0` of `table-scroll-container` are now flush at the actual scroll edges
- First-column `padding-left: 20px` keeps actor names clear of the 16px gradient overlay
- Scoped 16px gradient width retained for SCP table (nation tables unaffected)