### PR TITLE
fix: replace mobile back-to-top button with static chapter links

### DIFF
--- a/research/methodology/manual/index.html
+++ b/research/methodology/manual/index.html
@@ -621,16 +621,29 @@
             z-index: 100;
             touch-action: manipulation;
         }
-        .weo-back-to-top.visible { opacity: 1; }
+        .weo-back-to-top.visible { opacity: 1; pointer-events: auto; }
         .weo-back-to-top:hover { color: #60a5fa; border-color: #60a5fa; }
         @media (max-width: 768px) {
-            .weo-back-to-top { opacity: 0.4; pointer-events: auto; }
-            .weo-back-to-top:hover,
-            .weo-back-to-top:active { opacity: 1; }
+            #backToTop { display: none !important; }
+        }
+        .weo-mobile-top-link {
+            display: none;
+        }
+        @media (max-width: 768px) {
+            .weo-mobile-top-link {
+                display: block;
+                text-align: center;
+                padding: 1rem;
+                color: #94A3B8;
+                font-size: 0.875rem;
+                text-decoration: none;
+                border-top: 1px solid var(--weo-border-primary);
+                margin-top: 2rem;
+            }
         }
     </style>
 </head>
-<body>
+<body id="top">
     <a href="#main-content" class="sr-only" id="skip-link">Skip to main content</a>
     <div class="container pub-container" id="main-content">
 
@@ -1166,6 +1179,7 @@ absence. Fragmentation events are within scope because they are
 observable dynamics between blocs within this field — not because they
 involve cooperative coordination in the Keohane (1984) sense.</p>
 <hr />
+<a href="#top" class="weo-mobile-top-link">↑ Back to top</a>
 <h1 id="chapter-1">Chapter 1: Executive Summary</h1>
 <h2 id="section-1-what">What WEO Is</h2>
 <p>This methodology enables systematic tracking of AI infrastructure
@@ -1340,6 +1354,7 @@ C).</p>
 <hr />
 <p><strong>End of Chapter 1: Executive Summary</strong></p>
 <hr />
+<a href="#top" class="weo-mobile-top-link">↑ Back to top</a>
 <h1 id="chapter-2">Chapter 2: Methodology Architecture</h1>
 <h2 id="overview">Overview</h2>
 <p>This methodology enables systematic tracking of AI infrastructure
@@ -1773,6 +1788,7 @@ version milestones (§5.3 Review Mechanism).</p>
 <hr />
 <p><strong>End of Chapter 2: Methodology Architecture</strong></p>
 <hr />
+<a href="#top" class="weo-mobile-top-link">↑ Back to top</a>
 <h1 id="chapter-3">Chapter 3: Event Verification</h1>
 <p><a href="/research/methodology/rationale/#rationale-3" class="weo-rationale-link">View rationale for this chapter →</a></p>
 
@@ -6528,6 +6544,7 @@ dynamics across geopolitical blocs.</p>
 <hr />
 <p><strong>End of Chapter 3: Event Verification</strong></p>
 <hr />
+<a href="#top" class="weo-mobile-top-link">↑ Back to top</a>
 <h1 id="chapter-4">Chapter 4: Geopolitical Significance Assessment</h1>
 <p><a href="/research/methodology/rationale/#rationale-4" class="weo-rationale-link">View rationale for this chapter →</a></p>
 <h2 id="section-4-1">4.1 Purpose and Framework Overview</h2>
@@ -8521,6 +8538,7 @@ Response Evidence) for the Stage 2 qualification pathways.</em></p>
 <p><strong>End of Chapter 4: Geopolitical Significance
 Assessment</strong></p>
 <hr />
+<a href="#top" class="weo-mobile-top-link">↑ Back to top</a>
 <h1 id="chapter-5">Chapter 5: Tier Classification</h1>
 <p><a href="/research/methodology/rationale/#rationale-5" class="weo-rationale-link">View rationale for this chapter →</a></p>
 
