### PR TITLE
fix: re-apply methodology tooltip links and remove § annotation system

### DIFF
--- a/atlas.html
+++ b/atlas.html
@@ -1505,6 +1505,19 @@
           color: #F1F5F9;
           font-weight: 600;
         }
+        #weo-tooltip-overlay .weo-tooltip-method-link {
+          margin-top: 8px;
+          padding-top: 8px;
+          border-top: 1px solid rgba(148,163,184,0.15);
+        }
+        #weo-tooltip-overlay .weo-tooltip-method-link a {
+          color: #94A3B8;
+          text-decoration: none;
+          font-size: 0.78em;
+        }
+        #weo-tooltip-overlay .weo-tooltip-method-link a:hover {
+          color: #60a5fa;
+        }
         @media (max-width: 767px) {
           #weo-tooltip-overlay {
             width: 310px;
@@ -3878,63 +3891,6 @@
             .atlas-landscape-hint { display: none !important; }
         }
 
-    /* Methodology cross-reference system */
-    .weo-ref-toggle {
-        position: fixed;
-        bottom: 2rem;
-        right: 2rem;
-        width: 40px;
-        height: 40px;
-        border-radius: 50%;
-        background: var(--weo-surface-raised);
-        border: 1px solid var(--weo-border-primary);
-        color: #94A3B8;
-        font-size: 1.25rem;
-        font-family: 'Geist', sans-serif;
-        cursor: pointer;
-        z-index: 1000;
-        transition: all 200ms ease;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        opacity: 0.6;
-    }
-    .weo-ref-toggle:hover {
-        opacity: 1;
-        color: #60a5fa;
-        border-color: #60a5fa;
-    }
-    .weo-ref-toggle.active {
-        background: rgba(96, 165, 250, 0.15);
-        color: #60a5fa;
-        border-color: #60a5fa;
-        opacity: 1;
-    }
-    .weo-ref {
-        cursor: default;
-        position: relative;
-    }
-    .weo-refs-active .weo-ref {
-        cursor: pointer;
-        text-decoration: underline;
-        text-decoration-style: dotted;
-        text-decoration-color: #94A3B8;
-        text-underline-offset: 3px;
-    }
-    .weo-refs-active .weo-ref:hover {
-        text-decoration-color: #60a5fa;
-        color: #60a5fa;
-    }
-    .weo-refs-active .weo-ref:hover::after {
-        content: '§';
-        font-size: 0.7em;
-        color: #60a5fa;
-        margin-left: 2px;
-        vertical-align: super;
-    }
-    @media (max-width: 768px) {
-        .weo-ref-toggle { display: none; }
-    }
 
     </style>
 </head>
@@ -4315,23 +4271,47 @@
         };
 
         // Tooltip HTML helpers — same signatures as index.html.
+        const weoMethodAnchors = {
+          tier:              'section-5-2',
+          confidence:        'section-3-4-5',
+          checkpoints:       'section-3-5',
+          basel5:            'section-4-4',
+          cc:                'section-9-1',
+          keohane:           'section-4-2',
+          pisa5:             'section-4-9',
+          routeBased:        'section-4-8',
+          bloc:              'section-3-10',
+          domain:            'section-6-2',
+          highlyConnected:   'section-9-1',
+          industryTags:      'section-7-2',
+          environmentalNexus: 'section-8-2',
+          involvement:       'section-5-3-1',
+          scale:             null,
+          ccTypes: { 1: 'section-9-2-1-type-1', 2: 'section-9-2-1-type-2', 3: 'section-9-2-1-type-3', 4: 'section-9-2-1-type-4', 5: 'section-9-2-1-type-5', 6: 'section-9-2-1-type-6', 7: 'section-9-2-1-type-7' },
+          ccConfidence: { 'CC-V': 'section-9-3-1', 'CC-E': 'section-9-3-1', 'CC-A': 'section-9-3-1' }
+        };
+        function methodLink(anchor) {
+          if (!anchor) return '';
+          return '<div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#' + anchor + '" target="_blank" rel="noopener">§ View in Methodology →</a></div>';
+        }
+
         function generateTooltip(key, position) {
           const t = weoTooltips[key];
           if (!t) return '';
           const posClass = position ? ' tooltip-' + position : '';
-          return '<span class="weo-info-trigger">?<span class="weo-tooltip' + posClass + '"><div class="weo-tooltip-title">' + t.title + '</div><div class="weo-tooltip-body">' + t.body + '</div></span></span>';
+          return '<span class="weo-info-trigger">?<span class="weo-tooltip' + posClass + '"><div class="weo-tooltip-title">' + t.title + '</div><div class="weo-tooltip-body">' + t.body + '</div>' + methodLink(weoMethodAnchors[key]) + '</span></span>';
         }
         function generateCCTypeTooltip(typeNum, position) {
           const t = weoTooltips.ccTypes[typeNum];
           if (!t) return '';
           const posClass = position ? ' tooltip-' + position : '';
-          return '<span class="weo-info-trigger">?<span class="weo-tooltip' + posClass + '"><div class="weo-tooltip-title">' + t.title + '</div><div class="weo-tooltip-body">' + t.body + '</div></span></span>';
+          return '<span class="weo-info-trigger">?<span class="weo-tooltip' + posClass + '"><div class="weo-tooltip-title">' + t.title + '</div><div class="weo-tooltip-body">' + t.body + '</div>' + methodLink(weoMethodAnchors.ccTypes[typeNum]) + '</span></span>';
         }
         function generateCCConfidenceTooltip(level, position) {
           const t = weoTooltips.ccConfidence[level];
           if (!t) return '';
           const posClass = position ? ' tooltip-' + position : '';
-          return '<span class="weo-info-trigger">?<span class="weo-tooltip' + posClass + '"><div class="weo-tooltip-title">' + t.title + '</div><div class="weo-tooltip-body">' + t.body + '</div></span></span>';
+          return '<span class="weo-info-trigger">?<span class="weo-tooltip' + posClass + '"><div class="weo-tooltip-title">' + t.title + '</div><div class="weo-tooltip-body">' + t.body + '</div>' + methodLink(weoMethodAnchors.ccConfidence[level]) + '</span></span>';
         }
 
         // Brief 4 §3.7 — framework field → display name mapping. Manual
