### PR TITLE
fix: back-to-top button — always visible on mobile, no scroll listener

### DIFF
--- a/research/methodology/manual/index.html
+++ b/research/methodology/manual/index.html
@@ -623,6 +623,11 @@
         }
         .weo-back-to-top.visible { opacity: 1; }
         .weo-back-to-top:hover { color: #60a5fa; border-color: #60a5fa; }
+        @media (max-width: 768px) {
+            .weo-back-to-top { opacity: 0.4; pointer-events: auto; }
+            .weo-back-to-top:hover,
+            .weo-back-to-top:active { opacity: 1; }
+        }
     </style>
 </head>
 <body>
@@ -14930,45 +14935,11 @@ References indicate document and section.</p>
     <script>
     (function() {
         var btn = document.getElementById('backToTop');
-        var pointerTimer = null;
-
-        window.addEventListener('scroll', function() {
-            var shouldShow = window.scrollY > 500;
-            if (shouldShow) {
-                if (!btn.classList.contains('visible')) {
-                    btn.classList.add('visible');
-                    clearTimeout(pointerTimer);
-                    pointerTimer = setTimeout(function() {
-                        btn.style.pointerEvents = 'auto';
-                    }, 600);
-                }
-            } else {
-                btn.classList.remove('visible');
-                clearTimeout(pointerTimer);
-                btn.style.pointerEvents = '';
-            }
-        }, { passive: true });
-
-        var touchStartTime = 0;
-        var touchStartX = 0;
-        var touchStartY = 0;
-
-        btn.addEventListener('touchstart', function(e) {
-            touchStartTime = Date.now();
-            touchStartX = e.touches[0].clientX;
-            touchStartY = e.touches[0].clientY;
-        }, { passive: true });
-
-        btn.addEventListener('touchend', function(e) {
-            var duration = Date.now() - touchStartTime;
-            var dx = Math.abs(e.changedTouches[0].clientX - touchStartX);
-            var dy = Math.abs(e.changedTouches[0].clientY - touchStartY);
-            if (duration < 300 && dx < 10 && dy < 10) {
-                e.preventDefault();
-                window.scrollTo({ top: 0, behavior: 'smooth' });
-            }
-        });
-
+        if (window.matchMedia('(min-width: 769px)').matches) {
+            window.addEventListener('scroll', function() {
+                btn.classList.toggle('visible', window.scrollY > 500);
+            }, { passive: true });
+        }
         btn.addEventListener('click', function() {
             window.scrollTo({ top: 0, behavior: 'smooth' });
         });

--- a/research/methodology/rationale/index.html
+++ b/research/methodology/rationale/index.html
@@ -623,6 +623,11 @@
         }
         .weo-back-to-top.visible { opacity: 1; }
         .weo-back-to-top:hover { color: #60a5fa; border-color: #60a5fa; }
+        @media (max-width: 768px) {
+            .weo-back-to-top { opacity: 0.4; pointer-events: auto; }
+            .weo-back-to-top:hover,
+            .weo-back-to-top:active { opacity: 1; }
+        }
     </style>
 </head>
 <body>
@@ -11465,45 +11470,11 @@ via the contact information provided on the WEO platform.</p>
     <script>
     (function() {
         var btn = document.getElementById('backToTop');
-        var pointerTimer = null;
-
-        window.addEventListener('scroll', function() {
-            var shouldShow = window.scrollY > 500;
-            if (shouldShow) {
-                if (!btn.classList.contains('visible')) {
-                    btn.classList.add('visible');
-                    clearTimeout(pointerTimer);
-                    pointerTimer = setTimeout(function() {
-                        btn.style.pointerEvents = 'auto';
-                    }, 600);
-                }
-            } else {
-                btn.classList.remove('visible');
-                clearTimeout(pointerTimer);
-                btn.style.pointerEvents = '';
-            }
-        }, { passive: true });
-
-        var touchStartTime = 0;
-        var touchStartX = 0;
-        var touchStartY = 0;
-
-        btn.addEventListener('touchstart', function(e) {
-            touchStartTime = Date.now();
-            touchStartX = e.touches[0].clientX;
-            touchStartY = e.touches[0].clientY;
-        }, { passive: true });
-
-        btn.addEventListener('touchend', function(e) {
-            var duration = Date.now() - touchStartTime;
-            var dx = Math.abs(e.changedTouches[0].clientX - touchStartX);
-            var dy = Math.abs(e.changedTouches[0].clientY - touchStartY);
-            if (duration < 300 && dx < 10 && dy < 10) {
-                e.preventDefault();
-                window.scrollTo({ top: 0, behavior: 'smooth' });
-            }
-        });
-
+        if (window.matchMedia('(min-width: 769px)').matches) {
+            window.addEventListener('scroll', function() {
+                btn.classList.toggle('visible', window.scrollY > 500);
+            }, { passive: true });
+        }
         btn.addEventListener('click', function() {
             window.scrollTo({ top: 0, behavior: 'smooth' });
         });


### PR DESCRIPTION
On mobile (max-width: 768px): button is always visible at opacity 0.4, pointer-events always active, no scroll listener involvement whatsoever. Tap brightens to opacity 1 via :active. No show/hide, no touch timing tricks — eliminates the scroll interference at root cause.

On desktop (min-width: 769px): scroll listener unchanged — show/hide at 500px scroll with passive listener, click handler fires scrollTo.