### PR TITLE
fix: reset panel scroll position when entering CC peek mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -7816,7 +7816,8 @@ function collapsePanelToPeek() {
     panel.classList.remove('cc-type-1', 'cc-type-2', 'cc-type-3', 'cc-type-4', 'cc-type-5', 'cc-type-6', 'cc-type-7', 'cc-dashed');
     
     panel.classList.add('peek-mode');
-    
+    panel.scrollTop = 0;
+
     // Apply CC type-specific styling if we have an active CC visualisation
     if (ccVisState.active && ccVisState.connectionType) {
       panel.classList.add('cc-type-' + ccVisState.connectionType);


### PR DESCRIPTION
## Summary

- In `collapsePanelToPeek()`, adds `panel.scrollTop = 0` immediately after `panel.classList.add('peek-mode')`
- Ensures the event title is always visible in the 180px peek window when a CC is activated, regardless of how far the user had scrolled in the full panel

## Change

One line in `collapsePanelToPeek()` (line ~7818):

```js
panel.classList.add('peek-mode');
panel.scrollTop = 0;  // ← added
```

## Test plan

- [ ] Open an event panel and scroll down past the title
- [ ] Click a CC — panel should collapse to peek mode with the title visible at the top
- [ ] Confirm no regression when peek mode is entered from an unscrolled panel

**Do not merge — operator review required.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)