@@ -9944,6 +9962,7 @@ roles (not observers)</p>
 <hr />
 <p><strong>End of Chapter 5: Tier Classification</strong></p>
 <hr />
+<a href="#top" class="weo-mobile-top-link">↑ Back to top</a>
 <h1 id="chapter-6">Chapter 6: Domain Classification</h1>
 <p><a href="/research/methodology/rationale/#rationale-6" class="weo-rationale-link">View rationale for this chapter →</a></p>
 
@@ -10588,6 +10607,7 @@ stage checklists verified - [ ] No outstanding LOW confidence flags - [
 <hr />
 <p><strong>End of Chapter 6: Domain Classification</strong></p>
 <hr />
+<a href="#top" class="weo-mobile-top-link">↑ Back to top</a>
 <h1 id="chapter-7">Chapter 7: Industry Tags</h1>
 <p><a href="/research/methodology/rationale/#rationale-7" class="weo-rationale-link">View rationale for this chapter →</a></p>
 
@@ -11440,6 +11460,7 @@ directly addressing cloud infrastructure capital access.”</p>
 <hr />
 <p><strong>End of Chapter 7: Industry Tags</strong></p>
 <hr />
+<a href="#top" class="weo-mobile-top-link">↑ Back to top</a>
 <h1 id="chapter-8">Chapter 8: Environmental Nexus Tags</h1>
 <p><a href="/research/methodology/rationale/#rationale-8" class="weo-rationale-link">View rationale for this chapter →</a></p>
 <h2 id="section-8-1">8.1 Purpose</h2>
@@ -12091,6 +12112,7 @@ population provides empirical boundary cases to codify.</p>
 <hr />
 <p><strong>End of Chapter 8: Environmental Nexus Tags</strong></p>
 <hr />
+<a href="#top" class="weo-mobile-top-link">↑ Back to top</a>
 <h1 id="chapter-9">Chapter 9: Coordination Connections</h1>
 <p><a href="/research/methodology/rationale/#rationale-9" class="weo-rationale-link">View rationale for this chapter →</a></p>
 
@@ -13880,6 +13902,7 @@ analytical assessments, not documentary verification.</p>
 <hr />
 <p><strong>End of Chapter 9: Coordination Connections</strong></p>
 <hr />
+<a href="#top" class="weo-mobile-top-link">↑ Back to top</a>
 <h1 id="appendix-unified-index">Appendix: Unified Index</h1>
 <p>This index covers both the <strong>Methodology Manual</strong> (this
 document) and the companion <strong>Methodology Rationale</strong>.
@@ -14844,6 +14867,7 @@ References indicate document and section.</p>
 <p><em>End of Unified Index</em></p>
 <hr />
 <p><strong>End of Methodology Manual</strong></p>
+<a href="#top" class="weo-mobile-top-link">↑ Back to top</a>
 <p><em>Warmth Engine Observatory | January 2026 (v1.4, May
 2026)</em></p>
 

--- a/research/methodology/rationale/index.html
+++ b/research/methodology/rationale/index.html
@@ -621,16 +621,29 @@
             z-index: 100;
             touch-action: manipulation;
         }