@@ -8430,7 +8410,7 @@
             // tooltip carrier loaded from weoTooltips.ccConfidence.
             const confTipData = weoTooltips.ccConfidence && weoTooltips.ccConfidence[confLevel];
             const confTipHtml = confTipData
-                ? `<span class="weo-tooltip"><div class="weo-tooltip-title">${confTipData.title}</div><div class="weo-tooltip-body">${confTipData.body}</div></span>`
+                ? `<span class="weo-tooltip"><div class="weo-tooltip-title">${confTipData.title}</div><div class="weo-tooltip-body">${confTipData.body}</div>${methodLink('section-9-3-1')}</span>`
                 : '';
             html += `<span class="atlas-panel-confidence-pill atlas-panel-confidence-pill-${confClass} atlas-chip-trigger" tabindex="0" aria-label="Connection Confidence: ${escapeHtml(confLevel)}">${escapeHtml(confSlug)}${confTipHtml}</span>`;
             html += `<h2 class="atlas-panel-title" onclick="atlasScrollPanelToTop()" style="cursor:pointer">${escapeHtml(cc.connection_type_name || `Type ${typeNum}`)}</h2>`;
@@ -8534,7 +8514,7 @@
                 const conf = String(event.confidence).toUpperCase();
                 const confSlug = (conf === 'V' || conf === 'E' || conf === 'A') ? conf.toLowerCase() : 'a';
                 const confTip = weoTooltips.confidence
-                    ? `<span class="weo-tooltip"><div class="weo-tooltip-title">${weoTooltips.confidence.title}</div><div class="weo-tooltip-body">${weoTooltips.confidence.body}</div></span>`
+                    ? `<span class="weo-tooltip"><div class="weo-tooltip-title">${weoTooltips.confidence.title}</div><div class="weo-tooltip-body">${weoTooltips.confidence.body}</div>${methodLink('section-3-4-5')}</span>`
                     : '';
                 html += `<span class="atlas-panel-confidence-pill atlas-panel-confidence-pill-${confSlug} atlas-chip-trigger" tabindex="0" aria-label="Source Confidence Rating: CC-${escapeHtml(conf)}">${escapeHtml(conf)}${confTip}</span>`;
             }
@@ -8550,13 +8530,13 @@
             html += '<div class="atlas-panel-header-chips">';
             const tierNum = Number(event.tier) || 3;
             const tierTip = weoTooltips.tier
-                ? `<span class="weo-tooltip"><div class="weo-tooltip-title">${weoTooltips.tier.title}</div><div class="weo-tooltip-body">${weoTooltips.tier.body}</div></span>`
+                ? `<span class="weo-tooltip"><div class="weo-tooltip-title">${weoTooltips.tier.title}</div><div class="weo-tooltip-body">${weoTooltips.tier.body}</div>${methodLink('section-5-2')}</span>`
                 : '';
             html += `<span class="atlas-chip atlas-chip-tier-${tierNum} atlas-chip-trigger" onclick="atlasOpenAndScrollTo('atlas-section-tier')" tabindex="0">Tier ${tierNum}${tierTip}</span>`;
             if (event.bloc) {
                 const bc = ATLAS_BLOC_CHIP[event.bloc] || 'cross-bloc';
                 const blocTip = weoTooltips.bloc
-                    ? `<span class="weo-tooltip"><div class="weo-tooltip-title">${weoTooltips.bloc.title}</div><div class="weo-tooltip-body">${weoTooltips.bloc.body}</div></span>`
+                    ? `<span class="weo-tooltip"><div class="weo-tooltip-title">${weoTooltips.bloc.title}</div><div class="weo-tooltip-body">${weoTooltips.bloc.body}</div>${methodLink('section-3-10')}</span>`
                     : '';
                 html += `<span class="atlas-chip atlas-chip-bloc-${bc} atlas-chip-trigger" onclick="atlasOpenAndScrollTo('atlas-section-bloc')" tabindex="0">${escapeHtml(event.bloc)}${blocTip}</span>`;
             }
@@ -11405,11 +11385,6 @@
             </div>
         </div>
     </div>
-<!-- Methodology cross-reference toggle -->
-<button id="weoRefToggle" class="weo-ref-toggle"
-        onclick="WEO_REFS.toggle()"
-        title="Toggle methodology cross-references"
-        aria-label="Toggle methodology cross-references">§</button>
-<script src="/js/weo-methodology-refs.js"></script>
+
 </body>
 </html>

--- a/blocs.html
+++ b/blocs.html
@@ -1583,63 +1583,6 @@
         margin-top: var(--weo-space-xs);
     }
 
