### PR TITLE
fix: badge/category sizing, designation labels, toggle-close, :target…

### DIFF
--- a/blocs.html
+++ b/blocs.html
@@ -1606,10 +1606,45 @@
       margin-left: 0;
       gap: 2px;
     }
+    /* Badge and category label triggers: allow natural sizing */
+    .scp-badge.weo-info-trigger {
+      width: auto;
+      height: auto;
+      font-size: 0.6875rem;
+      margin-left: 0;
+      padding: 2px 10px;
+    }
+    .subcategory-title.weo-info-trigger {
+      width: auto;
+      height: auto;
+      font-size: inherit;
+      color: inherit;
+      margin-left: 0;
+      text-decoration: underline;
+      text-decoration-style: dotted;
+      text-underline-offset: 3px;
+      text-decoration-color: rgba(148, 163, 184, 0.4);
+    }
+    .subcategory-title.weo-info-trigger:hover {
+      color: #60a5fa;
+      text-decoration-color: #60a5fa;
+    }
+    .bloc-title.weo-info-trigger {
+      width: auto;
+      height: auto;
+      font-size: inherit;
+      color: inherit;
+      margin-left: 0;
+      text-decoration: underline;
+      text-decoration-style: dotted;
+      text-underline-offset: 3px;
+      text-decoration-color: rgba(148, 163, 184, 0.4);
+    }
+    .bloc-title.weo-info-trigger:hover {
+      color: #60a5fa;
+      text-decoration-color: #60a5fa;
+    }
     .weo-info-trigger:hover { color: #60a5fa; }
-    .subcategory-title.weo-info-trigger:hover { color: #60a5fa; }
-    .bloc-title.weo-info-trigger:hover { color: #60a5fa; }
-    .scp-badge.weo-info-trigger:hover { filter: brightness(1.3); }
     .weo-info-trigger::before {
       content: '';
       position: absolute;
@@ -2313,8 +2348,8 @@
 
                 <div class="scp-legend" role="list" aria-label="Designation categories">
                     <div class="scp-legend-item" role="listitem"><span class="scp-badge scp-badge-paa weo-info-trigger" style="cursor:pointer;">PAA<span class="weo-tooltip"><div class="weo-tooltip-title">Principal AI Actor (PAA)</div><div class="weo-tooltip-body">Ecosystem anchor — ≥3 dimensions met, passes ecosystem independence (severance) test, holds at least one sustainable platform dimension (D4 or D5).</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-5-3-1-paa-def" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span> Principal Actor</div>
-                    <div class="scp-legend-item" role="listitem"><span class="scp-badge scp-badge-aik weo-info-trigger" style="cursor:pointer;">AIK<span class="weo-tooltip"><div class="weo-tooltip-title">AI Infrastructure Keystone (AIK)</div><div class="weo-tooltip-body">Structural chokepoint leverage within an ecosystem without providing the ecosystem itself — ≥3 dimensions, passes severance test, no sustainable platform dimension.</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-5-3-1-aik-def" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span> Critical Node</div>
-                    <div class="scp-legend-item" role="listitem"><span class="scp-badge scp-badge-acs weo-info-trigger" style="cursor:pointer;">ACS<span class="weo-tooltip"><div class="weo-tooltip-title">Advanced Capability State (ACS)</div><div class="weo-tooltip-body">Significant sovereign capabilities that the actor cannot sustain autonomously under withdrawal of a PAA's ecosystem inputs — ≥3 dimensions, fails severance test.</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-5-3-1-acs-def" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span> Ecosystem-Coupled</div>
+                    <div class="scp-legend-item" role="listitem"><span class="scp-badge scp-badge-aik weo-info-trigger" style="cursor:pointer;">AIK<span class="weo-tooltip"><div class="weo-tooltip-title">AI Infrastructure Keystone (AIK)</div><div class="weo-tooltip-body">Structural chokepoint leverage within an ecosystem without providing the ecosystem itself — ≥3 dimensions, passes severance test, no sustainable platform dimension.</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-5-3-1-aik-def" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span> AI Infrastructure Keystone</div>
+                    <div class="scp-legend-item" role="listitem"><span class="scp-badge scp-badge-acs weo-info-trigger" style="cursor:pointer;">ACS<span class="weo-tooltip"><div class="weo-tooltip-title">Advanced Capability State (ACS)</div><div class="weo-tooltip-body">Significant sovereign capabilities that the actor cannot sustain autonomously under withdrawal of a PAA's ecosystem inputs — ≥3 dimensions, fails severance test.</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-5-3-1-acs-def" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span> Advanced Capability State</div>
                     <div class="scp-legend-item" role="listitem"><span class="scp-badge scp-badge-part weo-info-trigger" style="cursor:pointer;">PRT<span class="weo-tooltip"><div class="weo-tooltip-title">Participant</div><div class="weo-tooltip-body">Fewer than 3 dimensions met — operates within ecosystems shaped by PAAs and AIKs.</div><div class="weo-tooltip-method-link"><a href="/research/methodology/manual/#section-5-3-1-part-def" target="_blank" rel="noopener">§ View in Methodology →</a></div></span></span> Participant</div>
                 </div>
 
@@ -2725,8 +2760,19 @@
 
   document.addEventListener('click', function(e) {
     var trigger = e.target.closest('.weo-info-trigger');
-    if (trigger) { showTooltip(trigger); e.stopPropagation(); }
-    else if (!e.target.closest('#weo-tooltip-overlay')) { hideTooltip(); }
+    if (trigger) {
+      if (overlay.classList.contains('visible') && overlay._lastTrigger === trigger) {
+        hideTooltip();
+        overlay._lastTrigger = null;
+        return;
+      }
+      showTooltip(trigger);
+      overlay._lastTrigger = trigger;
+      e.stopPropagation();
+    } else if (!e.target.closest('#weo-tooltip-overlay')) {
+      hideTooltip();
+      overlay._lastTrigger = null;
+    }
   });
   document.addEventListener('keydown', function(e) { if (e.key === 'Escape') hideTooltip(); });
 })();

--- a/research/methodology/manual/index.html
+++ b/research/methodology/manual/index.html
@@ -559,7 +559,7 @@
         [id] { scroll-margin-top: 5ex; }
 
         :target {
-            background-color: rgba(96, 165, 250, 0.05);
+            background-color: rgba(96, 165, 250, 0.10);
             border-radius: 4px;
             padding: 2px 0;
         }
@@ -575,13 +575,13 @@
         span[id^="section-"]:target + table,
         span[id^="section-"]:target + div,
         span[id^="section-"]:target + blockquote {
-            background-color: rgba(96, 165, 250, 0.05);
+            background-color: rgba(96, 165, 250, 0.10);
             border-radius: 4px;
         }
 
         /* Span anchors inside list items: highlight the parent li */
         li:has(> span[id^="section-"]:target) {
-            background-color: rgba(96, 165, 250, 0.05);
+            background-color: rgba(96, 165, 250, 0.10);
             border-radius: 4px;
         }
 
@@ -1191,9 +1191,7 @@ structural feature of governance rather than merely coordination’s
 absence. Fragmentation events are within scope because they are
 observable dynamics between blocs within this field — not because they
 involve cooperative coordination in the Keohane (1984) sense.</p>
-<hr />
-<a href="#top" class="weo-mobile-top-link">↑ Back to top</a>
-<h1 id="chapter-1">Chapter 1: Executive Summary</h1>
+<hr /><h1 id="chapter-1">Chapter 1: Executive Summary</h1>
 <h2 id="section-1-what">What WEO Is</h2>
 <p>This methodology enables systematic tracking of AI infrastructure
 coordination dynamics across geopolitical blocs through verified events
@@ -1366,9 +1364,7 @@ notes is provided in <em>Methodology Rationale</em> (§2.5, Appendix
 C).</p>
 <hr />
 <p><strong>End of Chapter 1: Executive Summary</strong></p>
-<hr />
-<a href="#top" class="weo-mobile-top-link">↑ Back to top</a>
-<h1 id="chapter-2">Chapter 2: Methodology Architecture</h1>
+<hr /><h1 id="chapter-2">Chapter 2: Methodology Architecture</h1>
 <h2 id="overview">Overview</h2>
 <p>This methodology enables systematic tracking of AI infrastructure
 coordination dynamics through a structured classification framework.
@@ -1800,9 +1796,7 @@ Actor designations and bloc structure are reassessed at methodology
 version milestones (§5.3 Review Mechanism).</p>
 <hr />
 <p><strong>End of Chapter 2: Methodology Architecture</strong></p>
-<hr />
-<a href="#top" class="weo-mobile-top-link">↑ Back to top</a>
-<h1 id="chapter-3">Chapter 3: Event Verification</h1>
+<hr /><h1 id="chapter-3">Chapter 3: Event Verification</h1>
 <p><a href="/research/methodology/rationale/#rationale-3" class="weo-rationale-link">View rationale for this chapter →</a></p>
 
 <h2 id="gold-standard-requirements">Gold Standard Requirements</h2>
@@ -6561,9 +6555,7 @@ to systematically classify and document AI infrastructure coordination
 dynamics across geopolitical blocs.</p>
 <hr />
 <p><strong>End of Chapter 3: Event Verification</strong></p>
-<hr />
-<a href="#top" class="weo-mobile-top-link">↑ Back to top</a>
-<h1 id="chapter-4">Chapter 4: Geopolitical Significance Assessment</h1>
+<hr /><h1 id="chapter-4">Chapter 4: Geopolitical Significance Assessment</h1>
 <p><a href="/research/methodology/rationale/#rationale-4" class="weo-rationale-link">View rationale for this chapter →</a></p>
 <h2 id="section-4-1">4.1 Purpose and Framework Overview</h2>
 <p>This chapter establishes Qualification Criterion 4 (QC4) of WEO’s
@@ -8557,9 +8549,7 @@ Response Evidence) for the Stage 2 qualification pathways.</em></p>
 <hr />
 <p><strong>End of Chapter 4: Geopolitical Significance
 Assessment</strong></p>
-<hr />
-<a href="#top" class="weo-mobile-top-link">↑ Back to top</a>
-<h1 id="chapter-5">Chapter 5: Tier Classification</h1>
+<hr /><h1 id="chapter-5">Chapter 5: Tier Classification</h1>
 <p><a href="/research/methodology/rationale/#rationale-5" class="weo-rationale-link">View rationale for this chapter →</a></p>
 
 <h2 id="purpose">5.1 Purpose</h2>
@@ -9994,9 +9984,7 @@ roles (not observers)</p>
 <em>Methodology Rationale</em>, Section 5.</p>
 <hr />
 <p><strong>End of Chapter 5: Tier Classification</strong></p>
-<hr />
-<a href="#top" class="weo-mobile-top-link">↑ Back to top</a>
-<h1 id="chapter-6">Chapter 6: Domain Classification</h1>
+<hr /><h1 id="chapter-6">Chapter 6: Domain Classification</h1>
 <p><a href="/research/methodology/rationale/#rationale-6" class="weo-rationale-link">View rationale for this chapter →</a></p>
 
 <span id="section-6-1"></span>
@@ -10641,9 +10629,7 @@ stage checklists verified - [ ] No outstanding LOW confidence flags - [
 ] Event record ready for database entry</p>
 <hr />
 <p><strong>End of Chapter 6: Domain Classification</strong></p>
-<hr />
-<a href="#top" class="weo-mobile-top-link">↑ Back to top</a>
-<h1 id="chapter-7">Chapter 7: Industry Tags</h1>
+<hr /><h1 id="chapter-7">Chapter 7: Industry Tags</h1>
 <p><a href="/research/methodology/rationale/#rationale-7" class="weo-rationale-link">View rationale for this chapter →</a></p>
 
 <h2 id="section-7-1">7.1 Purpose</h2>
@@ -11494,9 +11480,7 @@ specify data centre infrastructure as a primary investment target,
 directly addressing cloud infrastructure capital access.”</p>
 <hr />
 <p><strong>End of Chapter 7: Industry Tags</strong></p>
-<hr />
-<a href="#top" class="weo-mobile-top-link">↑ Back to top</a>
-<h1 id="chapter-8">Chapter 8: Environmental Nexus Tags</h1>
+<hr /><h1 id="chapter-8">Chapter 8: Environmental Nexus Tags</h1>
 <p><a href="/research/methodology/rationale/#rationale-8" class="weo-rationale-link">View rationale for this chapter →</a></p>
 <h2 id="section-8-1">8.1 Purpose</h2>
 <p>This chapter introduces Environmental Nexus Tags (ENTs) — a distinct
@@ -12146,9 +12130,7 @@ documented. Edge-case guidance will be developed as the processed event
 population provides empirical boundary cases to codify.</p>
 <hr />
 <p><strong>End of Chapter 8: Environmental Nexus Tags</strong></p>
-<hr />
-<a href="#top" class="weo-mobile-top-link">↑ Back to top</a>
-<h1 id="chapter-9">Chapter 9: Coordination Connections</h1>
+<hr /><h1 id="chapter-9">Chapter 9: Coordination Connections</h1>
 <p><a href="/research/methodology/rationale/#rationale-9" class="weo-rationale-link">View rationale for this chapter →</a></p>
 
 <h2 id="section-9-1">9.1 Purpose and Scope</h2>
@@ -13937,9 +13919,7 @@ analytical assessments, not documentary verification.</p>
 </table>
 <hr />
 <p><strong>End of Chapter 9: Coordination Connections</strong></p>
-<hr />
-<a href="#top" class="weo-mobile-top-link">↑ Back to top</a>
-<h1 id="appendix-unified-index">Appendix: Unified Index</h1>
+<hr /><h1 id="appendix-unified-index">Appendix: Unified Index</h1>
 <p>This index covers both the <strong>Methodology Manual</strong> (this
 document) and the companion <strong>Methodology Rationale</strong>.
 References indicate document and section.</p>
@@ -14902,9 +14882,7 @@ References indicate document and section.</p>
 <hr />
 <p><em>End of Unified Index</em></p>
 <hr />
-<p><strong>End of Methodology Manual</strong></p>
-<a href="#top" class="weo-mobile-top-link">↑ Back to top</a>
-<p><em>Warmth Engine Observatory | January 2026 (v1.4, May
+<p><strong>End of Methodology Manual</strong></p><p><em>Warmth Engine Observatory | January 2026 (v1.4, May
 2026)</em></p>
 
             </main>


### PR DESCRIPTION
… visibility

blocs.html:
- Fix weo-info-trigger sizing override for badges, categories, bloc titles (was forcing 16x16px, now width/height: auto)
- Add dotted underline affordance for clickable category/bloc-title labels
- Fix designation labels: 'Critical Node' → 'AI Infrastructure Keystone', 'Ecosystem-Coupled' → 'Advanced Capability State'
- Add tooltip toggle-close (_lastTrigger pattern)

Manual HTML:
- Increase :target highlight from 0.05 to 0.10 opacity
- Remove all 10 chapter-end back-to-top links
- Chapter dividers verified: single hr directly before each chapter heading