### PR TITLE
fix: Type 4 CC label Enabling → Enablement

### DIFF
--- a/atlas.html
+++ b/atlas.html
@@ -9649,7 +9649,7 @@
                 h += '<p><strong>Relationship:</strong> ' + escapeHtml(detail.framework_relationship) + '</p>';
             }
             if (detail.enabling_relationship) {
-                h += '<p><strong>Enabling:</strong> ' + escapeHtml(detail.enabling_relationship) + '</p>';
+                h += '<p><strong>Enablement:</strong> ' + escapeHtml(detail.enabling_relationship) + '</p>';
             }
             if (detail.award_a && detail.award_b) {
                 h += '<div class="cc-funding-grid">';

--- a/events.html
+++ b/events.html
@@ -4484,7 +4484,7 @@ function generateEvidencePanel(conn) {
 
   // Enabling relationship (for Regulatory Enablement)
   if (detail.enabling_relationship) {
-    html += '<p><strong>Enabling:</strong> ' + detail.enabling_relationship + '</p>';
+    html += '<p><strong>Enablement:</strong> ' + detail.enabling_relationship + '</p>';
   }
 
   // Award comparison cards (for Framework Family CHIPS Act subgroup)

--- a/index.html
+++ b/index.html
@@ -8362,7 +8362,7 @@ function generateEvidencePanel(conn) {
 
   // Enabling relationship (for Regulatory Enablement)
   if (detail.enabling_relationship) {
-    html += '<p><strong>Enabling:</strong> ' + detail.enabling_relationship + '</p>';
+    html += '<p><strong>Enablement:</strong> ' + detail.enabling_relationship + '</p>';
   }
 
   // Award comparison cards (for Framework Family CHIPS Act subgroup)


### PR DESCRIPTION
## Summary

One-word label change in `generateEvidencePanel()` across `events.html`, `index.html`, and `atlas.html`.

- **Before:** `<strong>Enabling:</strong>`
- **After:** `<strong>Enablement:</strong>`

**Why:** "Enabling:" is a directional verb that contradicts the target event's section header ("← ENABLED BY / RESPONDS TO"). All other CC types with prose labels use direction-neutral nouns — "Hierarchy:" (Type 1), "Relationship:" (Type 6). Section headers already handle direction universally; the evidence label should describe the field type, not direction.

Affects all 10 Type 4 CCs across all rendered instances. No JSON data, CSS, interaction JS, or other labels touched.

## Test plan

- [ ] events.html → E96 (UNIDO AIM) → CC section → label reads **"Enablement:"**
- [ ] events.html → E53 (UNGA Resolution) → CC section → label reads **"Enablement:"**
- [ ] events.html → E30 (EU AI Act) → any Type 4 CC → label reads **"Enablement:"**
- [ ] index.html → E96 → CC section → label reads **"Enablement:"**
- [ ] Confirm no Type 4 CC anywhere still shows "Enabling:"

🤖 Generated with [Claude Code](https://claude.com/claude-code)