-/* Methodology cross-reference system */
-.weo-ref-toggle {
-    position: fixed;
-    bottom: 2rem;
-    right: 2rem;
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    background: var(--weo-surface-raised);
-    border: 1px solid var(--weo-border-primary);
-    color: #94A3B8;
-    font-size: 1.25rem;
-    font-family: 'Geist', sans-serif;
-    cursor: pointer;
-    z-index: 1000;
-    transition: all 200ms ease;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    opacity: 0.6;
-}
-.weo-ref-toggle:hover {
-    opacity: 1;
-    color: #60a5fa;
-    border-color: #60a5fa;
-}
-.weo-ref-toggle.active {
-    background: rgba(96, 165, 250, 0.15);
-    color: #60a5fa;
-    border-color: #60a5fa;
-    opacity: 1;
-}
-.weo-ref {
-    cursor: default;
-    position: relative;
-}
-.weo-refs-active .weo-ref {
-    cursor: pointer;
-    text-decoration: underline;
-    text-decoration-style: dotted;
-    text-decoration-color: #94A3B8;
-    text-underline-offset: 3px;
-}
-.weo-refs-active .weo-ref:hover {
-    text-decoration-color: #60a5fa;
-    color: #60a5fa;
-}
-.weo-refs-active .weo-ref:hover::after {
-    content: '§';
-    font-size: 0.7em;
-    color: #60a5fa;
-    margin-left: 2px;
-    vertical-align: super;
-}
-@media (max-width: 768px) {
-    .weo-ref-toggle { display: none; }
-}
 
 </style>
 </head>
@@ -2651,11 +2594,6 @@
     });
 })();
 </script>
-<!-- Methodology cross-reference toggle -->
-<button id="weoRefToggle" class="weo-ref-toggle"
-        onclick="WEO_REFS.toggle()"
-        title="Toggle methodology cross-references"
-        aria-label="Toggle methodology cross-references">§</button>
-<script src="/js/weo-methodology-refs.js"></script>
+
 </body>
 </html>

--- a/events.html
+++ b/events.html
@@ -1918,7 +1918,20 @@
       color: #F1F5F9;
       font-weight: 600;
     }
-    
+    #weo-tooltip-overlay .weo-tooltip-method-link {
+      margin-top: 8px;
+      padding-top: 8px;
+      border-top: 1px solid rgba(148,163,184,0.15);
+    }
+    #weo-tooltip-overlay .weo-tooltip-method-link a {
+      color: #94A3B8;
+      text-decoration: none;
+      font-size: 0.78em;
+    }
+    #weo-tooltip-overlay .weo-tooltip-method-link a:hover {
+      color: #60a5fa;
+    }
+
     @media (max-width: 767px) {
       #weo-tooltip-overlay {
         width: 310px;
@@ -3071,63 +3084,6 @@
         font-size: 12px;
     }
 
-/* Methodology cross-reference system */
-.weo-ref-toggle {
-    position: fixed;
-    bottom: 2rem;
-    right: 2rem;
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    background: var(--weo-surface-raised);
-    border: 1px solid var(--weo-border-primary);
-    color: #94A3B8;
-    font-size: 1.25rem;
-    font-family: 'Geist', sans-serif;
-    cursor: pointer;
-    z-index: 1000;
-    transition: all 200ms ease;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    opacity: 0.6;
-}
-.weo-ref-toggle:hover {
-    opacity: 1;
-    color: #60a5fa;
-    border-color: #60a5fa;
-}
-.weo-ref-toggle.active {
-    background: rgba(96, 165, 250, 0.15);
-    color: #60a5fa;
-    border-color: #60a5fa;
-    opacity: 1;
-}
-.weo-ref {
-    cursor: default;
-    position: relative;
-}
-.weo-refs-active .weo-ref {
-    cursor: pointer;
-    text-decoration: underline;
-    text-decoration-style: dotted;
-    text-decoration-color: #94A3B8;
-    text-underline-offset: 3px;
-}
-.weo-refs-active .weo-ref:hover {
-    text-decoration-color: #60a5fa;
-    color: #60a5fa;
-}
-.weo-refs-active .weo-ref:hover::after {
-    content: '§';
-    font-size: 0.7em;
-    color: #60a5fa;
-    margin-left: 2px;
-    vertical-align: super;
-}
-@media (max-width: 768px) {
-    .weo-ref-toggle { display: none; }
-}
 
 </style>
 </head>
