### PR TITLE
fix: back-to-top button never attached scroll listener (DOM order bug)

### DIFF
--- a/research/methodology/manual/index.html
+++ b/research/methodology/manual/index.html
@@ -14922,10 +14922,13 @@ References indicate document and section.</p>
         });
     }
 
-    // Back to top
+    </script>
+    <button class="weo-back-to-top" id="backToTop" aria-label="Back to top">
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"></polyline></svg>
+    </button>
+    <script>
     (function() {
-        const btn = document.getElementById('backToTop');
-        if (!btn) return;
+        var btn = document.getElementById('backToTop');
         window.addEventListener('scroll', function() {
             btn.classList.toggle('visible', window.scrollY > 500);
         }, { passive: true });
@@ -14933,11 +14936,7 @@ References indicate document and section.</p>
             window.scrollTo({ top: 0, behavior: 'smooth' });
         });
     })();
-
     </script>
-    <button class="weo-back-to-top" id="backToTop" aria-label="Back to top">
-        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"></polyline></svg>
-    </button>
     <script data-goatcounter="https://warmthengine.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
 </body>
 </html>

--- a/research/methodology/rationale/index.html
+++ b/research/methodology/rationale/index.html
@@ -11457,10 +11457,13 @@ via the contact information provided on the WEO platform.</p>
         });
     }
 
-    // Back to top
+    </script>
+    <button class="weo-back-to-top" id="backToTop" aria-label="Back to top">
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"></polyline></svg>
+    </button>
+    <script>
     (function() {
-        const btn = document.getElementById('backToTop');
-        if (!btn) return;
+        var btn = document.getElementById('backToTop');
         window.addEventListener('scroll', function() {
             btn.classList.toggle('visible', window.scrollY > 500);
         }, { passive: true });
@@ -11468,11 +11471,7 @@ via the contact information provided on the WEO platform.</p>
             window.scrollTo({ top: 0, behavior: 'smooth' });
         });
     })();
-
     </script>
-    <button class="weo-back-to-top" id="backToTop" aria-label="Back to top">
-        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="18 15 12 9 6 15"></polyline></svg>
-    </button>
     <script data-goatcounter="https://warmthengine.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
 </body>
 </html>


### PR DESCRIPTION
The back-to-top IIFE ran inside the main <script> block, which executes before the <button id="backToTop"> element is parsed. getElementById returned null, the if(!btn) guard fired, and the scroll listener was never registered.

Fix: move the back-to-top JS into a dedicated <script> block placed *after* the button HTML so the element exists when the script runs. Applied to both manual/index.html and rationale/index.html.