### PR TITLE
data: source durability Batch 2 — captureStatus/snapshotUrl for Chinese URLs

### DIFF
--- a/events-free.json
+++ b/events-free.json
@@ -4,7 +4,7 @@
     "total_events": 157,
     "sample_events": 6,
     "standard_events": 151,
-    "last_updated": "2026-05-23",
+    "last_updated": "2026-05-26",
     "source": "Extracted from index.html (WEO Map v1.25+)",
     "statistics": {
       "by_bloc": {
@@ -56,8 +56,8 @@
         "1.1.2": 1
       }
     },
-    "versionDate": "2026-05-23",
-    "lastAudit": "2026-05-23",
+    "versionDate": "2026-05-26",
+    "lastAudit": "2026-05-26",
     "auditDescription": "Loop 16: 2 new events added (E166 Cambricon SiYuan 590, E167 Biren BR100/BR106). 0 CCs added. Metadata fully recomputed from event array.",
     "event_count": 157,
     "version_note": "V1.3: Principal actor framework + Level 5 operational evidence retrospective application. 12 T1 reclassifications (1 maintained T1, 5 reclassified to T3, 6 removed). 1 additional event removed (Level 5 failure). 9 CCs removed.",


### PR DESCRIPTION
## Summary

- Applied Batch 2 (38 Chinese URLs) and retry pass results to `events-canonical.json`
- 29 sources marked `captureStatus: captured` with `snapshotUrl` populated
- 9 sources marked `captureStatus: retry_pending` (failed even after retry — `target_server_timeout`)
- 16 Reuters sources remain `no_capture` (permanent paywall — from Batch 1)
- Regenerated `events-free.json` and `events-full.json` from updated canonical
- All three KV keys uploaded; worker redeployed and verified (157 events via API)

## Source durability totals (post Batch 1 + Batch 2 + retry)

- Captured: 780 sources
- Retry pending: 9 (Chinese govt URLs, timeout)
- No capture: 16 (Reuters paywall)
- Unprocessed: 6

## Test plan

- [ ] Operator reviews PR diff (events-free.json only — no premium data)
- [ ] Operator verifies live site (log out/in for cache refresh)
- [ ] Operator merges PR manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)