@@ -3690,7 +3646,7 @@ function generateIndustryShelfHtml(eventId) {
     let html = '<div class="industry-shelf">';
     // INDUSTRY row — grid layout
     html += '<div class="shelf-row">';
-    html += '<span class="shelf-label weo-info-trigger">Industry<span class="weo-tooltip tooltip-below"><div class="weo-tooltip-title">Industry Tags</div><div class="weo-tooltip-body"><strong>Primary:</strong> the industry this event\x27s provisions most directly address. <strong>Secondary:</strong> additional industries also addressed — click for detail.</div></span></span>';
+    html += '<span class="shelf-label weo-info-trigger">Industry<span class="weo-tooltip tooltip-below"><div class="weo-tooltip-title">Industry Tags</div><div class="weo-tooltip-body"><strong>Primary:</strong> the industry this event\x27s provisions most directly address. <strong>Secondary:</strong> additional industries also addressed — click for detail.</div>' + methodLink('section-7-2') + '</span></span>';
     html += '<div class="shelf-badges">';
     html += '<span class="ind-tag-wrap"><span class="ind-tag ind-primary ' + getIndBadgeClass(tags.primary) + '" onclick="togglePrimaryName(this)">' + getIndAbbrev(tags.primary) + '</span><div class="ind-primary-popover">' + tags.primary + '</div></span>';
     for (let i = 0; i < tags.secondary.length; i++) {
@@ -3701,7 +3657,7 @@ function generateIndustryShelfHtml(eventId) {
     // ENVIRONMENT row — conditional
     if (entTags.length > 0) {
         html += '<div class="shelf-row" style="margin-left:-24px;padding-left:22px;border-left:3px solid rgba(252,211,77,0.55);box-shadow:-4px 0 8px -2px rgba(252,211,77,0.15)">';
-        html += '<span class="shelf-label weo-info-trigger" style="color:rgba(252,211,77,0.55);-webkit-text-stroke:0.5px rgba(252,211,77,0.8)">Environment<span class="weo-tooltip tooltip-below"><div class="weo-tooltip-title">Environmental Nexus Tags</div><div class="weo-tooltip-body">Analytical enrichment identifying where AI infrastructure coordination intersects with environmental systems. Tags describe resource demand, enablement, consequence, dependency, and governance coordination.</div></span></span>';
+        html += '<span class="shelf-label weo-info-trigger" style="color:rgba(252,211,77,0.55);-webkit-text-stroke:0.5px rgba(252,211,77,0.8)">Environment<span class="weo-tooltip tooltip-below"><div class="weo-tooltip-title">Environmental Nexus Tags</div><div class="weo-tooltip-body">Analytical enrichment identifying where AI infrastructure coordination intersects with environmental systems. Tags describe resource demand, enablement, consequence, dependency, and governance coordination.</div>' + methodLink('section-8-2') + '</span></span>';
         html += '<div class="shelf-badges">';
         for (let j = 0; j < entTags.length; j++) {
             html += buildEntBadgeHtml(entTags[j]);
@@ -4066,17 +4022,44 @@ function scrollToModalSection(sectionKey) {
   }
 }
 
+const weoMethodAnchors = {
+  tier:             'section-5-2',
+  confidence:       'section-3-4-5',
+  checkpoints:      'section-3-5',
+  checkpointsPiet:  'section-3-5-1',
+  checkpointsOep:   'section-3-5-d',
+  basel5:           'section-4-4',
+  cc:               'section-9-1',
+  keohane:          'section-4-2',
+  pisa5:            'section-4-9',
+  tiebreaker:       'section-4-9-tiebreakers',
+  piet:             'section-3-5-1',
+  oep:              'section-3-5-d',
+  pietCheckpoint:   'section-3-5-1',
+  oepCheckpoint:    'section-3-5-d',
+  routeBased:       'section-4-8',
+  bloc:             'section-3-10',
+  domain:           'section-6-2',
+  highlyConnected:  'section-9-1',
+  ccTypes: { 1: 'section-9-2-1-type-1', 2: 'section-9-2-1-type-2', 3: 'section-9-2-1-type-3', 4: 'section-9-2-1-type-4', 5: 'section-9-2-1-type-5', 6: 'section-9-2-1-type-6', 7: 'section-9-2-1-type-7' },
+  ccConfidence: { 'CC-V': 'section-9-3-1', 'CC-E': 'section-9-3-1', 'CC-A': 'section-9-3-1' }
+};
+function methodLink(anchor) {
+  if (!anchor) return '';
+  return '<div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#' + anchor + '" target="_blank" rel="noopener">§ View in Methodology →</a></div>';
+}
+
 function generateTooltip(key, position) {
   const t = weoTooltips[key];
   if (!t) return '';
   const posClass = position ? ' tooltip-' + position : '';
-  return '<span class="weo-info-trigger">?<span class="weo-tooltip' + posClass + '"><div class="weo-tooltip-title">' + t.title + '</div><div class="weo-tooltip-body">' + t.body + '</div></span></span>';
+  return '<span class="weo-info-trigger">?<span class="weo-tooltip' + posClass + '"><div class="weo-tooltip-title">' + t.title + '</div><div class="weo-tooltip-body">' + t.body + '</div>' + methodLink(weoMethodAnchors[key]) + '</span></span>';
 }
 function generateFieldLabel(labelText, tooltipKey, position) {
   const t = weoTooltips[tooltipKey];
   if (!t) return '<span class="z2-label">' + labelText + '</span>';
   const posClass = position ? ' tooltip-' + position : '';
-  return '<span class="z2-label weo-info-trigger">' + labelText + '<span class="weo-tooltip' + posClass + '"><div class="weo-tooltip-title">' + t.title + '</div><div class="weo-tooltip-body">' + t.body + '</div></span></span>';
+  return '<span class="z2-label weo-info-trigger">' + labelText + '<span class="weo-tooltip' + posClass + '"><div class="weo-tooltip-title">' + t.title + '</div><div class="weo-tooltip-body">' + t.body + '</div>' + methodLink(weoMethodAnchors[tooltipKey]) + '</span></span>';
 }
 
 // Generate tooltip for CC connection types (1-7)
@@ -4084,7 +4067,7 @@ function generateCCTypeTooltip(typeNum, position) {
   const t = weoTooltips.ccTypes[typeNum];
   if (!t) return '';
   const posClass = position ? ' tooltip-' + position : '';
-  return '<span class="weo-info-trigger">?<span class="weo-tooltip' + posClass + '"><div class="weo-tooltip-title">' + t.title + '</div><div class="weo-tooltip-body">' + t.body + '</div></span></span>';
+  return '<span class="weo-info-trigger">?<span class="weo-tooltip' + posClass + '"><div class="weo-tooltip-title">' + t.title + '</div><div class="weo-tooltip-body">' + t.body + '</div>' + methodLink(weoMethodAnchors.ccTypes[typeNum]) + '</span></span>';
 }
 
 // Generate tooltip for CC confidence levels (CC-V, CC-E, CC-A)
@@ -4092,7 +4075,7 @@ function generateCCConfidenceTooltip(level, position) {
   const t = weoTooltips.ccConfidence[level];
   if (!t) return '';
   const posClass = position ? ' tooltip-' + position : '';
-  return '<span class="weo-info-trigger">?<span class="weo-tooltip' + posClass + '"><div class="weo-tooltip-title">' + t.title + '</div><div class="weo-tooltip-body">' + t.body + '</div></span></span>';
+  return '<span class="weo-info-trigger">?<span class="weo-tooltip' + posClass + '"><div class="weo-tooltip-title">' + t.title + '</div><div class="weo-tooltip-body">' + t.body + '</div>' + methodLink(weoMethodAnchors.ccConfidence[level]) + '</span></span>';
 }
 
 // ========================================
@@ -5186,7 +5169,7 @@ const openModal = (id) => {
             let pathwayDisplayName = 'Software/Platform';
             if (pathwayInfo) {
                 pathwayDisplayName = pathwayInfo.displayName;
-                pathwayTooltipHtml = `<span class="weo-info-trigger">?<span class="weo-tooltip tooltip-left"><div class="weo-tooltip-title">${pathwayInfo.title}</div><div class="weo-tooltip-body">${pathwayInfo.body}</div></span></span>`;
+                pathwayTooltipHtml = `<span class="weo-info-trigger">?<span class="weo-tooltip tooltip-left"><div class="weo-tooltip-title">${pathwayInfo.title}</div><div class="weo-tooltip-body">${pathwayInfo.body}</div>${methodLink('section-4-8')}</span></span>`;
             }
             const pathwayText = '(Part B — ' + pathwayDisplayName + ')';
             html += `
@@ -5213,7 +5196,7 @@ const openModal = (id) => {
                     <thead>
                         <tr style="border-bottom:1px solid var(--weo-border-primary);">
                             <th style="text-align:left;padding:0.5rem 1rem 0.5rem 0;color:var(--weo-text-muted);font-weight:500;">Bloc</th>
-                            <th style="text-align:left;padding:0.5rem 1rem 0.5rem 0;color:var(--weo-text-muted);font-weight:500;white-space:nowrap;">Involvement <span class="weo-info-trigger">ⓘ<span class="weo-tooltip"><div class="weo-tooltip-title">Involvement</div><div class="weo-tooltip-body"><strong>Involvement</strong> records participation in the event's implementation — who developed, enacted, funded, or governed it. Commercial distribution, platform hosting, or downstream adoption on other-bloc infrastructure is not classified as involvement.</div></span></span></th>
+                            <th style="text-align:left;padding:0.5rem 1rem 0.5rem 0;color:var(--weo-text-muted);font-weight:500;white-space:nowrap;">Involvement <span class="weo-info-trigger">ⓘ<span class="weo-tooltip"><div class="weo-tooltip-title">Involvement</div><div class="weo-tooltip-body"><strong>Involvement</strong> records participation in the event's implementation — who developed, enacted, funded, or governed it. Commercial distribution, platform hosting, or downstream adoption on other-bloc infrastructure is not classified as involvement.</div>' + methodLink('section-5-3-1') + '</span></span></th>
                             <th style="text-align:left;padding:0.5rem 0;color:var(--weo-text-muted);font-weight:500;">Role</th>
                         </tr>
                     </thead>
@@ -6218,11 +6201,6 @@ if (navToggle && navLinks) {
 
 <script data-goatcounter="https://warmthengine.goatcounter.com/count"
         async src="//gc.zgo.at/count.js"></script>
-<!-- Methodology cross-reference toggle -->
-<button id="weoRefToggle" class="weo-ref-toggle"
-        onclick="WEO_REFS.toggle()"
-        title="Toggle methodology cross-references"
-        aria-label="Toggle methodology cross-references">§</button>
-<script src="/js/weo-methodology-refs.js"></script>
+
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -3981,7 +3981,20 @@
       color: #F1F5F9;
       font-weight: 600;
     }
-    
+    #weo-tooltip-overlay .weo-tooltip-method-link {
+      margin-top: 8px;
+      padding-top: 8px;
+      border-top: 1px solid rgba(148,163,184,0.15);
+    }
+    #weo-tooltip-overlay .weo-tooltip-method-link a {
+      color: #94A3B8;
+      text-decoration: none;
+      font-size: 0.78em;
+    }
+    #weo-tooltip-overlay .weo-tooltip-method-link a:hover {
+      color: #60a5fa;
+    }
+
     /* Mobile: slightly narrower tooltips */
     @media (max-width: 767px) {
       #weo-tooltip-overlay {
@@ -5942,65 +5955,6 @@
       .scp-footer { padding: 10px 20px 14px; }
       .weo-status-actor-row { display: none; }
     }
-
-  /* Methodology cross-reference system */
-  .weo-ref-toggle {
-    position: fixed;
-    bottom: 2rem;
-    right: 2rem;
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    background: var(--weo-surface-raised);
-    border: 1px solid var(--weo-border-primary);
-    color: #94A3B8;
-    font-size: 1.25rem;
-    font-family: 'Geist', sans-serif;
-    cursor: pointer;
-    z-index: 1000;
-    transition: all 200ms ease;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    opacity: 0.6;
-  }
-  .weo-ref-toggle:hover {
-    opacity: 1;
-    color: #60a5fa;
-    border-color: #60a5fa;
-  }
-  .weo-ref-toggle.active {
-    background: rgba(96, 165, 250, 0.15);
-    color: #60a5fa;
-    border-color: #60a5fa;
-    opacity: 1;
-  }
-  .weo-ref {
-    cursor: default;
-    position: relative;
-  }
-  .weo-refs-active .weo-ref {
-    cursor: pointer;
-    text-decoration: underline;
-    text-decoration-style: dotted;
-    text-decoration-color: #94A3B8;
-    text-underline-offset: 3px;
-  }
-  .weo-refs-active .weo-ref:hover {
-    text-decoration-color: #60a5fa;
-    color: #60a5fa;
-  }
-  .weo-refs-active .weo-ref:hover::after {
-    content: '§';
-    font-size: 0.7em;
-    color: #60a5fa;
-    margin-left: 2px;
-    vertical-align: super;
-  }
-  @media (max-width: 768px) {
-    .weo-ref-toggle { display: none; }
-  }
-  body:has(#detailPanel.open) .weo-ref-toggle { display: none; }
 
   </style>
 </head>
@@ -8174,7 +8128,7 @@ function generateCCPreview(eventId) {
   const totalConnections = upstream.length + downstream.length + bidirectional.length;
 
   // Reuse existing intro tooltip
-  const ccTooltip = '<span class="weo-info-trigger">ⓘ<span class="weo-tooltip"><div class="weo-tooltip-title">Coordination Connections</div><div class="weo-tooltip-body">Documented relationships between verified WEO events, capturing how events influence, enable, or respond to one another. Each connection requires documentary evidence and is classified by type and confidence level.</div></span></span>';
+  const ccTooltip = '<span class="weo-info-trigger">ⓘ<span class="weo-tooltip"><div class="weo-tooltip-title">Coordination Connections</div><div class="weo-tooltip-body">Documented relationships between verified WEO events, capturing how events influence, enable, or respond to one another. Each connection requires documentary evidence and is classified by type and confidence level.</div>' + methodLink('section-9-1') + '</span></span>';
 
   let html = '<div class="panel-section cc-section cc-preview">';
   html += '<div class="section-title-with-tooltip"><span class="section-title" style="margin-bottom: 0;">Coordination Connections</span>' + ccTooltip + '</div>';
@@ -8652,7 +8606,7 @@ function generateCCSection(eventId, showFullContent) {
   }
   
   let html = '<div class="panel-section cc-section">';
-  const ccTooltip = '<span class="weo-info-trigger">ⓘ<span class="weo-tooltip"><div class="weo-tooltip-title">Coordination Connections</div><div class="weo-tooltip-body">Documented relationships between verified WEO events, capturing how events influence, enable, or respond to one another. Each connection requires documentary evidence and is classified by type and confidence level.</div></span></span>';
+  const ccTooltip = '<span class="weo-info-trigger">ⓘ<span class="weo-tooltip"><div class="weo-tooltip-title">Coordination Connections</div><div class="weo-tooltip-body">Documented relationships between verified WEO events, capturing how events influence, enable, or respond to one another. Each connection requires documentary evidence and is classified by type and confidence level.</div>' + methodLink('section-9-1') + '</span></span>';
   html += '<div class="section-title-with-tooltip"><span class="section-title" style="margin-bottom: 0;">Coordination Connections</span>' + ccTooltip + '</div>';
   
   // Stats summary
@@ -9622,7 +9576,7 @@ function generateCCSection(eventId, showFullContent) {
       var html = '<div class="industry-shelf">';
       // INDUSTRY row — grid layout
       html += '<div class="shelf-row">';
-      html += '<span class="shelf-label weo-info-trigger">Industry<span class="weo-tooltip tooltip-below"><div class="weo-tooltip-title">Industry Tags</div><div class="weo-tooltip-body"><strong>Primary:</strong> the industry this event\x27s provisions most directly address. <strong>Secondary:</strong> additional industries also addressed — click for detail.</div></span></span>';
+      html += '<span class="shelf-label weo-info-trigger">Industry<span class="weo-tooltip tooltip-below"><div class="weo-tooltip-title">Industry Tags</div><div class="weo-tooltip-body"><strong>Primary:</strong> the industry this event\x27s provisions most directly address. <strong>Secondary:</strong> additional industries also addressed — click for detail.</div>' + methodLink('section-7-2') + '</span></span>';
       html += '<div class="shelf-badges">';
       html += '<span class="ind-tag-wrap"><span class="ind-tag ind-primary ' + getIndClass(tags.primary) + '" onclick="togglePrimaryName(this)">' + getIndAbbrev(tags.primary) + '</span><div class="ind-primary-popover">' + tags.primary + '</div></span>';
       for (var i = 0; i < tags.secondary.length; i++) {
@@ -9633,7 +9587,7 @@ function generateCCSection(eventId, showFullContent) {
       // ENVIRONMENT row — conditional, only when ENT tags exist
       if (entTags.length > 0) {
         html += '<div class="shelf-row" style="margin-left:-24px;padding-left:22px;border-left:3px solid rgba(252,211,77,0.55);box-shadow:-4px 0 8px -2px rgba(252,211,77,0.15)">';
-        html += '<span class="shelf-label weo-info-trigger" style="color:rgba(252,211,77,0.55);-webkit-text-stroke:0.5px rgba(252,211,77,0.8)">Environment<span class="weo-tooltip tooltip-below"><div class="weo-tooltip-title">Environmental Nexus Tags</div><div class="weo-tooltip-body">Analytical enrichment identifying where AI infrastructure coordination intersects with environmental systems. Tags describe resource demand, enablement, consequence, dependency, and governance coordination.</div></span></span>';
+        html += '<span class="shelf-label weo-info-trigger" style="color:rgba(252,211,77,0.55);-webkit-text-stroke:0.5px rgba(252,211,77,0.8)">Environment<span class="weo-tooltip tooltip-below"><div class="weo-tooltip-title">Environmental Nexus Tags</div><div class="weo-tooltip-body">Analytical enrichment identifying where AI infrastructure coordination intersects with environmental systems. Tags describe resource demand, enablement, consequence, dependency, and governance coordination.</div>' + methodLink('section-8-2') + '</span></span>';
         html += '<div class="shelf-badges">';
         for (var j = 0; j < entTags.length; j++) {
           html += buildEntBadgeHtml(entTags[j]);
@@ -9957,34 +9911,61 @@ function generateCCSection(eventId, showFullContent) {
       }
     };
     
+    const weoMethodAnchors = {
+      tier:             'section-5-2',
+      confidence:       'section-3-4-5',
+      checkpoints:      'section-3-5',
+      checkpointsPiet:  'section-3-5-1',
+      checkpointsOep:   'section-3-5-d',
+      basel5:           'section-4-4',
+      cc:               'section-9-1',
+      keohane:          'section-4-2',
+      pisa5:            'section-4-9',
+      tiebreaker:       'section-4-9-tiebreakers',
+      piet:             'section-3-5-1',
+      oep:              'section-3-5-d',
+      pietCheckpoint:   'section-3-5-1',
+      oepCheckpoint:    'section-3-5-d',
+      routeBased:       'section-4-8',
+      bloc:             'section-3-10',
+      domain:           'section-6-2',
+      highlyConnected:  'section-9-1',
+      ccTypes: { 1: 'section-9-2-1-type-1', 2: 'section-9-2-1-type-2', 3: 'section-9-2-1-type-3', 4: 'section-9-2-1-type-4', 5: 'section-9-2-1-type-5', 6: 'section-9-2-1-type-6', 7: 'section-9-2-1-type-7' },
+      ccConfidence: { 'CC-V': 'section-9-3-1', 'CC-E': 'section-9-3-1', 'CC-A': 'section-9-3-1' }
+    };
+    function methodLink(anchor) {
+      if (!anchor) return '';
+      return '<div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#' + anchor + '" target="_blank" rel="noopener">§ View in Methodology →</a></div>';
+    }
+
     // Generate tooltip HTML
     function generateTooltip(key, position) {
       const t = weoTooltips[key];
       if (!t) return '';
       const posClass = position ? ' tooltip-' + position : '';
-      return '<span class="weo-info-trigger">?<span class="weo-tooltip' + posClass + '"><div class="weo-tooltip-title">' + t.title + '</div><div class="weo-tooltip-body">' + t.body + '</div></span></span>';
+      return '<span class="weo-info-trigger">?<span class="weo-tooltip' + posClass + '"><div class="weo-tooltip-title">' + t.title + '</div><div class="weo-tooltip-body">' + t.body + '</div>' + methodLink(weoMethodAnchors[key]) + '</span></span>';
     }
     function generateFieldLabel(labelText, tooltipKey, position) {
       const t = weoTooltips[tooltipKey];
       if (!t) return '<span class="z2-label">' + labelText + '</span>';
       const posClass = position ? ' tooltip-' + position : '';
-      return '<span class="z2-label weo-info-trigger">' + labelText + '<span class="weo-tooltip' + posClass + '"><div class="weo-tooltip-title">' + t.title + '</div><div class="weo-tooltip-body">' + t.body + '</div></span></span>';
+      return '<span class="z2-label weo-info-trigger">' + labelText + '<span class="weo-tooltip' + posClass + '"><div class="weo-tooltip-title">' + t.title + '</div><div class="weo-tooltip-body">' + t.body + '</div>' + methodLink(weoMethodAnchors[tooltipKey]) + '</span></span>';
     }
-    
+
     // Generate tooltip for CC connection types (1-7)
     function generateCCTypeTooltip(typeNum, position) {
       const t = weoTooltips.ccTypes[typeNum];
       if (!t) return '';
       const posClass = position ? ' tooltip-' + position : '';
-      return '<span class="weo-info-trigger">?<span class="weo-tooltip' + posClass + '"><div class="weo-tooltip-title">' + t.title + '</div><div class="weo-tooltip-body">' + t.body + '</div></span></span>';
+      return '<span class="weo-info-trigger">?<span class="weo-tooltip' + posClass + '"><div class="weo-tooltip-title">' + t.title + '</div><div class="weo-tooltip-body">' + t.body + '</div>' + methodLink(weoMethodAnchors.ccTypes[typeNum]) + '</span></span>';
     }
-    
+
     // Generate tooltip for CC confidence levels (CC-V, CC-E, CC-A)
     function generateCCConfidenceTooltip(level, position) {
       const t = weoTooltips.ccConfidence[level];
       if (!t) return '';
       const posClass = position ? ' tooltip-' + position : '';
-      return '<span class="weo-info-trigger">?<span class="weo-tooltip' + posClass + '"><div class="weo-tooltip-title">' + t.title + '</div><div class="weo-tooltip-body">' + t.body + '</div></span></span>';
+      return '<span class="weo-info-trigger">?<span class="weo-tooltip' + posClass + '"><div class="weo-tooltip-title">' + t.title + '</div><div class="weo-tooltip-body">' + t.body + '</div>' + methodLink(weoMethodAnchors.ccConfidence[level]) + '</span></span>';
     }
 
     function generateFreeTierContent(event) {
@@ -10414,7 +10395,7 @@ function generateCCSection(eventId, showFullContent) {
       
       let blocAnalysisHtml = '';
       if (event.blocAnalysis) {
-        blocAnalysisHtml = '<table class="bloc-table"><thead><tr><th>Bloc</th><th style="white-space:nowrap;">Involvement <span class="weo-info-trigger">\u24d8<span class="weo-tooltip"><div class="weo-tooltip-title">Involvement</div><div class="weo-tooltip-body"><strong>Involvement</strong> records participation in the event\x27s implementation \u2014 who developed, enacted, funded, or governed it. Commercial distribution, platform hosting, or downstream adoption on other-bloc infrastructure is not classified as involvement.</div></span></span></th><th>Role</th></tr></thead><tbody>' + event.blocAnalysis.map(function(b) { return '<tr><td>' + b.bloc + '</td><td style="color:' + (b.involvement === 'Yes' ? '#22C55E' : '#94A3B8') + ';">' + b.involvement + '</td><td>' + b.role + '</td></tr>'; }).join('') + '</tbody></table>';
+        blocAnalysisHtml = '<table class="bloc-table"><thead><tr><th>Bloc</th><th style="white-space:nowrap;">Involvement <span class="weo-info-trigger">\u24d8<span class="weo-tooltip"><div class="weo-tooltip-title">Involvement</div><div class="weo-tooltip-body"><strong>Involvement</strong> records participation in the event\x27s implementation \u2014 who developed, enacted, funded, or governed it. Commercial distribution, platform hosting, or downstream adoption on other-bloc infrastructure is not classified as involvement.</div>' + methodLink('section-5-3-1') + '</span></span></th><th>Role</th></tr></thead><tbody>' + event.blocAnalysis.map(function(b) { return '<tr><td>' + b.bloc + '</td><td style="color:' + (b.involvement === 'Yes' ? '#22C55E' : '#94A3B8') + ';">' + b.involvement + '</td><td>' + b.role + '</td></tr>'; }).join('') + '</tbody></table>';
       }
       
       let sourcesHtml = '';
@@ -10579,7 +10560,7 @@ function generateCCSection(eventId, showFullContent) {
         if (pathwayInfo) {
           pathwayDisplayName = pathwayInfo.displayName;
           // Generate pathway-specific tooltip using same structure as other tooltips
-          pathwayTooltipHtml = '<span class="weo-info-trigger">?<span class="weo-tooltip tooltip-left"><div class="weo-tooltip-title">' + pathwayInfo.title + '</div><div class="weo-tooltip-body">' + pathwayInfo.body + '</div></span></span>';
+          pathwayTooltipHtml = '<span class="weo-info-trigger">?<span class="weo-tooltip tooltip-left"><div class="weo-tooltip-title">' + pathwayInfo.title + '</div><div class="weo-tooltip-body">' + pathwayInfo.body + '</div>' + methodLink('section-4-8') + '</span></span>';
         }
         
         const routeBasedMet = event.routeBased.filter(function(f) { return f.pass; }).length;
@@ -11973,11 +11954,6 @@ function generateCCSection(eventId, showFullContent) {
 </script>
 <script data-goatcounter="https://warmthengine.goatcounter.com/count"
         async src="//gc.zgo.at/count.js"></script>
-<!-- Methodology cross-reference toggle -->
-<button id="weoRefToggle" class="weo-ref-toggle"
-        onclick="WEO_REFS.toggle()"
-        title="Toggle methodology cross-references"
-        aria-label="Toggle methodology cross-references">§</button>
-<script src="/js/weo-methodology-refs.js"></script>
+
 </body>
 </html>


### PR DESCRIPTION
Removes the § toggle button, weo-ref-toggle CSS, and weo-methodology-refs.js script tag from all four pages (index, events, atlas, blocs). Replaces the annotation engine with methodology cross-reference links integrated directly into the existing tooltip system on index, events, and atlas.

Each tooltip now surfaces a "§ View in Methodology →" link (color #94A3B8, hover #60a5fa, border-top separator) mapping to the relevant section anchor in /research/methodology/manual/. Covers all four generator functions plus inline tooltip builds for route-based pathways, confidence/tier/bloc chips, CC confidence, industry tags, environmental nexus, and involvement.