### PR TITLE
fix: force-hide back-to-top button on mobile (nuclear override)

### DIFF
--- a/research/methodology/manual/index.html
+++ b/research/methodology/manual/index.html
@@ -641,6 +641,18 @@
                 margin-top: 2rem;
             }
         }
+        @media (max-width: 768px) {
+            .weo-back-to-top,
+            #backToTop,
+            [id="backToTop"] {
+                display: none !important;
+                visibility: hidden !important;
+                opacity: 0 !important;
+                pointer-events: none !important;
+                width: 0 !important;
+                height: 0 !important;
+            }
+        }
     </style>
 </head>
 <body id="top">

--- a/research/methodology/rationale/index.html
+++ b/research/methodology/rationale/index.html
@@ -641,6 +641,18 @@
                 margin-top: 2rem;
             }
         }
+        @media (max-width: 768px) {
+            .weo-back-to-top,
+            #backToTop,
+            [id="backToTop"] {
+                display: none !important;
+                visibility: hidden !important;
+                opacity: 0 !important;
+                pointer-events: none !important;
+                width: 0 !important;
+                height: 0 !important;
+            }
+        }
     </style>
 </head>
 <body id="top">


### PR DESCRIPTION
Adds a final @media (max-width: 768px) rule as the last CSS rule before </style> in both files, targeting the button by class, id, and attribute selector with six !important declarations: display:none, visibility:hidden, opacity:0, pointer-events:none, width:0, height:0.

Placed last in the stylesheet so it wins the cascade regardless of any earlier conflicting rules. Covers the iOS Safari edge case where display:none alone on a position:fixed element may not fully suppress the touch layer.