### PR TITLE
fix: add 27 missing section anchor IDs to Methodology Manual HTML

### DIFF
--- a/research/methodology/manual/index.html
+++ b/research/methodology/manual/index.html
@@ -2969,6 +2969,7 @@ development”</li>
 <li>✗ “Digital Innovation Fund supporting various technologies including
 AI” (not AI-explicit)</li>
 </ul>
+<span id="section-3-5-d"></span>
 <p><strong>Option D: Operational Evidence Protocol (OEP) —
 Infrastructure Events</strong></p>
 <p>Applies to Infrastructure events where official primary documentation
@@ -4459,6 +4460,7 @@ counter-relationship may emerge, shifting the nation to Non-Aligned.
 This gradient of permanence has implications for analytical confidence —
 higher categories carry greater classification certainty.</p>
 <hr />
+<span id="section-3-10-1-core"></span>
 <h4 id="core">Core</h4>
 <p><strong>Definition:</strong> A nation that structurally anchors or is
 deeply embedded within the bloc’s AI infrastructure ecosystem across
@@ -4493,6 +4495,7 @@ reclassification. Promotion to Core from Integrated requires sustained
 (multi-year) deepening of alignment across additional SCP dimensions,
 not merely the accumulation of agreements.</p>
 <hr />
+<span id="section-3-10-1-integrated"></span>
 <h4 id="integrated">Integrated</h4>
 <p><strong>Definition:</strong> A nation that actively participates in
 the bloc’s AI infrastructure ecosystem through formal agreements,
@@ -4535,6 +4538,7 @@ withdrawal from, or non-compliance with formal agreements. Promotion
 from Integrated to Core requires sustained multi-dimensional deepening
 over years, not a single event.</p>
 <hr />
+<span id="section-3-10-1-engaged"></span>
 <h4 id="engaged">Engaged</h4>
 <p><strong>Definition:</strong> A nation that participates in the bloc’s
 AI infrastructure ecosystem primarily through de facto technology
@@ -4572,6 +4576,7 @@ compliance conditions. Demotion from Engaged to Peripheral is triggered
 by diversification away from the bloc’s ecosystem to a level where
 participation is no longer multi-vector.</p>
 <hr />
+<span id="section-3-10-1-peripheral"></span>
 <h4 id="peripheral">Peripheral</h4>
 <p><strong>Definition:</strong> A nation with limited, recent, or
 single-vector connection to the bloc’s AI infrastructure ecosystem.
@@ -7478,6 +7483,7 @@ Criteria are independent pathways.</p>
 <p><strong>For empirical derivation:</strong> See <em>Methodology
 Rationale</em>, Sections 4.4-4.5.</p>
 <hr />
+<span id="section-4-9"></span>
 <h2 id="part-c-policy-and-institutional-events-pisa-5-assessment">4.9
 Part C: Policy and Institutional Events (PISA-5 Assessment)</h2>
 <h3 id="purpose-and-scope">Purpose and Scope</h3>
@@ -7880,6 +7886,7 @@ not meet automatic qualification (≥4/5 or F1+F2+F3).</p>
 qualification, §4.9): the marginal trigger is exactly 2/4 factors passed
 with F1+F2 not both failing. The same tiebreaker checklist (TB1–TB5)
 applies.</p>
+<span id="section-4-9-tiebreakers"></span>
 <h4 id="tiebreaker-checklist-tb1-tb5">Tiebreaker Checklist
 (TB1-TB5)</h4>
 <table>
@@ -8544,6 +8551,7 @@ into one of three tiers based on coordination scale: cross-bloc
 coordination (Tier 1), between-bloc fragmentation (Tier 2), and
 intra-bloc coordination (Tier 3).</p>
 <hr />
+<span id="section-5-2"></span>
 <h2 id="three-tier-architecture">5.2 Three-Tier Architecture</h2>
 <h3 id="tier-definitions">Tier Definitions</h3>
 <table>
@@ -8592,6 +8600,7 @@ without requiring fundamental architectural changes. This design
 prioritises methodological durability over current-state
 specificity.</p>
 <hr />
+<span id="section-5-3"></span>
 <h2 id="principal-ai-actors">5.3 Principal AI Actors</h2>
 <h3 id="definition">Definition</h3>
 <p>A principal AI actor (PAA) is a nation or supranational entity that
@@ -8818,10 +8827,10 @@ Gate 3.</em></p>
 <p>All three gates are necessary for PAA designation. The three-gate
 structure produces a four-designation classification:</p>
 <ul>
-<li>An actor scoring ≥3, passing the per-PAA severance test, AND holding
+<li><span id="section-5-3-1-paa-def"></span>An actor scoring ≥3, passing the per-PAA severance test, AND holding
 a sustainable platform dimension is classified as a <strong>Principal AI
 Actor (PAA)</strong> — an ecosystem anchor.</li>
-<li>An actor scoring ≥3, passing the per-PAA severance test, but holding
+<li><span id="section-5-3-1-aik-def"></span>An actor scoring ≥3, passing the per-PAA severance test, but holding
 NO sustainable platform dimension is classified as an <strong>AI
 Infrastructure Keystone (AIK)</strong> — an actor with structural
 chokepoint leverage within an ecosystem without providing the ecosystem
