### PR TITLE
fix: add evidence_summary to CC panel, remove transparency_note and linguistic_markers rendering

### DIFF
--- a/atlas.html
+++ b/atlas.html
@@ -9589,6 +9589,9 @@
             h += '</div>';
             // Content
             h += '<div class="cc-evidence-content">';
+            if (conn.evidence_summary) {
+                h += '<p class="cc-evidence-summary">' + escapeHtml(conn.evidence_summary) + '</p>';
+            }
             if (detail.primary_documentation) {
                 h += '<p>' + escapeHtml(detail.primary_documentation) + '</p>';
             }
@@ -9671,9 +9674,6 @@
             if (detail.bilateral_statement) {
                 h += '<div class="cc-citation">"' + escapeHtml(detail.bilateral_statement) + '"</div>';
             }
-            if (detail.transparency_note) {
-                h += '<div class="cc-transparency-note">' + escapeHtml(detail.transparency_note) + '</div>';
-            }
             h += '</div>'; // /.cc-evidence-content
             // Verification History
             if (Array.isArray(conn.verificationHistory) && conn.verificationHistory.length > 1) {
@@ -9739,27 +9739,6 @@
                 h += '</div>';
                 h += '<div class="cc-criterion-evidence">' + escapeHtml(detail.implementation_mapping) + '</div>';
                 h += '</div>';
-            }
-            if (detail.linguistic_markers || detail.linguistic_marker) {
-                const lm = detail.linguistic_markers || detail.linguistic_marker;
-                let lmText = '';
-                if (typeof lm === 'object' && !Array.isArray(lm)) {
-                    if (lm.marker) lmText += '"' + escapeHtml(lm.marker) + '"';
-                    if (lm.function) lmText += ' — ' + escapeHtml(lm.function);
-                } else if (Array.isArray(lm)) {
-                    lmText = lm.map(m => m.marker ? '"' + escapeHtml(m.marker) + '" — ' + escapeHtml(m.function || m.translation || '') : escapeHtml(String(m))).join('<br>');
-                } else {
-                    lmText = escapeHtml(String(lm));
-                }
-                if (lmText) {
-                    h += '<div class="cc-criterion has-evidence" onclick="event.stopPropagation(); this.classList.toggle(\'expanded\')">';
-                    h += '<div class="cc-criterion-header">';
-                    h += '<span class="cc-criterion-name">Original-Language Markers</span>';
-                    h += '<span class="cc-criterion-expand">▼</span>';
-                    h += '</div>';
-                    h += '<div class="cc-criterion-evidence">' + lmText + '</div>';
-                    h += '</div>';
-                }
             }
             if (detail.cross_references) {
                 h += '<div class="cc-transparency-note" style="font-size: 0.85em; opacity: 0.7;">📎 Cross-references documented</div>';

--- a/events.html
+++ b/events.html
@@ -4392,11 +4392,16 @@ function generateEvidencePanel(conn) {
   // Content
   html += '<div class="cc-evidence-content">';
   
+  // Evidence summary (opening paragraph)
+  if (conn.evidence_summary || conn.evidence) {
+    html += '<p class="cc-evidence-summary">' + (conn.evidence_summary || conn.evidence) + '</p>';
+  }
+
   // Primary documentation
   if (detail.primary_documentation) {
     html += '<p>' + detail.primary_documentation + '</p>';
   }
-  
+
   // Citation text (for Policy Cascade, Funding Flow)
   if (detail.citation_text) {
     html += '<div class="cc-citation">';
@@ -4524,11 +4529,6 @@ function generateEvidencePanel(conn) {
     html += '</div>';
   }
   
-  // Transparency note
-  if (detail.transparency_note) {
-    html += '<div class="cc-transparency-note">' + detail.transparency_note + '</div>';
-  }
-  
   html += '</div>'; // End cc-evidence-content
   
   // Verification History (if present)
@@ -4619,38 +4619,6 @@ function generateEvidencePanel(conn) {
     html += '<span class="cc-criterion-expand">▼</span>';
     html += '</div>';
     html += '<div class="cc-criterion-evidence">' + detail.implementation_mapping + '</div>';
-    html += '</div>';
-  }
-
-  // Progressive disclosure: linguistic markers (for Chinese regulatory CCs)
-  if (detail.linguistic_markers) {
-    const lm = detail.linguistic_markers;
-    let lmText = '';
-    if (typeof lm === 'object' && !Array.isArray(lm)) {
-        if (lm.marker) lmText += '"' + lm.marker + '"';
-        if (lm.function) lmText += ' — ' + lm.function;
-    } else if (Array.isArray(lm)) {
-        lmText = lm.map(function(m) { return m.marker ? '"' + m.marker + '" — ' + (m.function || m.translation || '') : String(m); }).join('<br>');
-    } else {
-        lmText = String(lm);
-    }
-    if (lmText) {
-        html += '<div class="cc-criterion has-evidence" onclick="this.classList.toggle(\'expanded\')">';
-        html += '<div class="cc-criterion-header">';
-        html += '<span class="cc-criterion-name">Original-Language Markers</span>';
-        html += '<span class="cc-criterion-expand">▼</span>';
-        html += '</div>';
-        html += '<div class="cc-criterion-evidence">' + lmText + '</div>';
-        html += '</div>';
-    }
-  }
-  if (!detail.linguistic_markers && detail.linguistic_marker) {
-    html += '<div class="cc-criterion has-evidence" onclick="this.classList.toggle(\'expanded\')">';
-    html += '<div class="cc-criterion-header">';
-    html += '<span class="cc-criterion-name">Original-Language Markers</span>';
-    html += '<span class="cc-criterion-expand">▼</span>';
-    html += '</div>';
-    html += '<div class="cc-criterion-evidence">' + detail.linguistic_marker + '</div>';
     html += '</div>';
   }
 

--- a/index.html
+++ b/index.html
@@ -8270,11 +8270,16 @@ function generateEvidencePanel(conn) {
   // Content
   html += '<div class="cc-evidence-content">';
   
+  // Evidence summary (opening paragraph)
+  if (conn.evidence_summary) {
+    html += '<p class="cc-evidence-summary">' + conn.evidence_summary + '</p>';
+  }
+
   // Primary documentation
   if (detail.primary_documentation) {
     html += '<p>' + detail.primary_documentation + '</p>';
   }
-  
+
   // Citation text (for Policy Cascade, Funding Flow)
   if (detail.citation_text) {
     html += '<div class="cc-citation">';
@@ -8402,11 +8407,6 @@ function generateEvidencePanel(conn) {
     html += '</div>';
   }
   
-  // Transparency note
-  if (detail.transparency_note) {
-    html += '<div class="cc-transparency-note">' + detail.transparency_note + '</div>';
-  }
-  
   html += '</div>'; // End cc-evidence-content
   
   // Verification History (if present)
@@ -8497,38 +8497,6 @@ function generateEvidencePanel(conn) {
     html += '<span class="cc-criterion-expand">▼</span>';
     html += '</div>';
     html += '<div class="cc-criterion-evidence">' + detail.implementation_mapping + '</div>';
-    html += '</div>';
-  }
-
-  // Progressive disclosure: linguistic markers (for Chinese regulatory CCs)
-  if (detail.linguistic_markers) {
-    const lm = detail.linguistic_markers;
-    let lmText = '';
-    if (typeof lm === 'object' && !Array.isArray(lm)) {
-        if (lm.marker) lmText += '"' + lm.marker + '"';
-        if (lm.function) lmText += ' — ' + lm.function;
-    } else if (Array.isArray(lm)) {
-        lmText = lm.map(function(m) { return m.marker ? '"' + m.marker + '" — ' + (m.function || m.translation || '') : String(m); }).join('<br>');
-    } else {
-        lmText = String(lm);
-    }
-    if (lmText) {
-        html += '<div class="cc-criterion has-evidence" onclick="this.classList.toggle(\'expanded\')">';
-        html += '<div class="cc-criterion-header">';
-        html += '<span class="cc-criterion-name">Original-Language Markers</span>';
-        html += '<span class="cc-criterion-expand">▼</span>';
-        html += '</div>';
-        html += '<div class="cc-criterion-evidence">' + lmText + '</div>';
-        html += '</div>';
-    }
-  }
-  if (!detail.linguistic_markers && detail.linguistic_marker) {
-    html += '<div class="cc-criterion has-evidence" onclick="this.classList.toggle(\'expanded\')">';
-    html += '<div class="cc-criterion-header">';
-    html += '<span class="cc-criterion-name">Original-Language Markers</span>';
-    html += '<span class="cc-criterion-expand">▼</span>';
-    html += '</div>';
-    html += '<div class="cc-criterion-evidence">' + detail.linguistic_marker + '</div>';
     html += '</div>';
   }
 


### PR DESCRIPTION
## Summary

- Adds `evidence_summary` as the opening paragraph of the expanded CC evidence panel (before `primary_documentation`) in `events.html`, `index.html`, and `atlas.html`. In `events.html`, the field is mapped as `conn.evidence`; in the other two files it is `conn.evidence_summary`.
- Removes `transparency_note` yellow-box rendering (`⚠ Note:` / `.cc-transparency-note` block) — data field remains in JSON.
- Removes `linguistic_markers` / `linguistic_marker` "Original-Language Markers" accordion rendering — data remains in JSON.

All other type-specific evidence fields are **untouched**: `primary_documentation`, `citation_text` (incl. Chinese/English pair), `funding_breakdown`, `criteria_assessment` 4-card grid, `criteria_score`, `framework_relationship`, `enabling_relationship`, `hierarchical_relationship`, `implementation_mapping`, `bilateral_statement`, `award_a/award_b`, `normative_reference`, `cross_references`, `conditions`, `sources`, `verification_history`, `verified_date` header.

This is a scoped 3-change fix following the revert of #127 (which over-removed 277 lines). Scope is exactly 3 rendering suppressions + 1 rendering addition.

## Test plan

- [ ] Open a CC with `evidence_summary` — confirm opening paragraph appears before `primary_documentation`
- [ ] Open a Type 3 CC — confirm `funding_breakdown` grid renders
- [ ] Open a Type 4 CC — confirm `enabling_relationship` renders
- [ ] Open a Type 6 CC — confirm `framework_relationship` renders
- [ ] Open a Type 7 CC — confirm `criteria_assessment` 4-card grid renders
- [ ] Confirm no yellow warning box (`transparency_note`) appears on any CC panel
- [ ] Confirm no "Original-Language Markers" accordion appears on any CC panel
- [ ] Verify in all three pages: events.html, index.html, atlas.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)