### PR TITLE
fix: JS DOM removal of back-to-top on mobile, chapter links always vi…

### DIFF
--- a/research/methodology/manual/index.html
+++ b/research/methodology/manual/index.html
@@ -627,19 +627,14 @@
             #backToTop { display: none !important; }
         }
         .weo-mobile-top-link {
-            display: none;
-        }
-        @media (max-width: 768px) {
-            .weo-mobile-top-link {
-                display: block;
-                text-align: center;
-                padding: 1rem;
-                color: #94A3B8;
-                font-size: 0.875rem;
-                text-decoration: none;
-                border-top: 1px solid var(--weo-border-primary);
-                margin-top: 2rem;
-            }
+            display: block;
+            text-align: center;
+            padding: 1rem;
+            color: #94A3B8;
+            font-size: 0.875rem;
+            text-decoration: none;
+            border-top: 1px solid var(--weo-border-primary);
+            margin-top: 2rem;
         }
         @media (max-width: 768px) {
             .weo-back-to-top,
@@ -14979,6 +14974,7 @@ References indicate document and section.</p>
         btn.addEventListener('click', function() {
             window.scrollTo({ top: 0, behavior: 'smooth' });
         });
+        if (window.innerWidth <= 768) document.getElementById('backToTop')?.remove();
     })();
     </script>
     <script data-goatcounter="https://warmthengine.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>

--- a/research/methodology/rationale/index.html
+++ b/research/methodology/rationale/index.html
@@ -627,19 +627,14 @@
             #backToTop { display: none !important; }
         }
         .weo-mobile-top-link {
-            display: none;
-        }
-        @media (max-width: 768px) {
-            .weo-mobile-top-link {
-                display: block;
-                text-align: center;
-                padding: 1rem;
-                color: #94A3B8;
-                font-size: 0.875rem;
-                text-decoration: none;
-                border-top: 1px solid var(--weo-border-primary);
-                margin-top: 2rem;
-            }
+            display: block;
+            text-align: center;
+            padding: 1rem;
+            color: #94A3B8;
+            font-size: 0.875rem;
+            text-decoration: none;
+            border-top: 1px solid var(--weo-border-primary);
+            margin-top: 2rem;
         }
         @media (max-width: 768px) {
             .weo-back-to-top,
@@ -11517,6 +11512,7 @@ via the contact information provided on the WEO platform.</p>
         btn.addEventListener('click', function() {
             window.scrollTo({ top: 0, behavior: 'smooth' });
         });
+        if (window.innerWidth <= 768) document.getElementById('backToTop')?.remove();
     })();
     </script>
     <script data-goatcounter="https://warmthengine.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>


### PR DESCRIPTION
…sible

- Add one line at end of back-to-top IIFE: removes #backToTop from the DOM entirely on window.innerWidth <= 768. Element cannot appear, intercept touches, or be affected by any CSS rule if it doesn't exist.

- Make .weo-mobile-top-link unconditional (remove display:none default and @media wrapper) so chapter-end back-to-top links are visible on all screen sizes, not just mobile.