-        .weo-back-to-top.visible { opacity: 1; }
+        .weo-back-to-top.visible { opacity: 1; pointer-events: auto; }
         .weo-back-to-top:hover { color: #60a5fa; border-color: #60a5fa; }
         @media (max-width: 768px) {
-            .weo-back-to-top { opacity: 0.4; pointer-events: auto; }
-            .weo-back-to-top:hover,
-            .weo-back-to-top:active { opacity: 1; }
+            #backToTop { display: none !important; }
+        }
+        .weo-mobile-top-link {
+            display: none;
+        }
+        @media (max-width: 768px) {
+            .weo-mobile-top-link {
+                display: block;
+                text-align: center;
+                padding: 1rem;
+                color: #94A3B8;
+                font-size: 0.875rem;
+                text-decoration: none;
+                border-top: 1px solid var(--weo-border-primary);
+                margin-top: 2rem;
+            }
         }
     </style>
 </head>
-<body>
+<body id="top">
     <a href="#main-content" class="sr-only" id="skip-link">Skip to main content</a>
     <div class="container pub-container" id="main-content">
 
@@ -937,6 +950,7 @@ Sustainability</td>
 </tbody>
 </table>
 <hr />
+<a href="#top" class="weo-mobile-top-link">↑ Back to top</a>
 <h1 id="rationale-1">Section 1: Introduction &amp; Document Purpose</h1>
 <h2 id="rationale-1-1">1.1 Purpose</h2>
 <p>This document provides the empirical derivation, theoretical
@@ -1022,6 +1036,7 @@ methodological transparency.</p>
 </tbody>
 </table>
 <hr />
+<a href="#top" class="weo-mobile-top-link">↑ Back to top</a>
 <h1 id="rationale-2">Section 2: Methodology Balance Statement</h1>
 <h2 id="rationale-2-1">2.1 Overall Balance</h2>
 <p>WEO methodology components distribute approximately <strong>~32%
@@ -1196,6 +1211,7 @@ validation commitments. Category Creator elements are flagged for
 priority review as the evidence base matures. Version history and
 material changes are documented in methodology version notes.</p>
 <hr />
+<a href="#top" class="weo-mobile-top-link">↑ Back to top</a>
 <h1 id="rationale-3">Section 3: Event Verification Rationale</h1>
 <p><a href="/research/methodology/manual/#chapter-3" class="weo-rationale-link">← View Manual chapter</a></p>
 <p><em>Manual Reference: Chapter 3</em></p>
@@ -3882,6 +3898,7 @@ extends; and (3) evolution of intelligence community or journalism
 source-assessment frameworks that may provide refined models for
 accommodated-source confidence calibration.</p>
 <hr />
+<a href="#top" class="weo-mobile-top-link">↑ Back to top</a>
 <h1 id="rationale-4">Section 4: Significance Assessment Rationale</h1>
 <p><a href="/research/methodology/manual/#chapter-4" class="weo-rationale-link">← View Manual chapter</a></p>
 <p><em>Manual Reference: Chapter 4</em></p>
@@ -4480,6 +4497,7 @@ language</p>
 (explicit China naming); Banque de France geopolitical trade
 fragmentation analysis; EU Chips Act implementation criteria.</p>
 <hr />
+<a href="#top" class="weo-mobile-top-link">↑ Back to top</a>
 <h1 id="rationale-5">Section 5: Tier Classification Rationale</h1>
 <p><a href="/research/methodology/manual/#chapter-5" class="weo-rationale-link">← View Manual chapter</a></p>
 <p><em>Manual Reference: Chapter 5</em></p>
@@ -6686,6 +6704,7 @@ Track whether any dimension qualification is subsequently challenged on
 evidence grounds. Review source descriptor implementation for
 consistency across assessors.</p>
 <hr />
+<a href="#top" class="weo-mobile-top-link">↑ Back to top</a>
 <h1 id="rationale-6">Section 6: Domain Classification Rationale</h1>
 <p><a href="/research/methodology/manual/#chapter-6" class="weo-rationale-link">← View Manual chapter</a></p>
 <p><em>Manual Reference: Chapter 6</em></p>
@@ -6925,6 +6944,7 @@ Technologies, Increasing Returns, and Lock-In by Historical Events.”
 “Clio and the Economics of QWERTY.” <em>American Economic Review</em>,
 75(2), 332-337.</p>
 <hr />
+<a href="#top" class="weo-mobile-top-link">↑ Back to top</a>
 <h1 id="rationale-7">Section 7: Industry Tags Rationale</h1>
 <p><a href="/research/methodology/manual/#chapter-7" class="weo-rationale-link">← View Manual chapter</a></p>
 <p><em>Manual Reference: Chapter 7</em></p>
@@ -7633,6 +7653,7 @@ event, override rates, and inter-analyst agreement. No special
 validation required — this is process design, not analytical
 methodology.</p>
 <hr />
+<a href="#top" class="weo-mobile-top-link">↑ Back to top</a>
 <h1 id="rationale-8">Section 8: Environmental Nexus Tags Rationale</h1>
 <p><a href="/research/methodology/manual/#chapter-8" class="weo-rationale-link">← View Manual chapter</a></p>
 <p><em>Manual Reference: Chapter 8</em></p>
@@ -8595,6 +8616,7 @@ governance provisions.</p>
 EDWC hub provinces as coverage expands. Track whether market-mechanism
 pathway expands as green electricity trading markets mature.</p>
 <hr />
+<a href="#top" class="weo-mobile-top-link">↑ Back to top</a>
 <h1 id="rationale-9">Section 9: Coordination Connections Rationale</h1>
 <p><a href="/research/methodology/manual/#chapter-9" class="weo-rationale-link">← View Manual chapter</a></p>
 <p><em>Manual Reference: Chapter 9</em></p>
@@ -10325,6 +10347,7 @@ relationship taxonomy found. Coordination Connections (CC) represents
 genuine novel contribution. The 7-type taxonomy qualifies as
 copyrightable “creative selection and arrangement.”</p>
 <hr />
+<a href="#top" class="weo-mobile-top-link">↑ Back to top</a>
 <h1 id="rationale-10">Section 10: Category Creator Documentation</h1>
 <h2 id="rationale-10-1">10.1 Purpose</h2>
 <p>This section explicitly documents all methodology components where
@@ -10733,6 +10756,7 @@ evidence emerges</td>
 <li><strong>Academic peer review</strong> as methodology matures</li>
 </ol>
 <hr />
+<a href="#top" class="weo-mobile-top-link">↑ Back to top</a>
 <h1 id="rationale-appendix-a">Appendix A: Glossary of Key Terms</h1>
 <table>
 <colgroup>
@@ -10912,6 +10936,7 @@ governance</td>
 </tbody>
 </table>
 <hr />
+<a href="#top" class="weo-mobile-top-link">↑ Back to top</a>
 <h1 id="rationale-appendix-b">Appendix B: Cross-Reference
 Verification</h1>
 <p>All Manual cross-references verified against WEO Methodology
@@ -11359,6 +11384,7 @@ Classification</td>
 </tbody>
 </table>
 <hr />
+<a href="#top" class="weo-mobile-top-link">↑ Back to top</a>
 <h1 id="rationale-appendix-c">Appendix C: Note on Source Accuracy</h1>
 <p>This methodology draws on extensive research across academic
 literature, regulatory frameworks, and institutional documentation.
@@ -11379,6 +11405,7 @@ Users identifying potential inaccuracies are encouraged to report them
 via the contact information provided on the WEO platform.</p>
 <hr />
 <p><strong>End of Methodology Rationale</strong></p>
+<a href="#top" class="weo-mobile-top-link">↑ Back to top</a>
 <p><em>Warmth Engine Observatory | January 2026 (v1.4, May
 2026)</em></p>
 


### PR DESCRIPTION
The fixed-position floating button is incompatible with mobile touch scrolling. New approach:

Desktop: floating button unchanged — scroll-based show/hide, click handler, pointer-events restored on .visible (fixes v3 regression where desktop button was unclickable).

Mobile: floating button hidden via #backToTop { display: none }. Static .weo-mobile-top-link anchor inserted before every chapter/ section heading and at end of document:
- manual/index.html: 11 links (chapters 1-9, appendix, end)
- rationale/index.html: 14 links (sections 1-10, appendices A-C, end)

Links are display:none by default, display:block in the mobile media query. href="#top" resolves to body id="top" added to both pages. No scroll listeners, no pointer-events tricks, no touch event handling.