### PR TITLE
feat: extend JSON-LD with SCP and V1.4 bloc classification metadata

### DIFF
--- a/blocs.html
+++ b/blocs.html
@@ -29,7 +29,7 @@
       "@context": "https://schema.org",
       "@type": "WebPage",
       "name": "Bloc Membership Register — Warmth Engine Observatory",
-      "description": "WEO Bloc Membership Register — Western Bloc, Eastern Bloc, and Non-Aligned nation classifications used in AI infrastructure coordination dynamics tracking.",
+      "description": "WEO Bloc Membership Register and Actor Capability Profiles — nation classifications using universal categories (Core, Integrated, Engaged, Peripheral, Non-Aligned), actor designation assessments, and sovereign capability scoring across seven dimensions of the AI infrastructure stack.",
       "url": "https://www.warmthengine.com/blocs.html",
       "isPartOf": {
         "@type": "WebSite",
@@ -40,6 +40,19 @@
       "sameAs": [
         "https://doi.org/10.5281/zenodo.18427565",
         "https://doi.org/10.5281/zenodo.18427582"
+      ],
+      "keywords": ["Bloc Membership Register", "Western Bloc", "Eastern Bloc", "Non-Aligned", "Core", "Integrated", "Engaged", "Peripheral", "Sovereign Capability Profiles", "Principal AI Actor", "AI Infrastructure Keystone", "Advanced Capability State", "7-dimension framework"],
+      "about": [
+        {
+          "@type": "Thing",
+          "name": "Bloc Classification",
+          "description": "Universal category framework classifying nations by AI infrastructure ecosystem alignment — Core, Integrated, Engaged, Peripheral, and Non-Aligned"
+        },
+        {
+          "@type": "Thing",
+          "name": "Sovereign Capability Profiles",
+          "description": "Seven-dimension actor assessment identifying structural roles across the global AI infrastructure stack"
+        }
       ]
     }
     </script>

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
     "name": "Warmth Engine Observatory",
     "alternateName": "WEO",
     "url": "https://www.warmthengine.com",
-    "description": "The Warmth Engine Observatory tracks AI infrastructure coordination dynamics across geopolitical blocs through verified events and mapped Coordination Connections. Events are classified by three orthogonal systems — Event Type (Coordination, Infrastructure, Policy, Corporate), Tier (Cross-Bloc, Between-Bloc, Intra-Bloc), and Domain (Energy/Infrastructure, Security, Technology, Trade) — and carry two analytical enrichment layers: Industry Tags identifying which sectors an event's provisions address, and Environmental Nexus Tags identifying documented environmental intersections. The Warmth Engine Ratio measures the balance between documented environmental resource demand and environmental governance across the event database. The methodology applies institutional-grade classification adapted from Basel Committee frameworks, intelligence community verification standards, and international relations theory to systematically document coordination and fragmentation patterns in AI infrastructure deployment.",
+    "description": "The Warmth Engine Observatory tracks AI infrastructure coordination dynamics across geopolitical blocs through verified events and mapped Coordination Connections. Events are classified by three orthogonal systems — Event Type (Coordination, Infrastructure, Policy, Corporate), Tier (Cross-Bloc, Between-Bloc, Intra-Bloc), and Domain (Energy/Infrastructure, Security, Technology, Trade) — and carry two analytical enrichment layers: Industry Tags identifying which sectors an event's provisions address, and Environmental Nexus Tags identifying documented environmental intersections. The Warmth Engine Ratio measures the balance between documented environmental resource demand and environmental governance across the event database. The methodology applies institutional-grade classification adapted from Basel Committee frameworks, intelligence community verification standards, and international relations theory to systematically document coordination and fragmentation patterns in AI infrastructure deployment. Sovereign Capability Profiles assess actor control across seven dimensions of the AI infrastructure stack, identifying which actors anchor global AI ecosystems through a three-gate designation framework.",
     "disambiguatingDescription": "An AI Infrastructure Coordination Dynamics Tracking platform. Not related to thermal energy, Stirling engines, heat engines, or physical warmth/cooling systems.",
     "foundingDate": "2026",
     "founder": {
@@ -62,7 +62,16 @@
       "Warmth Engine Ratio",
       "WER",
       "Industry Tags",
-      "Principal AI Actors"
+      "Principal AI Actors",
+      "Sovereign Capability Profiles",
+      "SCP",
+      "AI Infrastructure Keystone",
+      "Advanced Capability State",
+      "bloc classification",
+      "Core",
+      "Integrated",
+      "Engaged",
+      "Peripheral"
     ],
     "about": [
       {
@@ -74,6 +83,11 @@
         "@type": "Thing",
         "name": "Geopolitical Coordination",
         "description": "Observable coordination and fragmentation dynamics between major power centres"
+      },
+      {
+        "@type": "Thing",
+        "name": "Sovereign Capability Profiles",
+        "description": "Seven-dimension assessment framework identifying Principal AI Actors, AI Infrastructure Keystones, Advanced Capability States, and Participants across the global AI infrastructure stack"
       }
     ],
     "audience": {


### PR DESCRIPTION
## Summary

- **index.html**: Extended JSON-LD `keywords` array with 9 SCP/bloc classification terms; appended SCP description sentence to the `description` field; added third `about` entry for Sovereign Capability Profiles
- **blocs.html**: Replaced description with expanded V1.4 text covering universal bloc categories and SCP scoring; added `keywords` array (13 terms); added `about` array with Bloc Classification and Sovereign Capability Profiles entries

## Test plan

- [ ] Validate both JSON-LD blocks parse as valid JSON (no trailing commas, balanced brackets)
- [ ] Confirm no other JSON-LD fields were modified (name, url, isPartOf, inLanguage, sameAs, founder, license, etc.)
- [ ] Run Google Rich Results Test or Schema Markup Validator on both pages after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)