### PR TITLE
fix: restore Manual chapter dividers, permanent :target highlight, de…

### DIFF
--- a/atlas.html
+++ b/atlas.html
@@ -9818,7 +9818,7 @@
             h += `<span class="atlas-data-value">${escapeHtml(sourceTallyText)}</span>`;
             h += '</div>';
             h += '<div class="atlas-data-row">';
-            h += `<span class="atlas-data-label">Confidence${generateTooltip('confidence', 'below')}</span>`;
+            h += `<span class="atlas-data-label">Confidence</span>`;
             if (conf) {
                 h += `<span class="atlas-data-value">${escapeHtml(conf)} &mdash; ${escapeHtml(confBand)}</span>`;
             } else {

--- a/blocs.html
+++ b/blocs.html
@@ -1607,6 +1607,9 @@
       gap: 2px;
     }
     .weo-info-trigger:hover { color: #60a5fa; }
+    .subcategory-title.weo-info-trigger:hover { color: #60a5fa; }
+    .bloc-title.weo-info-trigger:hover { color: #60a5fa; }
+    .scp-badge.weo-info-trigger:hover { filter: brightness(1.3); }
     .weo-info-trigger::before {
       content: '';
       position: absolute;
@@ -1867,7 +1870,7 @@
                     <!-- Core -->
                     <div class="subcategory">
                         <div class="subcategory-header">
-                            <span class="subcategory-title">Core<span class="weo-info-trigger">ⓘ<span class="weo-tooltip"><div class="weo-tooltip-title">Core</div><div class="weo-tooltip-body">Deepest alignment — the actor anchoring the ecosystem or hosting the most critical infrastructure nodes.</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-3-10-1-core" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span></span>
+                            <span class="subcategory-title weo-info-trigger" style="cursor:pointer;">Core<span class="weo-tooltip"><div class="weo-tooltip-title">Core</div><div class="weo-tooltip-body">Deepest alignment — the actor anchoring the ecosystem or hosting the most critical infrastructure nodes.</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-3-10-1-core" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span>
                             <span class="subcategory-count">(34)</span>
                         </div>
                         <div class="prose" style="margin-bottom: var(--weo-space-md);">
@@ -1896,7 +1899,7 @@
                     <!-- Integrated -->
                     <div class="subcategory">
                         <div class="subcategory-header">
-                            <span class="subcategory-title">Integrated<span class="weo-info-trigger">ⓘ<span class="weo-tooltip"><div class="weo-tooltip-title">Integrated</div><div class="weo-tooltip-body">Embedded in the bloc's AI infrastructure through institutional, regulatory, or industrial integration.</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-3-10-1-integrated" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span></span>
+                            <span class="subcategory-title weo-info-trigger" style="cursor:pointer;">Integrated<span class="weo-tooltip"><div class="weo-tooltip-title">Integrated</div><div class="weo-tooltip-body">Embedded in the bloc's AI infrastructure through institutional, regulatory, or industrial integration.</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-3-10-1-integrated" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span>
                             <span class="subcategory-count">(4)</span>
                         </div>
                         <div class="prose" style="margin-bottom: var(--weo-space-md);">
@@ -1958,7 +1961,7 @@
                     <!-- Engaged -->
                     <div class="subcategory">
                         <div class="subcategory-header">
-                            <span class="subcategory-title">Engaged<span class="weo-info-trigger">ⓘ<span class="weo-tooltip"><div class="weo-tooltip-title">Engaged</div><div class="weo-tooltip-body">Active participation in bloc coordination without full institutional integration.</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-3-10-1-engaged" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span></span>
+                            <span class="subcategory-title weo-info-trigger" style="cursor:pointer;">Engaged<span class="weo-tooltip"><div class="weo-tooltip-title">Engaged</div><div class="weo-tooltip-body">Active participation in bloc coordination without full institutional integration.</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-3-10-1-engaged" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span>
                             <span class="subcategory-count">(3)</span>
                         </div>
                         <div class="prose" style="margin-bottom: var(--weo-space-md);">
@@ -2007,7 +2010,7 @@
                     <!-- Peripheral -->
                     <div class="subcategory">
                         <div class="subcategory-header">
-                            <span class="subcategory-title">Peripheral<span class="weo-info-trigger">ⓘ<span class="weo-tooltip"><div class="weo-tooltip-title">Peripheral</div><div class="weo-tooltip-body">Geographic or economic proximity without substantive AI infrastructure coordination.</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-3-10-1-peripheral" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span></span>
+                            <span class="subcategory-title weo-info-trigger" style="cursor:pointer;">Peripheral<span class="weo-tooltip"><div class="weo-tooltip-title">Peripheral</div><div class="weo-tooltip-body">Geographic or economic proximity without substantive AI infrastructure coordination.</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-3-10-1-peripheral" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span>
                             <span class="subcategory-count">(1)</span>
                         </div>
                         <div class="prose" style="margin-bottom: var(--weo-space-md);">
@@ -2057,7 +2060,7 @@
                     <!-- Core -->
                     <div class="subcategory">
                         <div class="subcategory-header">
-                            <span class="subcategory-title">Core<span class="weo-info-trigger">ⓘ<span class="weo-tooltip"><div class="weo-tooltip-title">Core</div><div class="weo-tooltip-body">Deepest alignment — the actor anchoring the ecosystem or hosting the most critical infrastructure nodes.</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-3-10-1-core" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span></span>
+                            <span class="subcategory-title weo-info-trigger" style="cursor:pointer;">Core<span class="weo-tooltip"><div class="weo-tooltip-title">Core</div><div class="weo-tooltip-body">Deepest alignment — the actor anchoring the ecosystem or hosting the most critical infrastructure nodes.</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-3-10-1-core" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span>
                             <span class="subcategory-count">(2)</span>
                         </div>
                         <div class="prose" style="margin-bottom: var(--weo-space-md);">
@@ -2086,7 +2089,7 @@
                     <!-- Integrated -->
                     <div class="subcategory">
                         <div class="subcategory-header">
-                            <span class="subcategory-title">Integrated<span class="weo-info-trigger">ⓘ<span class="weo-tooltip"><div class="weo-tooltip-title">Integrated</div><div class="weo-tooltip-body">Embedded in the bloc's AI infrastructure through institutional, regulatory, or industrial integration.</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-3-10-1-integrated" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span></span>
+                            <span class="subcategory-title weo-info-trigger" style="cursor:pointer;">Integrated<span class="weo-tooltip"><div class="weo-tooltip-title">Integrated</div><div class="weo-tooltip-body">Embedded in the bloc's AI infrastructure through institutional, regulatory, or industrial integration.</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-3-10-1-integrated" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span>
                             <span class="subcategory-count">(2)</span>
                         </div>
                         <div class="prose" style="margin-bottom: var(--weo-space-md);">
@@ -2115,7 +2118,7 @@
                     <!-- Engaged -->
                     <div class="subcategory">
                         <div class="subcategory-header">
-                            <span class="subcategory-title">Engaged<span class="weo-info-trigger">ⓘ<span class="weo-tooltip"><div class="weo-tooltip-title">Engaged</div><div class="weo-tooltip-body">Active participation in bloc coordination without full institutional integration.</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-3-10-1-engaged" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span></span>
+                            <span class="subcategory-title weo-info-trigger" style="cursor:pointer;">Engaged<span class="weo-tooltip"><div class="weo-tooltip-title">Engaged</div><div class="weo-tooltip-body">Active participation in bloc coordination without full institutional integration.</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-3-10-1-engaged" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span>
                             <span class="subcategory-count">(3)</span>
                         </div>
                         <div class="prose" style="margin-bottom: var(--weo-space-md);">
@@ -2148,7 +2151,7 @@
                     <!-- Peripheral -->
                     <div class="subcategory">
                         <div class="subcategory-header">
-                            <span class="subcategory-title">Peripheral<span class="weo-info-trigger">ⓘ<span class="weo-tooltip"><div class="weo-tooltip-title">Peripheral</div><div class="weo-tooltip-body">Geographic or economic proximity without substantive AI infrastructure coordination.</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-3-10-1-peripheral" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span></span>
+                            <span class="subcategory-title weo-info-trigger" style="cursor:pointer;">Peripheral<span class="weo-tooltip"><div class="weo-tooltip-title">Peripheral</div><div class="weo-tooltip-body">Geographic or economic proximity without substantive AI infrastructure coordination.</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-3-10-1-peripheral" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span>
                             <span class="subcategory-count">(4)</span>
                         </div>
                         <div class="prose" style="margin-bottom: var(--weo-space-md);">
@@ -2199,7 +2202,7 @@
                 <div class="bloc-header" onclick="toggleBloc('non-aligned')">
                     <div class="bloc-header-left">
                         <span class="bloc-indicator non-aligned"></span>
-                        <span class="bloc-title">Non-Aligned<span class="weo-info-trigger">ⓘ<span class="weo-tooltip"><div class="weo-tooltip-title">Non-Aligned</div><div class="weo-tooltip-body">Nations with documented AI infrastructure partnerships with both blocs and maintained strategic autonomy. Classified to either bloc per event based on dominant partnership characteristics.</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-3-10-2" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span></span>
+                        <span class="bloc-title weo-info-trigger" style="cursor:pointer;">Non-Aligned<span class="weo-tooltip"><div class="weo-tooltip-title">Non-Aligned</div><div class="weo-tooltip-body">Nations with documented AI infrastructure partnerships with both blocs and maintained strategic autonomy. Classified to either bloc per event based on dominant partnership characteristics.</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-3-10-2" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span>
                     </div>
                     <div style="display: flex; align-items: center; gap: var(--weo-space-md);">
                         <span class="bloc-count non-aligned">9</span>
@@ -2304,15 +2307,15 @@
         
         <!-- Actor Capability Profiles -->
         <section class="section scp-section">
-            <h2 class="section-title">Actor Capability Profiles<span class="weo-info-trigger">ⓘ<span class="weo-tooltip"><div class="weo-tooltip-title">Sovereign Capability Profiles</div><div class="weo-tooltip-body">Seven-dimension framework assessing each actor's sovereign control across the AI infrastructure stack. Actors are designated as <strong>PAA</strong> (ecosystem anchor), <strong>AIK</strong> (structural chokepoint), <strong>ACS</strong> (significant but dependent capabilities), or <strong>Participant</strong> based on capability breadth, ecosystem independence, and platform sustainability.</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-5-3" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span></h2>
+            <h2 class="section-title">Actor Capability Profiles <span class="weo-info-trigger">?<span class="weo-tooltip"><div class="weo-tooltip-title">Sovereign Capability Profiles</div><div class="weo-tooltip-body">Seven-dimension framework assessing each actor's sovereign control across the AI infrastructure stack. Actors are designated as <strong>PAA</strong> (ecosystem anchor), <strong>AIK</strong> (structural chokepoint), <strong>ACS</strong> (significant but dependent capabilities), or <strong>Participant</strong> based on capability breadth, ecosystem independence, and platform sustainability.</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-5-3" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span></h2>
             <div class="card">
                 <p class="scp-intro">The actor capability framework assesses sovereign control across seven dimensions of the AI infrastructure stack. Two actors qualify as principal actors — anchoring the Western and Eastern ecosystems respectively. The remaining actors are classified by the depth and independence of their capabilities within those ecosystems.</p>
 
                 <div class="scp-legend" role="list" aria-label="Designation categories">
-                    <div class="scp-legend-item" role="listitem"><span class="scp-badge scp-badge-paa">PAA</span><span class="weo-info-trigger">ⓘ<span class="weo-tooltip"><div class="weo-tooltip-title">Principal AI Actor (PAA)</div><div class="weo-tooltip-body">Ecosystem anchor — ≥3 dimensions met, passes ecosystem independence (severance) test, holds at least one sustainable platform dimension (D4 or D5).</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-5-3-1-paa-def" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span> Principal Actor</div>
-                    <div class="scp-legend-item" role="listitem"><span class="scp-badge scp-badge-aik">AIK</span><span class="weo-info-trigger">ⓘ<span class="weo-tooltip"><div class="weo-tooltip-title">AI Infrastructure Keystone (AIK)</div><div class="weo-tooltip-body">Structural chokepoint leverage within an ecosystem without providing the ecosystem itself — ≥3 dimensions, passes severance test, no sustainable platform dimension.</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-5-3-1-aik-def" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span> Critical Node</div>
-                    <div class="scp-legend-item" role="listitem"><span class="scp-badge scp-badge-acs">ACS</span><span class="weo-info-trigger">ⓘ<span class="weo-tooltip"><div class="weo-tooltip-title">Advanced Capability State (ACS)</div><div class="weo-tooltip-body">Significant sovereign capabilities that the actor cannot sustain autonomously under withdrawal of a PAA's ecosystem inputs — ≥3 dimensions, fails severance test.</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-5-3-1-acs-def" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span> Ecosystem-Coupled</div>
-                    <div class="scp-legend-item" role="listitem"><span class="scp-badge scp-badge-part">PRT</span><span class="weo-info-trigger">ⓘ<span class="weo-tooltip"><div class="weo-tooltip-title">Participant</div><div class="weo-tooltip-body">Fewer than 3 dimensions met — operates within ecosystems shaped by PAAs and AIKs.</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-5-3-1-part-def" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span> Participant</div>
+                    <div class="scp-legend-item" role="listitem"><span class="scp-badge scp-badge-paa weo-info-trigger" style="cursor:pointer;">PAA<span class="weo-tooltip"><div class="weo-tooltip-title">Principal AI Actor (PAA)</div><div class="weo-tooltip-body">Ecosystem anchor — ≥3 dimensions met, passes ecosystem independence (severance) test, holds at least one sustainable platform dimension (D4 or D5).</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-5-3-1-paa-def" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span> Principal Actor</div>
+                    <div class="scp-legend-item" role="listitem"><span class="scp-badge scp-badge-aik weo-info-trigger" style="cursor:pointer;">AIK<span class="weo-tooltip"><div class="weo-tooltip-title">AI Infrastructure Keystone (AIK)</div><div class="weo-tooltip-body">Structural chokepoint leverage within an ecosystem without providing the ecosystem itself — ≥3 dimensions, passes severance test, no sustainable platform dimension.</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-5-3-1-aik-def" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span> Critical Node</div>
+                    <div class="scp-legend-item" role="listitem"><span class="scp-badge scp-badge-acs weo-info-trigger" style="cursor:pointer;">ACS<span class="weo-tooltip"><div class="weo-tooltip-title">Advanced Capability State (ACS)</div><div class="weo-tooltip-body">Significant sovereign capabilities that the actor cannot sustain autonomously under withdrawal of a PAA's ecosystem inputs — ≥3 dimensions, fails severance test.</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-5-3-1-acs-def" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span> Ecosystem-Coupled</div>
+                    <div class="scp-legend-item" role="listitem"><span class="scp-badge scp-badge-part weo-info-trigger" style="cursor:pointer;">PRT<span class="weo-tooltip"><div class="weo-tooltip-title">Participant</div><div class="weo-tooltip-body">Fewer than 3 dimensions met — operates within ecosystems shaped by PAAs and AIKs.</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-5-3-1-part-def" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span> Participant</div>
                 </div>
 
                 <div class="scp-dim-key" style="display: flex; flex-wrap: wrap; gap: 4px 16px;">

--- a/research/methodology/manual/index.html
+++ b/research/methodology/manual/index.html
@@ -554,18 +554,35 @@
             border-color: #60a5fa;
         }
 
-        /* :target highlight */
+        /* Deep-link highlighting — permanent subtle background */
         html { scroll-behavior: smooth; }
         [id] { scroll-margin-top: 5ex; }
 
         :target {
-            animation: weoTargetHighlight 2000ms ease-out forwards;
+            background-color: rgba(96, 165, 250, 0.05);
+            border-radius: 4px;
+            padding: 2px 0;
+        }
+
+        /* Span-based anchors: highlight the next sibling element */
+        span[id^="section-"]:target + h1,
+        span[id^="section-"]:target + h2,
+        span[id^="section-"]:target + h3,
+        span[id^="section-"]:target + h4,
+        span[id^="section-"]:target + p,
+        span[id^="section-"]:target + ul,
+        span[id^="section-"]:target + ol,
+        span[id^="section-"]:target + table,
+        span[id^="section-"]:target + div,
+        span[id^="section-"]:target + blockquote {
+            background-color: rgba(96, 165, 250, 0.05);
             border-radius: 4px;
         }
 
-        @keyframes weoTargetHighlight {
-            0% { background-color: rgba(96, 165, 250, 0.15); box-shadow: 0 0 0 4px rgba(96, 165, 250, 0.15); }
-            100% { background-color: transparent; box-shadow: 0 0 0 0 transparent; }
+        /* Span anchors inside list items: highlight the parent li */
+        li:has(> span[id^="section-"]:target) {
+            background-color: rgba(96, 165, 250, 0.05);
+            border-radius: 4px;
         }
 
         /* Mobile */


### PR DESCRIPTION
…dup confidence, remove ⓘ

Manual HTML:
- Restore <hr> dividers between End of Chapter and next chapter heading
- Replace fade-based :target highlighting with permanent subtle background (rgba(96,165,250,0.05)) — universal across all anchor types, no left border

atlas.html:
- Remove duplicate confidence ? tooltip from Verification section (keep confidence pill tooltip at top of event header)

blocs.html:
- Convert category labels (Core/Integrated/Engaged/Peripheral/Non-Aligned) from ⓘ icon triggers to click-label triggers
- Convert designation badges (PAA/AIK/ACS/PRT) from ⓘ icon triggers to click-badge triggers
- Section header 'Actor Capability Profiles' changed ⓘ to ? for consistency
- Add hover CSS for subcategory-title, bloc-title, scp-badge triggers
- D1-D7 dimensions verified clean (no ⓘ)