### PR TITLE
fix: SCP tooltip rewrite (click-label approach) + atlas gating + anch…

### DIFF
--- a/atlas.html
+++ b/atlas.html
@@ -4292,7 +4292,7 @@
           highlyConnected:   'section-9-1',
           industryTags:      'section-7-2',
           environmentalNexus: 'section-8-2',
-          involvement:       'section-5-3-1',
+          involvement:       'section-3-10',
           scale:             null,
           tierSection:       'section-5-2',
           tiebreaker:        'section-4-9-tiebreakers',
@@ -8769,6 +8769,8 @@
             html += '<div class="atlas-panel-section-title"><span class="badge-with-tooltip">Tier classification' + generateTooltip('tierSection', 'below') + '</span></div>';
             if (event.tier_rationale) {
                 html += atlasMethodologyProseBlock('', event.tier_rationale, 75);
+            } else if (event.sample) {
+                html += '<div class="atlas-section-note" style="color:#94A3B8;font-size:13px;padding:8px 0;">Tier classification rationale loading...</div>';
             } else {
                 html += '<div class="atlas-section-locked">';
                 // §21 standardised copy.
@@ -8784,6 +8786,8 @@
             html += '<div class="atlas-panel-section-title">Bloc analysis</div>';
             if (event.bloc_analysis) {
                 html += atlasBlocAnalysisBlock(event.bloc_analysis);
+            } else if (event.sample) {
+                html += '<div class="atlas-section-note" style="color:#94A3B8;font-size:13px;padding:8px 0;">Bloc analysis loading...</div>';
             } else {
                 html += '<div class="atlas-section-locked">';
                 // §21 standardised copy.

--- a/blocs.html
+++ b/blocs.html
@@ -1867,7 +1867,7 @@
                     <!-- Core -->
                     <div class="subcategory">
                         <div class="subcategory-header">
-                            <span class="subcategory-title">Core<span class="weo-info-trigger">ⓘ<span class="weo-tooltip"><div class="weo-tooltip-title">Core</div><div class="weo-tooltip-body">Deepest alignment — the actor anchoring the ecosystem or hosting the most critical infrastructure nodes.</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-3-10-1" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span></span>
+                            <span class="subcategory-title">Core<span class="weo-info-trigger">ⓘ<span class="weo-tooltip"><div class="weo-tooltip-title">Core</div><div class="weo-tooltip-body">Deepest alignment — the actor anchoring the ecosystem or hosting the most critical infrastructure nodes.</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-3-10-1-core" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span></span>
                             <span class="subcategory-count">(34)</span>
                         </div>
                         <div class="prose" style="margin-bottom: var(--weo-space-md);">
@@ -1896,7 +1896,7 @@
                     <!-- Integrated -->
                     <div class="subcategory">
                         <div class="subcategory-header">
-                            <span class="subcategory-title">Integrated<span class="weo-info-trigger">ⓘ<span class="weo-tooltip"><div class="weo-tooltip-title">Integrated</div><div class="weo-tooltip-body">Embedded in the bloc's AI infrastructure through institutional, regulatory, or industrial integration.</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-3-10-1" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span></span>
+                            <span class="subcategory-title">Integrated<span class="weo-info-trigger">ⓘ<span class="weo-tooltip"><div class="weo-tooltip-title">Integrated</div><div class="weo-tooltip-body">Embedded in the bloc's AI infrastructure through institutional, regulatory, or industrial integration.</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-3-10-1-integrated" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span></span>
                             <span class="subcategory-count">(4)</span>
                         </div>
                         <div class="prose" style="margin-bottom: var(--weo-space-md);">
@@ -1958,7 +1958,7 @@
                     <!-- Engaged -->
                     <div class="subcategory">
                         <div class="subcategory-header">
-                            <span class="subcategory-title">Engaged<span class="weo-info-trigger">ⓘ<span class="weo-tooltip"><div class="weo-tooltip-title">Engaged</div><div class="weo-tooltip-body">Active participation in bloc coordination without full institutional integration.</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-3-10-1" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span></span>
+                            <span class="subcategory-title">Engaged<span class="weo-info-trigger">ⓘ<span class="weo-tooltip"><div class="weo-tooltip-title">Engaged</div><div class="weo-tooltip-body">Active participation in bloc coordination without full institutional integration.</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-3-10-1-engaged" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span></span>
                             <span class="subcategory-count">(3)</span>
                         </div>
                         <div class="prose" style="margin-bottom: var(--weo-space-md);">
@@ -2007,7 +2007,7 @@
                     <!-- Peripheral -->
                     <div class="subcategory">
                         <div class="subcategory-header">
-                            <span class="subcategory-title">Peripheral<span class="weo-info-trigger">ⓘ<span class="weo-tooltip"><div class="weo-tooltip-title">Peripheral</div><div class="weo-tooltip-body">Geographic or economic proximity without substantive AI infrastructure coordination.</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-3-10-1" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span></span>
+                            <span class="subcategory-title">Peripheral<span class="weo-info-trigger">ⓘ<span class="weo-tooltip"><div class="weo-tooltip-title">Peripheral</div><div class="weo-tooltip-body">Geographic or economic proximity without substantive AI infrastructure coordination.</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-3-10-1-peripheral" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span></span>
                             <span class="subcategory-count">(1)</span>
                         </div>
                         <div class="prose" style="margin-bottom: var(--weo-space-md);">
@@ -2057,7 +2057,7 @@
                     <!-- Core -->
                     <div class="subcategory">
                         <div class="subcategory-header">
-                            <span class="subcategory-title">Core<span class="weo-info-trigger">ⓘ<span class="weo-tooltip"><div class="weo-tooltip-title">Core</div><div class="weo-tooltip-body">Deepest alignment — the actor anchoring the ecosystem or hosting the most critical infrastructure nodes.</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-3-10-1" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span></span>
+                            <span class="subcategory-title">Core<span class="weo-info-trigger">ⓘ<span class="weo-tooltip"><div class="weo-tooltip-title">Core</div><div class="weo-tooltip-body">Deepest alignment — the actor anchoring the ecosystem or hosting the most critical infrastructure nodes.</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-3-10-1-core" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span></span>
                             <span class="subcategory-count">(2)</span>
                         </div>
                         <div class="prose" style="margin-bottom: var(--weo-space-md);">
@@ -2086,7 +2086,7 @@
                     <!-- Integrated -->
                     <div class="subcategory">
                         <div class="subcategory-header">
-                            <span class="subcategory-title">Integrated<span class="weo-info-trigger">ⓘ<span class="weo-tooltip"><div class="weo-tooltip-title">Integrated</div><div class="weo-tooltip-body">Embedded in the bloc's AI infrastructure through institutional, regulatory, or industrial integration.</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-3-10-1" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span></span>
+                            <span class="subcategory-title">Integrated<span class="weo-info-trigger">ⓘ<span class="weo-tooltip"><div class="weo-tooltip-title">Integrated</div><div class="weo-tooltip-body">Embedded in the bloc's AI infrastructure through institutional, regulatory, or industrial integration.</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-3-10-1-integrated" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span></span>
                             <span class="subcategory-count">(2)</span>
                         </div>
                         <div class="prose" style="margin-bottom: var(--weo-space-md);">
@@ -2115,7 +2115,7 @@
                     <!-- Engaged -->
                     <div class="subcategory">
                         <div class="subcategory-header">
-                            <span class="subcategory-title">Engaged<span class="weo-info-trigger">ⓘ<span class="weo-tooltip"><div class="weo-tooltip-title">Engaged</div><div class="weo-tooltip-body">Active participation in bloc coordination without full institutional integration.</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-3-10-1" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span></span>
+                            <span class="subcategory-title">Engaged<span class="weo-info-trigger">ⓘ<span class="weo-tooltip"><div class="weo-tooltip-title">Engaged</div><div class="weo-tooltip-body">Active participation in bloc coordination without full institutional integration.</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-3-10-1-engaged" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span></span>
                             <span class="subcategory-count">(3)</span>
                         </div>
                         <div class="prose" style="margin-bottom: var(--weo-space-md);">
@@ -2148,7 +2148,7 @@
                     <!-- Peripheral -->
                     <div class="subcategory">
                         <div class="subcategory-header">
-                            <span class="subcategory-title">Peripheral<span class="weo-info-trigger">ⓘ<span class="weo-tooltip"><div class="weo-tooltip-title">Peripheral</div><div class="weo-tooltip-body">Geographic or economic proximity without substantive AI infrastructure coordination.</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-3-10-1" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span></span>
+                            <span class="subcategory-title">Peripheral<span class="weo-info-trigger">ⓘ<span class="weo-tooltip"><div class="weo-tooltip-title">Peripheral</div><div class="weo-tooltip-body">Geographic or economic proximity without substantive AI infrastructure coordination.</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-3-10-1-peripheral" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span></span>
                             <span class="subcategory-count">(4)</span>
                         </div>
                         <div class="prose" style="margin-bottom: var(--weo-space-md);">
@@ -2304,15 +2304,15 @@
         
         <!-- Actor Capability Profiles -->
         <section class="section scp-section">
-            <h2 class="section-title">Actor Capability Profiles<span class="weo-info-trigger">ⓘ<span class="weo-tooltip"><div class="weo-tooltip-title">Sovereign Capability Profiles</div><div class="weo-tooltip-body">Seven-dimension framework assessing each actor's sovereign control across the AI infrastructure stack. Actors are designated as <strong>PAA</strong> (ecosystem anchor), <strong>AIK</strong> (structural chokepoint), <strong>ACS</strong> (significant but dependent capabilities), or <strong>Participant</strong> based on capability breadth, ecosystem independence, and platform sustainability.</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-5-3-1" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span></h2>
+            <h2 class="section-title">Actor Capability Profiles<span class="weo-info-trigger">ⓘ<span class="weo-tooltip"><div class="weo-tooltip-title">Sovereign Capability Profiles</div><div class="weo-tooltip-body">Seven-dimension framework assessing each actor's sovereign control across the AI infrastructure stack. Actors are designated as <strong>PAA</strong> (ecosystem anchor), <strong>AIK</strong> (structural chokepoint), <strong>ACS</strong> (significant but dependent capabilities), or <strong>Participant</strong> based on capability breadth, ecosystem independence, and platform sustainability.</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-5-3" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span></h2>
             <div class="card">
                 <p class="scp-intro">The actor capability framework assesses sovereign control across seven dimensions of the AI infrastructure stack. Two actors qualify as principal actors — anchoring the Western and Eastern ecosystems respectively. The remaining actors are classified by the depth and independence of their capabilities within those ecosystems.</p>
 
                 <div class="scp-legend" role="list" aria-label="Designation categories">
-                    <div class="scp-legend-item" role="listitem"><span class="scp-badge scp-badge-paa">PAA</span><span class="weo-info-trigger">ⓘ<span class="weo-tooltip"><div class="weo-tooltip-title">Principal AI Actor (PAA)</div><div class="weo-tooltip-body">Ecosystem anchor — ≥3 dimensions met, passes ecosystem independence (severance) test, holds at least one sustainable platform dimension (D4 or D5).</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-5-3-1" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span> Principal Actor</div>
-                    <div class="scp-legend-item" role="listitem"><span class="scp-badge scp-badge-aik">AIK</span><span class="weo-info-trigger">ⓘ<span class="weo-tooltip"><div class="weo-tooltip-title">AI Infrastructure Keystone (AIK)</div><div class="weo-tooltip-body">Structural chokepoint leverage within an ecosystem without providing the ecosystem itself — ≥3 dimensions, passes severance test, no sustainable platform dimension.</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-5-3-1" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span> Critical Node</div>
-                    <div class="scp-legend-item" role="listitem"><span class="scp-badge scp-badge-acs">ACS</span><span class="weo-info-trigger">ⓘ<span class="weo-tooltip"><div class="weo-tooltip-title">Advanced Capability State (ACS)</div><div class="weo-tooltip-body">Significant sovereign capabilities that the actor cannot sustain autonomously under withdrawal of a PAA's ecosystem inputs — ≥3 dimensions, fails severance test.</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-5-3-1" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span> Ecosystem-Coupled</div>
-                    <div class="scp-legend-item" role="listitem"><span class="scp-badge scp-badge-part">PRT</span><span class="weo-info-trigger">ⓘ<span class="weo-tooltip"><div class="weo-tooltip-title">Participant</div><div class="weo-tooltip-body">Fewer than 3 dimensions met — operates within ecosystems shaped by PAAs and AIKs.</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-5-3-1" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span> Participant</div>
+                    <div class="scp-legend-item" role="listitem"><span class="scp-badge scp-badge-paa">PAA</span><span class="weo-info-trigger">ⓘ<span class="weo-tooltip"><div class="weo-tooltip-title">Principal AI Actor (PAA)</div><div class="weo-tooltip-body">Ecosystem anchor — ≥3 dimensions met, passes ecosystem independence (severance) test, holds at least one sustainable platform dimension (D4 or D5).</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-5-3-1-paa-def" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span> Principal Actor</div>
+                    <div class="scp-legend-item" role="listitem"><span class="scp-badge scp-badge-aik">AIK</span><span class="weo-info-trigger">ⓘ<span class="weo-tooltip"><div class="weo-tooltip-title">AI Infrastructure Keystone (AIK)</div><div class="weo-tooltip-body">Structural chokepoint leverage within an ecosystem without providing the ecosystem itself — ≥3 dimensions, passes severance test, no sustainable platform dimension.</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-5-3-1-aik-def" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span> Critical Node</div>
+                    <div class="scp-legend-item" role="listitem"><span class="scp-badge scp-badge-acs">ACS</span><span class="weo-info-trigger">ⓘ<span class="weo-tooltip"><div class="weo-tooltip-title">Advanced Capability State (ACS)</div><div class="weo-tooltip-body">Significant sovereign capabilities that the actor cannot sustain autonomously under withdrawal of a PAA's ecosystem inputs — ≥3 dimensions, fails severance test.</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-5-3-1-acs-def" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span> Ecosystem-Coupled</div>
+                    <div class="scp-legend-item" role="listitem"><span class="scp-badge scp-badge-part">PRT</span><span class="weo-info-trigger">ⓘ<span class="weo-tooltip"><div class="weo-tooltip-title">Participant</div><div class="weo-tooltip-body">Fewer than 3 dimensions met — operates within ecosystems shaped by PAAs and AIKs.</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-5-3-1-part-def" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span> Participant</div>
                 </div>
 
                 <div class="scp-dim-key" style="display: flex; flex-wrap: wrap; gap: 4px 16px;">

--- a/events.html
+++ b/events.html
@@ -4050,7 +4050,7 @@ const weoMethodAnchors = {
   highlyConnected:  'section-9-1',
   industryTags:     'section-7-2',
   environmentalNexus: 'section-8-2',
-  involvement:      'section-5-3-1',
+  involvement:      'section-3-10',
   scale:            null,
   tierSection:      'section-5-2',
   ccTypes: { 1: 'section-9-2-1-type-1', 2: 'section-9-2-1-type-2', 3: 'section-9-2-1-type-3', 4: 'section-9-2-1-type-4', 5: 'section-9-2-1-type-5', 6: 'section-9-2-1-type-6', 7: 'section-9-2-1-type-7' },
@@ -5208,7 +5208,7 @@ const openModal = (id) => {
                     <thead>
                         <tr style="border-bottom:1px solid var(--weo-border-primary);">
                             <th style="text-align:left;padding:0.5rem 1rem 0.5rem 0;color:var(--weo-text-muted);font-weight:500;">Bloc</th>
-                            <th style="text-align:left;padding:0.5rem 1rem 0.5rem 0;color:var(--weo-text-muted);font-weight:500;white-space:nowrap;">Involvement <span class="weo-info-trigger">ⓘ<span class="weo-tooltip"><div class="weo-tooltip-title">Involvement</div><div class="weo-tooltip-body"><strong>Involvement</strong> records participation in the event's implementation — who developed, enacted, funded, or governed it. Commercial distribution, platform hosting, or downstream adoption on other-bloc infrastructure is not classified as involvement.</div>' + methodLink('section-5-3-1') + '</span></span></th>
+                            <th style="text-align:left;padding:0.5rem 1rem 0.5rem 0;color:var(--weo-text-muted);font-weight:500;white-space:nowrap;">Involvement <span class="weo-info-trigger">ⓘ<span class="weo-tooltip"><div class="weo-tooltip-title">Involvement</div><div class="weo-tooltip-body"><strong>Involvement</strong> records participation in the event's implementation — who developed, enacted, funded, or governed it. Commercial distribution, platform hosting, or downstream adoption on other-bloc infrastructure is not classified as involvement.</div>${methodLink('section-3-10')}</span></span></th>
                             <th style="text-align:left;padding:0.5rem 0;color:var(--weo-text-muted);font-weight:500;">Role</th>
                         </tr>
                     </thead>

--- a/index.html
+++ b/index.html
@@ -5958,11 +5958,11 @@
       .weo-status-actor-row { display: none; }
     }
 
-    /* SCP panel tooltip triggers — minimal visual weight */
-    .scp-panel .weo-info-trigger { cursor: pointer; }
-    .scp-row-badge.weo-info-trigger { cursor: pointer; }
-    .scp-row-score.weo-info-trigger { cursor: pointer; text-decoration-style: dotted; text-decoration-line: underline; text-underline-offset: 3px; text-decoration-color: rgba(148,163,184,0.4); }
-    .scp-dim-name.weo-info-trigger:hover { color: #60a5fa; }
+    /* SCP tooltip triggers — click-to-reveal, minimal visual weight */
+    .scp-tip-trigger { cursor: pointer; }
+    .scp-dim-name.scp-tip-trigger:hover { color: #60a5fa; text-decoration: underline; text-decoration-style: dotted; text-underline-offset: 3px; text-decoration-color: rgba(148,163,184,0.4); }
+    .scp-row-badge.scp-tip-trigger:hover .scp-badge { filter: brightness(1.2); }
+    .scp-sev .scp-tip-trigger:hover { color: #60a5fa; }
 
   </style>
 </head>
@@ -6243,7 +6243,7 @@
   <div class="scp-panel" id="scpPanel" role="dialog" aria-label="Sovereign Capability Profiles">
     <div class="scp-hdr">
       <div>
-        <div class="scp-title">Sovereign Capability Profiles <span class="weo-info-trigger" style="font-size:12px;vertical-align:middle;opacity:0.6;cursor:pointer;">ⓘ<span class="weo-tooltip"><div class="weo-tooltip-title">Sovereign Capability Profiles</div><div class="weo-tooltip-body">Seven-dimension framework assessing each actor's sovereign control across the AI infrastructure stack. Actors are designated as <strong>PAA</strong> (ecosystem anchor), <strong>AIK</strong> (structural chokepoint), <strong>ACS</strong> (significant but dependent capabilities), or <strong>Participant</strong> based on capability breadth, ecosystem independence, and platform sustainability.</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-5-3-1" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span></div>
+        <div class="scp-title">Sovereign Capability Profiles <span class="scp-tip-trigger" data-scp-tip="scp-overview" style="font-size:12px;opacity:0.5;cursor:pointer;">&#9432;</span></div>
         <div class="scp-subtitle">Actor Designation Framework — <span id="scpCount">14</span> actors assessed</div>
       </div>
       <button class="scp-close" id="scpClose" aria-label="Close">×</button>
@@ -9945,7 +9945,7 @@ function generateCCSection(eventId, showFullContent) {
       highlyConnected:  'section-9-1',
       industryTags:     'section-7-2',
       environmentalNexus: 'section-8-2',
-      involvement:      'section-5-3-1',
+      involvement:      'section-3-10',
       scale:            null,
       tierSection:      'section-5-2',
       ccTypes: { 1: 'section-9-2-1-type-1', 2: 'section-9-2-1-type-2', 3: 'section-9-2-1-type-3', 4: 'section-9-2-1-type-4', 5: 'section-9-2-1-type-5', 6: 'section-9-2-1-type-6', 7: 'section-9-2-1-type-7' },
@@ -10413,7 +10413,7 @@ function generateCCSection(eventId, showFullContent) {
       
       let blocAnalysisHtml = '';
       if (event.blocAnalysis) {
-        blocAnalysisHtml = '<table class="bloc-table"><thead><tr><th>Bloc</th><th style="white-space:nowrap;">Involvement <span class="weo-info-trigger">\u24d8<span class="weo-tooltip"><div class="weo-tooltip-title">Involvement</div><div class="weo-tooltip-body"><strong>Involvement</strong> records participation in the event\x27s implementation \u2014 who developed, enacted, funded, or governed it. Commercial distribution, platform hosting, or downstream adoption on other-bloc infrastructure is not classified as involvement.</div>' + methodLink('section-5-3-1') + '</span></span></th><th>Role</th></tr></thead><tbody>' + event.blocAnalysis.map(function(b) { return '<tr><td>' + b.bloc + '</td><td style="color:' + (b.involvement === 'Yes' ? '#22C55E' : '#94A3B8') + ';">' + b.involvement + '</td><td>' + b.role + '</td></tr>'; }).join('') + '</tbody></table>';
+        blocAnalysisHtml = '<table class="bloc-table"><thead><tr><th>Bloc</th><th style="white-space:nowrap;">Involvement <span class="weo-info-trigger">\u24d8<span class="weo-tooltip"><div class="weo-tooltip-title">Involvement</div><div class="weo-tooltip-body"><strong>Involvement</strong> records participation in the event\x27s implementation \u2014 who developed, enacted, funded, or governed it. Commercial distribution, platform hosting, or downstream adoption on other-bloc infrastructure is not classified as involvement.</div>' + methodLink('section-3-10') + '</span></span></th><th>Role</th></tr></thead><tbody>' + event.blocAnalysis.map(function(b) { return '<tr><td>' + b.bloc + '</td><td style="color:' + (b.involvement === 'Yes' ? '#22C55E' : '#94A3B8') + ';">' + b.involvement + '</td><td>' + b.role + '</td></tr>'; }).join('') + '</tbody></table>';
       }
       
       let sourcesHtml = '';
@@ -11449,19 +11449,15 @@ function generateCCSection(eventId, showFullContent) {
     {t:'D7: Sovereign AI Infrastructure Investment', b:'Nationally transformative public capital towards AI compute, fabrication, or infrastructure capacity.', a:'section-5-3-d7'}
   ];
   var SCP_DESIG_TIPS = {
-    PAA: {t:'Principal AI Actor (PAA)', b:'Ecosystem anchor — ≥3 dimensions met, passes ecosystem independence (severance) test, holds at least one sustainable platform dimension (D4 or D5).'},
-    AIK: {t:'AI Infrastructure Keystone (AIK)', b:'Structural chokepoint leverage within an ecosystem without providing the ecosystem itself — ≥3 dimensions, passes severance test, no sustainable platform dimension.'},
-    ACS: {t:'Advanced Capability State (ACS)', b:'Significant sovereign capabilities that the actor cannot sustain autonomously under withdrawal of a PAA\x27s ecosystem inputs — ≥3 dimensions, fails severance test.'},
-    Part: {t:'Participant', b:'Fewer than 3 dimensions met — operates within ecosystems shaped by PAAs and AIKs.'}
+    PAA: {t:'Principal AI Actor (PAA)', b:'Ecosystem anchor — ≥3 dimensions met, passes ecosystem independence (severance) test, holds at least one sustainable platform dimension (D4 or D5).', a:'section-5-3-1-paa-def'},
+    AIK: {t:'AI Infrastructure Keystone (AIK)', b:'Structural chokepoint leverage within an ecosystem without providing the ecosystem itself — ≥3 dimensions, passes severance test, no sustainable platform dimension.', a:'section-5-3-1-aik-def'},
+    ACS: {t:'Advanced Capability State (ACS)', b:'Significant sovereign capabilities that the actor cannot sustain autonomously under withdrawal of a PAA\x27s ecosystem inputs — ≥3 dimensions, fails severance test.', a:'section-5-3-1-acs-def'},
+    Part: {t:'Participant', b:'Fewer than 3 dimensions met — operates within ecosystems shaped by PAAs and AIKs.', a:'section-5-3-1-part-def'}
   };
   function scpMethodLink(anchor) {
     if (!anchor) return '';
     return '<div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#' + anchor + '" target="_blank" rel="noopener">§ View in Methodology →</a></div>';
   }
-  function scpTip(title, body, anchor) {
-    return '<span class="weo-info-trigger">ⓘ<span class="weo-tooltip"><div class="weo-tooltip-title">' + title + '</div><div class="weo-tooltip-body">' + body + '</div>' + scpMethodLink(anchor) + '</span></span>';
-  }
-
   /* ---- Expose designation lookup for event tooltip enrichment ---- */
   var _scpLocKeys = [
     ['South Korea','KR'],['United States','US'],['United Kingdom','GB'],
@@ -11500,10 +11496,8 @@ function generateCCSection(eventId, showFullContent) {
   /* ---- Build pills ---- */
   var ph = '';
   DS.forEach(function(name, i) {
-    var tip = SCP_DIM_TIPS[i];
-    ph += '<span class="scp-pill ' + PC[DC[i]] + ' weo-info-trigger" data-dim="' + i + '">';
+    ph += '<span class="scp-pill ' + PC[DC[i]] + '" data-dim="' + i + '">';
     ph += '<span class="scp-pill-dot"></span>' + name + ' <span class="scp-pill-ct">' + DF[i] + '</span>';
-    ph += '<span class="weo-tooltip"><div class="weo-tooltip-title">' + tip.t + '</div><div class="weo-tooltip-body">' + tip.b + '</div>' + scpMethodLink(tip.a) + '</span>';
     ph += '</span>';
   });
   pillsEl.innerHTML = ph;
@@ -11553,7 +11547,36 @@ function generateCCSection(eventId, showFullContent) {
     if (!listenersAttached) {
       listenersAttached = true;
       bodyEl.addEventListener('click', function(e) {
-        if (e.target.closest('.weo-info-trigger')) return;
+        // SCP tooltip triggers \u2014 intercept before row expansion
+        var tipTrigger = e.target.closest('.scp-tip-trigger');
+        if (tipTrigger) {
+          e.stopPropagation();
+          var tipKey = tipTrigger.getAttribute('data-scp-tip');
+          var tipData = null;
+          if (tipKey && tipKey.indexOf('dim-') === 0) {
+            tipData = SCP_DIM_TIPS[parseInt(tipKey.split('-')[1], 10)];
+          } else if (tipKey && tipKey.indexOf('desig-') === 0) {
+            tipData = SCP_DESIG_TIPS[tipKey.split('-')[1]];
+          } else if (tipKey === 'severance') {
+            tipData = {t:'Severance Test', b:'Ecosystem independence test. Assesses whether the actor can sustain its met dimensions without access to any single Principal AI Actor\x27s ecosystem inputs within 24\u201336 months.', a:'section-5-3-1-severance'};
+          }
+          if (tipData && tooltipOv) {
+            tooltipOv.querySelector('.weo-tooltip-title').textContent = tipData.t;
+            tooltipOv.querySelector('.weo-tooltip-body').innerHTML = tipData.b;
+            var ml = tooltipOv.querySelector('.weo-tooltip-method-link');
+            if (ml) ml.innerHTML = tipData.a ? '<a href="/research/methodology/manual/#' + tipData.a + '" target="_blank" rel="noopener">\u00a7 View in Methodology \u2192</a>' : '';
+            var rect = tipTrigger.getBoundingClientRect();
+            var top = rect.bottom + 8;
+            var left = rect.left;
+            if (left + 350 > window.innerWidth) left = window.innerWidth - 366;
+            if (left < 16) left = 16;
+            if (top + 200 > window.innerHeight) top = rect.top - 208;
+            tooltipOv.style.top = top + 'px';
+            tooltipOv.style.left = left + 'px';
+            tooltipOv.classList.add('visible');
+          }
+          return;
+        }
         if (e.target.closest('#scpPartToggle')) {
           partsExpanded = !partsExpanded;
           var pr = document.getElementById('scpPartRows');
@@ -11589,13 +11612,8 @@ function generateCCSection(eventId, showFullContent) {
       h += '<div class="scp-row-seg' + (d ? ' ' + DC[i] + '-m' : '') + '" data-di="' + i + '"></div>';
     });
     h += '</div>';
-    h += '<span class="scp-row-score weo-info-trigger">' + a.s + '/7';
-    h += '<span class="weo-tooltip"><div class="weo-tooltip-title">Dimension Score</div><div class="weo-tooltip-body">Dimensions met out of 7 total. ≥3 required for PAA, AIK, or ACS designation; fewer than 3 = Participant.</div>' + scpMethodLink('section-5-3-1') + '</span>';
-    h += '</span>';
-    var dTip = SCP_DESIG_TIPS[a.d];
-    h += '<span class="scp-row-badge weo-info-trigger"><span class="scp-badge ' + BC[a.d] + '">' + BL[a.d] + '</span>';
-    h += '<span class="weo-tooltip"><div class="weo-tooltip-title">' + dTip.t + '</div><div class="weo-tooltip-body">' + dTip.b + '</div>' + scpMethodLink('section-5-3-1') + '</span>';
-    h += '</span>';
+    h += '<span class="scp-row-score">' + a.s + '/7</span>';
+    h += '<span class="scp-row-badge scp-tip-trigger" data-scp-tip="desig-' + a.d + '"><span class="scp-badge ' + BC[a.d] + '">' + BL[a.d] + '</span></span>';
     h += '<span class="scp-row-chev">\u25BC</span></div>';
     return h;
   }
@@ -11605,10 +11623,7 @@ function generateCCSection(eventId, showFullContent) {
 
     a.dims.forEach(function(d, i) {
       h += '<div class="scp-dim-row">';
-      var dimTip = SCP_DIM_TIPS[i];
-      h += '<span class="scp-dim-name weo-info-trigger"><span class="scp-dim-dot ' + DC[i] + '"></span>' + DN[i];
-      h += '<span class="weo-tooltip"><div class="weo-tooltip-title">' + dimTip.t + '</div><div class="weo-tooltip-body">' + dimTip.b + '</div>' + scpMethodLink(dimTip.a) + '</span>';
-      h += '</span>';
+      h += '<span class="scp-dim-name scp-tip-trigger" data-scp-tip="dim-' + i + '"><span class="scp-dim-dot ' + DC[i] + '"></span>' + DN[i] + '</span>';
       h += '<span class="scp-dim-st ' + (d ? 'scp-dim-met' : 'scp-dim-not') + '">' + (d ? 'Met' : '—') + '</span>';
       h += '</div>';
       if (d && a.con && a.con[i]) {
@@ -11630,7 +11645,7 @@ function generateCCSection(eventId, showFullContent) {
     });
 
     if (a.svd) {
-      h += '<div class="scp-sev"><strong>Severance:</strong> <span class="weo-info-trigger" style="font-size:11px;opacity:0.6;cursor:pointer;">ⓘ<span class="weo-tooltip"><div class="weo-tooltip-title">Severance Test</div><div class="weo-tooltip-body">Ecosystem independence test. Assesses whether the actor can sustain its met dimensions without access to any single Principal AI Actor\x27s ecosystem inputs within 24–36 months.</div>' + scpMethodLink('section-5-3-1') + '</span></span> ' + escH(a.svd) + '</div>';
+      h += '<div class="scp-sev"><strong class="scp-tip-trigger" data-scp-tip="severance">Severance:</strong> ' + escH(a.svd) + '</div>';
     } else if (a.d === 'PAA' || a.d === 'AIK' || a.d === 'ACS') {
       h += '<div class="scp-src-lock" title="Supporter access required">' + WEO_ICON_LOCK + ' Severance analysis (supporter access)</div>';
     }
@@ -11867,39 +11882,30 @@ function generateCCSection(eventId, showFullContent) {
   window._scpReloadActors = loadActorsData;
 
   /* ---- SCP Tooltip Overlay Handler ---- */
-  /* showTooltip() in the main IIFE is scoped to #detailPanel, so we
-     wire up our own handler here for triggers inside #scpPanel. */
-  if (tooltipOv) {
-    var scpOvTitle = tooltipOv.querySelector('.weo-tooltip-title');
-    var scpOvBody = tooltipOv.querySelector('.weo-tooltip-body');
-    var scpOvMethod = tooltipOv.querySelector('.weo-tooltip-method-link');
-
-    function showSCPTooltip(trigger) {
-      var tip = trigger.querySelector('.weo-tooltip');
-      if (!tip) return;
-      var t = tip.querySelector('.weo-tooltip-title');
-      var b = tip.querySelector('.weo-tooltip-body');
-      var ml = tip.querySelector('.weo-tooltip-method-link');
-      if (scpOvTitle) scpOvTitle.textContent = t ? t.textContent : '';
-      if (scpOvBody) scpOvBody.innerHTML = b ? b.innerHTML : '';
-      if (scpOvMethod) scpOvMethod.innerHTML = ml ? ml.innerHTML : '';
-      var rect = trigger.getBoundingClientRect();
-      var top = rect.bottom + 8;
-      var left = rect.left;
-      if (left + 320 > window.innerWidth) left = window.innerWidth - 336;
-      if (left < 16) left = 16;
-      if (top + 200 > window.innerHeight) top = rect.top - 208;
-      tooltipOv.style.top = top + 'px';
-      tooltipOv.style.left = left + 'px';
-      tooltipOv.classList.add('visible');
+  panel.addEventListener('click', function(e) {
+    var tipTrigger = e.target.closest('.scp-tip-trigger');
+    if (tipTrigger && !bodyEl.contains(tipTrigger)) {
+      // Handle header-level tooltip triggers (SCP title ⓘ)
+      var tipKey = tipTrigger.getAttribute('data-scp-tip');
+      var tipData = null;
+      if (tipKey === 'scp-overview') {
+        tipData = {t:'Sovereign Capability Profiles', b:'Seven-dimension framework assessing each actor\x27s sovereign control across the AI infrastructure stack. Actors are designated as <strong>PAA</strong> (ecosystem anchor), <strong>AIK</strong> (structural chokepoint), <strong>ACS</strong> (significant but dependent capabilities), or <strong>Participant</strong> based on capability breadth, ecosystem independence, and platform sustainability.', a:'section-5-3'};
+      }
+      if (tipData && tooltipOv) {
+        tooltipOv.querySelector('.weo-tooltip-title').textContent = tipData.t;
+        tooltipOv.querySelector('.weo-tooltip-body').innerHTML = tipData.b;
+        var ml = tooltipOv.querySelector('.weo-tooltip-method-link');
+        if (ml) ml.innerHTML = tipData.a ? '<a href="/research/methodology/manual/#' + tipData.a + '" target="_blank" rel="noopener">§ View in Methodology →</a>' : '';
+        var rect = tipTrigger.getBoundingClientRect();
+        tooltipOv.style.top = (rect.bottom + 8) + 'px';
+        tooltipOv.style.left = Math.max(16, Math.min(rect.left, window.innerWidth - 366)) + 'px';
+        tooltipOv.classList.add('visible');
+        e.stopPropagation();
+      }
+      return;
     }
-
-    panel.addEventListener('click', function(e) {
-      var trigger = e.target.closest('.weo-info-trigger');
-      if (trigger) { showSCPTooltip(trigger); return; }
-      if (!e.target.closest('#weo-tooltip-overlay')) { hideTooltipIfActive(); }
-    });
-  }
+    if (!e.target.closest('#weo-tooltip-overlay')) { hideTooltipIfActive(); }
+  });
 
   /* ---- Initial actor data load from API ---- */
   loadActorsData();


### PR DESCRIPTION
…or fixes

SCP panel (index.html):
- Strip all weo-info-trigger icons from pills, badges, scores, dimension names
- Implement click-label-reveals-tooltip pattern via data-scp-tip attributes
- Designation badges clickable → tooltip with granular anchor (-paa-def etc)
- Dimension names clickable → tooltip with per-dimension anchor (d1-d7)
- Severance label clickable → tooltip with section-5-3-1-severance anchor
- Single ⓘ retained on panel title only (scp-overview key)
- Pills restored to column-highlighting-only (no tooltip conflict)
- Dedicated SCP tooltip handler prevents row expansion on tooltip clicks
- Remove unused scpTip() helper function

Atlas gating (atlas.html):
- Sample events no longer show locked state for Tier Classification and Bloc Analysis sections; show loading placeholder instead

Tooltip anchor fixes (all pages):
- Involvement anchor changed from section-5-3-1 to section-3-10
- events.html Involvement tooltip: fix template literal interpolation bug (was using string concat inside backtick literal)
- blocs.html Core/Integrated/Engaged/Peripheral → granular -core/-integrated/ -engaged/-peripheral anchors
- blocs.html PAA/AIK/ACS/PRT designation badges → granular -paa-def/-aik-def/ -acs-def/-part-def anchors
- blocs.html SCP overview tooltip: section-5-3-1 → section-5-3
- Domain anchor (chapter-6) verified correct on all three pages