### PR TITLE
fix: stop rendering CC audit trail fields on user-facing panels

### DIFF
--- a/atlas.html
+++ b/atlas.html
@@ -9589,23 +9589,6 @@
             h += '</div>';
             // Content
             h += '<div class="cc-evidence-content">';
-            if (detail.primary_documentation) {
-                h += '<p>' + escapeHtml(detail.primary_documentation) + '</p>';
-            }
-            if (detail.citation_text) {
-                h += '<div class="cc-citation">';
-                if (typeof detail.citation_text === 'object') {
-                    if (detail.citation_text.chinese) {
-                        h += '"' + escapeHtml(detail.citation_text.chinese) + '"';
-                    }
-                    if (detail.citation_text.english) {
-                        h += '<span class="cc-citation-source">' + escapeHtml(detail.citation_text.english) + '</span>';
-                    }
-                } else {
-                    h += '"' + escapeHtml(detail.citation_text) + '"';
-                }
-                h += '</div>';
-            }
             if (detail.funding_breakdown) {
                 const fb = detail.funding_breakdown;
                 h += '<div class="cc-funding-grid">';
@@ -9615,38 +9598,8 @@
                 if (fb.percentage) h += '<div class="cc-funding-item"><div class="cc-funding-label">Attribution</div><div class="cc-funding-value">' + escapeHtml(fb.percentage) + '</div></div>';
                 h += '</div>';
             }
-            if (detail.criteria_assessment) {
-                const ca = detail.criteria_assessment;
-                h += '<div class="cc-criteria-grid">';
-                ['mechanism', 'target', 'scope', 'timing'].forEach(k => {
-                    if (!ca[k]) return;
-                    const c = ca[k];
-                    const statusClass = c.met === true ? 'met' : (c.met === 'partial' ? 'partial' : 'not-met');
-                    const statusIcon = c.met === true ? WEO_ICON_CHECK : (c.met === 'partial' ? '◐' : '○');
-                    const hasEvidence = c.evidence && c.evidence.length > 0;
-                    const onClick = hasEvidence ? ' onclick="event.stopPropagation(); this.classList.toggle(\'expanded\')"' : '';
-                    h += '<div class="cc-criterion' + (hasEvidence ? ' has-evidence' : '') + '"' + onClick + '>';
-                    h += '<div class="cc-criterion-header">';
-                    h += '<span class="cc-criterion-status ' + statusClass + '">' + statusIcon + '</span>';
-                    h += '<span class="cc-criterion-name">' + escapeHtml(k.charAt(0).toUpperCase() + k.slice(1)) + '</span>';
-                    if (hasEvidence) h += '<span class="cc-criterion-expand">▼</span>';
-                    h += '</div>';
-                    if (hasEvidence) h += '<div class="cc-criterion-evidence">' + escapeHtml(c.evidence) + '</div>';
-                    h += '</div>';
-                });
-                h += '</div>';
-                if (detail.criteria_score) {
-                    h += '<div class="cc-criteria-score">';
-                    h += '<span class="cc-criteria-score-value">' + escapeHtml(String(detail.criteria_score)) + '</span>';
-                    h += '<span class="cc-criteria-score-label">criteria met</span>';
-                    h += '</div>';
-                }
-            }
             if (detail.framework_relationship) {
                 h += '<p><strong>Relationship:</strong> ' + escapeHtml(detail.framework_relationship) + '</p>';
-            }
-            if (detail.enabling_relationship) {
-                h += '<p><strong>Enabling:</strong> ' + escapeHtml(detail.enabling_relationship) + '</p>';
             }
             if (detail.award_a && detail.award_b) {
                 h += '<div class="cc-funding-grid">';
@@ -9670,9 +9623,6 @@
             }
             if (detail.bilateral_statement) {
                 h += '<div class="cc-citation">"' + escapeHtml(detail.bilateral_statement) + '"</div>';
-            }
-            if (detail.transparency_note) {
-                h += '<div class="cc-transparency-note">' + escapeHtml(detail.transparency_note) + '</div>';
             }
             h += '</div>'; // /.cc-evidence-content
             // Verification History