@@ -8832,11 +8841,11 @@ hub orchestrators). AIKs hold leverage over the AI supply chain (through
 equipment monopolies, fabrication capacity, or governance authority) but
 do not host the compute or model development platforms that define an
 ecosystem.</li>
-<li>An actor scoring ≥3 but FAILING the per-PAA severance test is
+<li><span id="section-5-3-1-acs-def"></span>An actor scoring ≥3 but FAILING the per-PAA severance test is
 classified as an <strong>Advanced Capability State (ACS)</strong> — an
 actor with significant sovereign capabilities that nonetheless operates
 within an ecosystem anchored by a Principal AI Actor.</li>
-<li>An actor scoring fewer than 3 dimensions is classified as a
+<li><span id="section-5-3-1-part-def"></span>An actor scoring fewer than 3 dimensions is classified as a
 <strong>Participant</strong> — an actor operating within ecosystem(s)
 shaped by PAAs and AIKs. The dimension profile (which specific
 dimensions are met) carries the analytical detail for
@@ -8844,6 +8853,7 @@ Participant-designated actors; no further subdivision is applied because
 the structural distinctions below the ≥3 threshold are better captured
 by per-dimension data than by additional designation categories.</li>
 </ul>
+<span id="section-5-3-1-severance"></span>
 <h3 id="severance-test-criteria">Severance Test Criteria</h3>
 <p>The severance test is applied against each existing PAA individually.
 For each actor scoring ≥3 on the capability threshold, the test
@@ -8976,6 +8986,7 @@ assessed as “met” includes documented constraints and dependencies. The
 severance test synthesises these dependencies to determine whether a
 structural collapse would occur upon withdrawal of a specific PAA’s
 ecosystem inputs.</p>
+<span id="section-5-3-1-hierarchy"></span>
 <h3 id="actor-classification-hierarchy">Actor Classification
 Hierarchy</h3>
 <table>
@@ -9105,6 +9116,7 @@ test (see sovereign control principle above). Dimensions 6 and 7 assess
 sovereign governmental actions where the clause is inapplicable.</p>
 <h3 id="dimension-specific-qualification-principles">Dimension-Specific
 Qualification Principles</h3>
