### PR TITLE
fix: deep-link zoom uses zoomToShowLayer to break clusters

### DIFF
--- a/index.html
+++ b/index.html
@@ -11252,10 +11252,20 @@ function generateCCSection(eventId, showFullContent) {
 
         // Centre map on the event and open its panel
         setTimeout(function() {
-            map.flyTo([targetEvent.lat, targetEvent.lng], 6, { duration: 0.8 });
-            setTimeout(function() {
-                openPanel(targetEvent);
-            }, 400);
+            var targetMarker = null;
+            markers.eachLayer(function(layer) {
+                if (layer.eventData && (layer.eventData.id === paddedId || layer.eventData.id === eventId)) {
+                    targetMarker = layer;
+                }
+            });
+            if (targetMarker) {
+                markers.zoomToShowLayer(targetMarker, function() {
+                    openPanel(targetEvent);
+                });
+            } else {
+                map.flyTo([targetEvent.lat, targetEvent.lng], 14, { duration: 0.8 });
+                setTimeout(function() { openPanel(targetEvent); }, 400);
+            }
         }, 300);
     })();
 


### PR DESCRIPTION
## Summary

- Replaces `map.flyTo(..., 6)` with MarkerCluster's `zoomToShowLayer` in `handleMapDeepLink()`
- `zoomToShowLayer` zooms just enough to uncluster the target marker, then fires the callback to open the panel — avoiding the previous behaviour where deep-linked events would land in a cluster at zoom 6 with the panel unable to open
- Fallback to `flyTo` at zoom 14 if the marker isn't found in the cluster group (e.g. event not yet rendered)

## Behaviour change

| Before | After |
|--------|-------|
| `flyTo` to zoom 6, then `openPanel` after 400ms delay | `zoomToShowLayer` unspiders the cluster, `openPanel` fires in callback |
| Panel could silently fail if event was clustered | Panel always opens after cluster is broken |

## Test plan

- [ ] Navigate to a deep-link URL (e.g. `?event=E185`) — map should zoom to uncluster, panel should open
- [ ] Test with an event in a dense cluster area — confirm `zoomToShowLayer` fires instead of fallback
- [ ] Test with an unknown event ID — confirm fallback `flyTo` does not throw

**Do not merge — operator review required.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)