@@ -9739,27 +9689,6 @@
                 h += '</div>';
                 h += '<div class="cc-criterion-evidence">' + escapeHtml(detail.implementation_mapping) + '</div>';
                 h += '</div>';
-            }
-            if (detail.linguistic_markers || detail.linguistic_marker) {
-                const lm = detail.linguistic_markers || detail.linguistic_marker;
-                let lmText = '';
-                if (typeof lm === 'object' && !Array.isArray(lm)) {
-                    if (lm.marker) lmText += '"' + escapeHtml(lm.marker) + '"';
-                    if (lm.function) lmText += ' — ' + escapeHtml(lm.function);
-                } else if (Array.isArray(lm)) {
-                    lmText = lm.map(m => m.marker ? '"' + escapeHtml(m.marker) + '" — ' + escapeHtml(m.function || m.translation || '') : escapeHtml(String(m))).join('<br>');
-                } else {
-                    lmText = escapeHtml(String(lm));
-                }
-                if (lmText) {
-                    h += '<div class="cc-criterion has-evidence" onclick="event.stopPropagation(); this.classList.toggle(\'expanded\')">';
-                    h += '<div class="cc-criterion-header">';
-                    h += '<span class="cc-criterion-name">Original-Language Markers</span>';
-                    h += '<span class="cc-criterion-expand">▼</span>';
-                    h += '</div>';
-                    h += '<div class="cc-criterion-evidence">' + lmText + '</div>';
-                    h += '</div>';
-                }
             }
             if (detail.cross_references) {
                 h += '<div class="cc-transparency-note" style="font-size: 0.85em; opacity: 0.7;">📎 Cross-references documented</div>';

--- a/events.html
+++ b/events.html
@@ -4392,28 +4392,6 @@ function generateEvidencePanel(conn) {
   // Content
   html += '<div class="cc-evidence-content">';
   
-  // Primary documentation
-  if (detail.primary_documentation) {
-    html += '<p>' + detail.primary_documentation + '</p>';
-  }
-  
-  // Citation text (for Policy Cascade, Funding Flow)
-  if (detail.citation_text) {
-    html += '<div class="cc-citation">';
-    if (typeof detail.citation_text === 'object') {
-      // Chinese/English pair
-      if (detail.citation_text.chinese) {
-        html += '"' + detail.citation_text.chinese + '"';
-      }
-      if (detail.citation_text.english) {
-        html += '<span class="cc-citation-source">' + detail.citation_text.english + '</span>';
-      }
-    } else {
-      html += '"' + detail.citation_text + '"';
-    }
-    html += '</div>';
-  }
-  
   // Funding breakdown (for Funding Flow)
   if (detail.funding_breakdown) {
     const fb = detail.funding_breakdown;
@@ -4433,53 +4411,9 @@ function generateEvidencePanel(conn) {
     html += '</div>';
   }
   
-  // Criteria assessment (for Parallel Policy) - with expandable evidence
-  if (detail.criteria_assessment) {
-    const ca = detail.criteria_assessment;
-    html += '<div class="cc-criteria-grid">';
-    
-    ['mechanism', 'target', 'scope', 'timing'].forEach(function(criterion) {
-      if (ca[criterion]) {
-        const c = ca[criterion];
-        const statusClass = c.met === true ? 'met' : (c.met === 'partial' ? 'partial' : 'not-met');
-        const statusIcon = c.met === true ? WEO_ICON_CHECK : (c.met === 'partial' ? '◐' : '○');
-        const hasEvidence = c.evidence && c.evidence.length > 0;
-        
-        html += '<div class="cc-criterion' + (hasEvidence ? ' has-evidence' : '') + '"' + (hasEvidence ? ' onclick="this.classList.toggle(\'expanded\')"' : '') + '>';
-        html += '<div class="cc-criterion-header">';
-        html += '<span class="cc-criterion-status ' + statusClass + '">' + statusIcon + '</span>';
-        html += '<span class="cc-criterion-name">' + criterion.charAt(0).toUpperCase() + criterion.slice(1) + '</span>';
-        if (hasEvidence) {
-          html += '<span class="cc-criterion-expand">▼</span>';
-        }
-        html += '</div>';
-        
-        if (hasEvidence) {
-          html += '<div class="cc-criterion-evidence">' + c.evidence + '</div>';
-        }
-        
-        html += '</div>';
-      }
-    });
-    
-    html += '</div>';
-    
-    if (detail.criteria_score) {
-      html += '<div class="cc-criteria-score">';
-      html += '<span class="cc-criteria-score-value">' + detail.criteria_score + '</span>';
-      html += '<span class="cc-criteria-score-label">criteria met</span>';
-      html += '</div>';
-    }
-  }
-  
   // Framework relationship
   if (detail.framework_relationship) {
     html += '<p><strong>Relationship:</strong> ' + detail.framework_relationship + '</p>';
-  }
-
-  // Enabling relationship (for Regulatory Enablement)
-  if (detail.enabling_relationship) {
-    html += '<p><strong>Enabling:</strong> ' + detail.enabling_relationship + '</p>';
   }
 
   // Award comparison cards (for Framework Family CHIPS Act subgroup)
@@ -4522,11 +4456,6 @@ function generateEvidencePanel(conn) {
     html += '<div class="cc-citation">';
     html += '"' + detail.bilateral_statement + '"';
     html += '</div>';
-  }
-  
-  // Transparency note
-  if (detail.transparency_note) {
-    html += '<div class="cc-transparency-note">' + detail.transparency_note + '</div>';
   }
   
   html += '</div>'; // End cc-evidence-content
@@ -4619,38 +4548,6 @@ function generateEvidencePanel(conn) {
     html += '<span class="cc-criterion-expand">▼</span>';
     html += '</div>';
     html += '<div class="cc-criterion-evidence">' + detail.implementation_mapping + '</div>';
-    html += '</div>';
-  }
-
-  // Progressive disclosure: linguistic markers (for Chinese regulatory CCs)
-  if (detail.linguistic_markers) {
-    const lm = detail.linguistic_markers;
-    let lmText = '';
-    if (typeof lm === 'object' && !Array.isArray(lm)) {
-        if (lm.marker) lmText += '"' + lm.marker + '"';
-        if (lm.function) lmText += ' — ' + lm.function;
-    } else if (Array.isArray(lm)) {
-        lmText = lm.map(function(m) { return m.marker ? '"' + m.marker + '" — ' + (m.function || m.translation || '') : String(m); }).join('<br>');
-    } else {
-        lmText = String(lm);
-    }
-    if (lmText) {
-        html += '<div class="cc-criterion has-evidence" onclick="this.classList.toggle(\'expanded\')">';
-        html += '<div class="cc-criterion-header">';
-        html += '<span class="cc-criterion-name">Original-Language Markers</span>';
-        html += '<span class="cc-criterion-expand">▼</span>';
-        html += '</div>';
-        html += '<div class="cc-criterion-evidence">' + lmText + '</div>';
-        html += '</div>';
-    }
-  }
-  if (!detail.linguistic_markers && detail.linguistic_marker) {
-    html += '<div class="cc-criterion has-evidence" onclick="this.classList.toggle(\'expanded\')">';
-    html += '<div class="cc-criterion-header">';
-    html += '<span class="cc-criterion-name">Original-Language Markers</span>';
-    html += '<span class="cc-criterion-expand">▼</span>';
-    html += '</div>';
-    html += '<div class="cc-criterion-evidence">' + detail.linguistic_marker + '</div>';
     html += '</div>';
   }
 

--- a/index.html
+++ b/index.html
@@ -7816,7 +7816,8 @@ function collapsePanelToPeek() {
     panel.classList.remove('cc-type-1', 'cc-type-2', 'cc-type-3', 'cc-type-4', 'cc-type-5', 'cc-type-6', 'cc-type-7', 'cc-dashed');
     
     panel.classList.add('peek-mode');
-    
+    panel.scrollTop = 0;
+
     // Apply CC type-specific styling if we have an active CC visualisation
     if (ccVisState.active && ccVisState.connectionType) {
       panel.classList.add('cc-type-' + ccVisState.connectionType);

--- a/index.html
+++ b/index.html
@@ -8270,28 +8270,6 @@ function generateEvidencePanel(conn) {
   // Content
   html += '<div class="cc-evidence-content">';
   
-  // Primary documentation
-  if (detail.primary_documentation) {
-    html += '<p>' + detail.primary_documentation + '</p>';
-  }
-  
-  // Citation text (for Policy Cascade, Funding Flow)
-  if (detail.citation_text) {
-    html += '<div class="cc-citation">';
-    if (typeof detail.citation_text === 'object') {
-      // Chinese/English pair
-      if (detail.citation_text.chinese) {
-        html += '"' + detail.citation_text.chinese + '"';
-      }
-      if (detail.citation_text.english) {
-        html += '<span class="cc-citation-source">' + detail.citation_text.english + '</span>';
-      }
-    } else {
-      html += '"' + detail.citation_text + '"';
-    }
-    html += '</div>';
-  }
-  
   // Funding breakdown (for Funding Flow)
   if (detail.funding_breakdown) {
     const fb = detail.funding_breakdown;
@@ -8311,53 +8289,9 @@ function generateEvidencePanel(conn) {
     html += '</div>';
   }
   
-  // Criteria assessment (for Parallel Policy) - with expandable evidence
-  if (detail.criteria_assessment) {
-    const ca = detail.criteria_assessment;
-    html += '<div class="cc-criteria-grid">';
-    
-    ['mechanism', 'target', 'scope', 'timing'].forEach(function(criterion) {
-      if (ca[criterion]) {
-        const c = ca[criterion];
-        const statusClass = c.met === true ? 'met' : (c.met === 'partial' ? 'partial' : 'not-met');
-        const statusIcon = c.met === true ? WEO_ICON_CHECK : (c.met === 'partial' ? '◐' : '○');
-        const hasEvidence = c.evidence && c.evidence.length > 0;
-        
-        html += '<div class="cc-criterion' + (hasEvidence ? ' has-evidence' : '') + '"' + (hasEvidence ? ' onclick="this.classList.toggle(\'expanded\')"' : '') + '>';
-        html += '<div class="cc-criterion-header">';
-        html += '<span class="cc-criterion-status ' + statusClass + '">' + statusIcon + '</span>';
-        html += '<span class="cc-criterion-name">' + criterion.charAt(0).toUpperCase() + criterion.slice(1) + '</span>';
-        if (hasEvidence) {
-          html += '<span class="cc-criterion-expand">▼</span>';
-        }
-        html += '</div>';
-        
-        if (hasEvidence) {
-          html += '<div class="cc-criterion-evidence">' + c.evidence + '</div>';
-        }
-        
-        html += '</div>';
-      }
-    });
-    
-    html += '</div>';
-    
-    if (detail.criteria_score) {
-      html += '<div class="cc-criteria-score">';
-      html += '<span class="cc-criteria-score-value">' + detail.criteria_score + '</span>';
-      html += '<span class="cc-criteria-score-label">criteria met</span>';
-      html += '</div>';
-    }
-  }
-  
   // Framework relationship
   if (detail.framework_relationship) {
     html += '<p><strong>Relationship:</strong> ' + detail.framework_relationship + '</p>';
-  }
-
-  // Enabling relationship (for Regulatory Enablement)
-  if (detail.enabling_relationship) {
-    html += '<p><strong>Enabling:</strong> ' + detail.enabling_relationship + '</p>';
   }
 
   // Award comparison cards (for Framework Family CHIPS Act subgroup)
@@ -8400,11 +8334,6 @@ function generateEvidencePanel(conn) {
     html += '<div class="cc-citation">';
     html += '"' + detail.bilateral_statement + '"';
     html += '</div>';
-  }
-  
-  // Transparency note
-  if (detail.transparency_note) {
-    html += '<div class="cc-transparency-note">' + detail.transparency_note + '</div>';
   }
   
   html += '</div>'; // End cc-evidence-content
@@ -8497,38 +8426,6 @@ function generateEvidencePanel(conn) {
     html += '<span class="cc-criterion-expand">▼</span>';
     html += '</div>';
     html += '<div class="cc-criterion-evidence">' + detail.implementation_mapping + '</div>';
-    html += '</div>';
-  }
-
-  // Progressive disclosure: linguistic markers (for Chinese regulatory CCs)
-  if (detail.linguistic_markers) {
-    const lm = detail.linguistic_markers;
-    let lmText = '';
-    if (typeof lm === 'object' && !Array.isArray(lm)) {
-        if (lm.marker) lmText += '"' + lm.marker + '"';
-        if (lm.function) lmText += ' — ' + lm.function;
-    } else if (Array.isArray(lm)) {
-        lmText = lm.map(function(m) { return m.marker ? '"' + m.marker + '" — ' + (m.function || m.translation || '') : String(m); }).join('<br>');
-    } else {
-        lmText = String(lm);
-    }
-    if (lmText) {
-        html += '<div class="cc-criterion has-evidence" onclick="this.classList.toggle(\'expanded\')">';
-        html += '<div class="cc-criterion-header">';
-        html += '<span class="cc-criterion-name">Original-Language Markers</span>';
-        html += '<span class="cc-criterion-expand">▼</span>';
-        html += '</div>';
-        html += '<div class="cc-criterion-evidence">' + lmText + '</div>';
-        html += '</div>';
-    }
-  }
-  if (!detail.linguistic_markers && detail.linguistic_marker) {
-    html += '<div class="cc-criterion has-evidence" onclick="this.classList.toggle(\'expanded\')">';
-    html += '<div class="cc-criterion-header">';
-    html += '<span class="cc-criterion-name">Original-Language Markers</span>';
-    html += '<span class="cc-criterion-expand">▼</span>';
-    html += '</div>';
-    html += '<div class="cc-criterion-evidence">' + detail.linguistic_marker + '</div>';
     html += '</div>';
   }
 


### PR DESCRIPTION
## Summary

- Removes 6 `evidence_detail` sub-fields from `generateEvidencePanel()` in **events.html**, **index.html**, and **atlas.html**: `transparency_note`, `linguistic_markers` (and `linguistic_marker`), `criteria_assessment` (including `criteria_score`), `primary_documentation`, `enabling_relationship`, `citation_text`
- Fields remain intact in the JSON — API consumers are unaffected
- Retained: `evidence_summary` (rendered at the CC row level by `generateCCItem`), `sources` array, CC type/confidence badges, verification history

## Test plan

- [ ] Open events.html → find any event with CCs → expand CC evidence section → no yellow warning box, no "Original-Language Markers", no verbatim citation block; sources and badges still visible
- [ ] Open index.html (map) → open E96 → scroll to Coordination Connections → expand CC evidence → same checks
- [ ] Verified locally by calling `generateEvidencePanel()` directly with a mock CC containing all 6 audit fields — generated HTML contained only the header, empty content div, and sources section; no audit content rendered

🤖 Generated with [Claude Code](https://claude.com/claude-code)