+<span id="section-5-3-d1"></span>
 <p><strong>Dimension 1 — AI accelerator design.</strong> The actor hosts
 an entity that designs and commercially markets AI training-relevant
 accelerators (GPUs, TPUs, NPUs, or equivalent processors designed
@@ -9121,6 +9133,7 @@ not independently satisfy this dimension. Mobile, edge, or
 inference-only processors do not qualify unless they are also deployed
 at scale for data centre AI training. The subsidiary and acquisition
 clause (above) applies.</p>
+<span id="section-5-3-d2"></span>
 <p><strong>Dimension 2 — Advanced semiconductor fabrication
 (≤7nm).</strong> The actor operates production-capable semiconductor
 fabrication facilities at process nodes of 7nm or below, where
@@ -9137,6 +9150,7 @@ manufacturing qualifies for that territory regardless of the operating
 entity’s corporate domicile; where the facility is foreign-owned, the
 foreign ownership and any associated strategic dependencies are
 documented as constraints.</p>
+<span id="section-5-3-d3"></span>
 <p><strong>Dimension 3 — Semiconductor manufacturing equipment.</strong>
 The actor hosts entities that design and manufacture critical
 semiconductor production equipment — or sole-sourced subsystems and
@@ -9154,6 +9168,7 @@ this dimension if its supplier performs a function for which no
 alternative from another territory could substitute without significant
 process redesign, capability loss, or multi-year qualification delay.
 The subsidiary and acquisition clause applies.</p>
+<span id="section-5-3-d4"></span>
 <p><strong>Dimension 4 — Cloud AI compute services.</strong> The actor
 hosts hyperscale cloud providers that operate AI training and inference
 infrastructure as a commercially available service, where operational
@@ -9180,6 +9195,7 @@ in D2. Cloud providers with a primarily domestic customer base qualify,
 but the scope limitation is noted. The subsidiary and acquisition clause
 applies to the corporate capability aspects (strategic direction, IP)
 but does not override the territorial compute requirement.</p>
+<span id="section-5-3-d5"></span>
 <p><strong>Dimension 5 — Frontier AI model development.</strong> The
 actor’s territory hosts organisations that develop state-of-the-art
 foundation models with general applicability, where the research
@@ -9202,6 +9218,7 @@ The subsidiary and acquisition clause applies: where a model developer
 is a subsidiary of a parent headquartered in another territory, the
 dimension is assessed for the parent’s territory unless the subsidiary
 demonstrates strategic autonomy over model development.</p>
+<span id="section-5-3-d6"></span>
 <p><strong>Dimension 6 — AI-specific regulatory authority with
 extraterritorial reach.</strong> The actor enforces AI-relevant
 compliance frameworks that create binding obligations for entities
@@ -9223,6 +9240,7 @@ enacted at the supranational level with binding legal force for member
 states and extraterritorial applicability to foreign entities.
 Enforcement capacity may be evidenced by the entity’s demonstrated track
 record with analogous cross-border regulatory frameworks.</p>
+<span id="section-5-3-d7"></span>
 <p><strong>Dimension 7 — Sovereign AI infrastructure investment at
 scale.</strong> The actor operates a national or supranational programme
 directing significant public capital towards AI compute infrastructure,
@@ -9519,6 +9537,7 @@ governance frameworks</p>
 Apply the corresponding Tier 2 test based on the event’s observable
 action.</p>
 <hr />
+<span id="section-5-5-restriction"></span>
 <h4 id="t2-restriction-test">T2 Restriction Test</h4>
 <p><strong>Question:</strong> Does official policy documentation
 explicitly restrict other-bloc actor’s: - Access to domestic market? -
@@ -9587,6 +9606,7 @@ basis is recorded without requiring a separate Chapter 5 determination.
 For non-PIET events, T2 Impact-Demonstrated is assessed as a standalone
 Chapter 5 determination applying the same evidence standard.</p>
 <hr />
+<span id="section-5-5-buildout"></span>
 <h4 id="t2-buildout-test">T2 Buildout Test</h4>
 <p><strong>Four-Criteria Framework</strong></p>
 <p>Meeting <strong>ONE OR MORE</strong> criteria classifies the event as
@@ -9962,6 +9982,7 @@ roles (not observers)</p>
 <h1 id="chapter-6">Chapter 6: Domain Classification</h1>
 <p><a href="/research/methodology/rationale/#rationale-6" class="weo-rationale-link">View rationale for this chapter →</a></p>
 
+<span id="section-6-1"></span>
 <h2 id="overview-1">6.1 Overview</h2>
 <p>Domain classification categorises each verified event by its primary
 subject matter — the thematic arena within which the event takes
@@ -10008,6 +10029,7 @@ assignment — determining WHAT each event is primarily about. Domain
 classification is independent of Event Type classification (which
 determines HOW the event occurred).</p>
 <hr />
+<span id="section-6-2"></span>
 <h2 id="domains-vs-event-types">6.2 Domains vs Event Types</h2>
 <p>Domain classification (subject matter) is independent of Event Type
 classification (mechanism). See <em>Section 2.4</em> for the
@@ -13238,6 +13260,7 @@ graduated assessment or margin of appreciation is applied.</p>
 reported as ranges and any point within the range exceeds the 3×
 threshold, the criterion is assessed as Not Met. The conservative bound
 governs.</p>
+<span id="section-9-4-3-scale"></span>
 <p><strong>Scale assessment status:</strong> Each scope assessment must
 record one of the following statuses for Dimension 2:</p>
 <table>


### PR DESCRIPTION
## Summary

- **Audited** all anchor IDs referenced by data surface tooltip deep-links against what actually exists in `research/methodology/manual/index.html`
- **Found 27 missing anchors** — all previous tooltip `§ View in Methodology` links were loading the page at the top instead of jumping to the correct section
- **Inserted `<span id="..."></span>` anchors** immediately before the correct heading/element for each missing anchor, preserving all existing pandoc-generated `id` attributes

## Anchors added

**Critical section anchors (data surface tooltip links):**
- `section-5-2` (Three-Tier Architecture)
- `section-5-3` (Principal AI Actors)
- `section-5-3-1-hierarchy` (Actor Classification Hierarchy table)
- `section-5-3-1-severance` (Severance Test Criteria)
- `section-5-3-d1` through `section-5-3-d7` (7 SCP dimensions)
- `section-5-5-restriction` / `section-5-5-buildout` (T2 test headings)
- `section-3-5-d` (Option D: OEP)
- `section-4-9` (Part C: PISA-5)
- `section-4-9-tiebreakers` (TB1–TB5 checklist)
- `section-6-1` / `section-6-2` (Domain Overview / Domains vs Event Types)
- `section-9-4-3-scale` (Scale Assessment Status taxonomy)

**Granular definition anchors:**
- `section-3-10-1-core/integrated/engaged/peripheral` (bloc membership categories)
- `section-5-3-1-paa-def/aik-def/acs-def/part-def` (actor designation definitions, placed inside `<li>` as `<li><span id="..."></span>text` for valid HTML)

## Rationale HTML
No changes — `research/methodology/rationale/index.html` uses its own `rationale-X` anchor scheme and no data surface pages link to it with `chapter-X` format anchors.

## Test plan
- [ ] `warmthengine.com/research/methodology/manual/#section-5-2` → scrolls to Three-Tier Architecture
- [ ] `warmthengine.com/research/methodology/manual/#section-5-3-d1` → scrolls to Dimension 1
- [ ] `warmthengine.com/research/methodology/manual/#section-5-3-1-paa-def` → scrolls to PAA definition
- [ ] `warmthengine.com/research/methodology/manual/#section-3-10-1-core` → scrolls to Core category
- [ ] `warmthengine.com/research/methodology/manual/#section-8-5` → scrolls to Warmth Engine Ratio (pre-existing)
- [ ] `warmthengine.com/research/methodology/manual/#chapter-6` → scrolls to Domain Classification (pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)