### PR TITLE
Loop 21 QC corrections: E185, E187, E53/E54 relatedEvents, CC-53-96-4

### DIFF
--- a/data/events-free.json
+++ b/data/events-free.json
@@ -6913,7 +6913,7 @@
       "location": "United States",
       "scope": "United States (with extraterritorial supply-chain implications for critical mineral and battery component sourcing)",
       "description": "The IRA Section 30D Foreign Entity of Concern Final Rule (89 FR 37706), published 06 May 2024, conditions clean vehicle tax credit eligibility on battery component and critical mineral supply chain provenance under the Inflation Reduction Act. A concurrent DOE Interpretive Rule defines FEOC determination criteria.",
-      "investment": "N/A (regulatory instrument). Phased exclusion: battery components from 2024, critical minerals from 2025; Section 30D credit value US$7,500/US$3,750 per vehicle; qualifying models reduced from 43 to 19; covered nations: PRC, Russia, DPRK, Iran.",
+      "investment": "Fiscal conditionality (no direct financial allocation); phased exclusion: battery components from 2024, critical minerals from 2025; Section 30D credit value US$7,500/US$3,750 per vehicle; qualifying models reduced from 43 to 19; covered nations: PRC, Russia, DPRK, Iran.",
       "domain": "Trade",
       "industryPrimary": "Trade & Logistics",
       "environmentalNexusTags": [],

--- a/data/events-free.json
+++ b/data/events-free.json
@@ -1,0 +1,6962 @@
+{
+  "metadata": {
+    "version": "1.6",
+    "total_events": 159,
+    "sample_events": 6,
+    "standard_events": 153,
+    "last_updated": "2026-06-03",
+    "source": "Extracted from index.html (WEO Map v1.25+)",
+    "statistics": {
+      "by_bloc": {
+        "Eastern": 45,
+        "Western": 96,
+        "Western-Led": 13,
+        "Eastern-Led": 4,
+        "Cross-Bloc": 1
+      },
+      "by_tier": {
+        "T3": 141,
+        "T2": 17,
+        "T1": 1
+      },
+      "by_type": {
+        "Infrastructure": 43,
+        "Coordination": 29,
+        "Policy": 41,
+        "Corporate": 46
+      },
+      "by_confidence": {
+        "A": 155,
+        "B": 4
+      },
+      "by_assessment_pathway": {
+        "basel5": 86,
+        "keohane": 28,
+        "pisa5": 26,
+        "routeBased": 19,
+        "oep": 6,
+        "piet": 4
+      },
+      "by_industry_primary": {
+        "Cloud, Data Centres & Connectivity Infrastructure": 46,
+        "Semiconductors & Equipment": 30,
+        "AI Software & Platforms": 59,
+        "Mining & Critical Minerals": 5,
+        "Defence & Aerospace": 9,
+        "Financial Services & Investment": 3,
+        "Energy & Power Infrastructure": 5,
+        "Automotive & Manufacturing": 1,
+        "Trade & Logistics": 1
+      },
+      "by_version": {
+        "1.2": 45,
+        "1.3": 11,
+        "1.1": 60,
+        "1.4": 1,
+        "1.0": 41,
+        "1.1.2": 1
+      }
+    },
+    "versionDate": "2026-06-03",
+    "lastAudit": "2026-06-03",
+    "auditDescription": "Loop 16: 2 new events added (E166 Cambricon SiYuan 590, E167 Biren BR100/BR106). 0 CCs added. Metadata fully recomputed from event array.",
+    "event_count": 159,
+    "version_note": "V1.3: Principal actor framework + Level 5 operational evidence retrospective application. 12 T1 reclassifications (1 maintained T1, 5 reclassified to T3, 6 removed). 1 additional event removed (Level 5 failure). 9 CCs removed.",
+    "ent_version": "1.0",
+    "ent_tagged_events": 47,
+    "ent_total_tags": 75,
+    "wer": {
+      "value": 6.6,
+      "formula": "ENT-1 (33) ÷ ENT-5 (5)"
+    },
+    "tier": "free"
+  },
+  "events": [
+    {
+      "id": "01",
+      "name": "China East Data West Compute Infrastructure Network",
+      "lat": 26.642,
+      "lng": 106.63,
+      "bloc": "Eastern",
+      "tier": 3,
+      "type": "Infrastructure",
+      "sample": true,
+      "date": "February 2022",
+      "location": "Guiyang, China",
+      "scope": "China national (8 computing hubs, 10 data centre clusters)",
+      "description": "National integrated big data centre system channelling computing resources from eastern to western China. Establishes eight national computing hubs with 215.5 EFLOPS aggregate hub capacity (Q1 2025).",
+      "investment": "RMB 43.5B direct government investment (~US$6.1B); ~US$28B total leveraged",
+      "domain": "Energy/Infrastructure",
+      "sources": 3,
+      "corroborating": 4,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.2",
+      "basel5": [
+        {
+          "factor": "Size",
+          "pass": true,
+          "rationale": "US$6.1B direct/~US$28B total investment far exceeds US$500M threshold"
+        },
+        {
+          "factor": "Interconnectedness",
+          "pass": true,
+          "rationale": "Creates national computing backbone enabling AI model training at scale; reduces dependency on foreign cloud providers"
+        },
+        {
+          "factor": "Substitutability",
+          "pass": true,
+          "rationale": "Unique national-scale intelligent computing network; no comparable domestic alternative"
+        },
+        {
+          "factor": "Complexity",
+          "pass": true,
+          "rationale": "Multi-year construction (2022-2025+) with cutting-edge AI infrastructure across 8 hubs"
+        },
+        {
+          "factor": "Cross-jurisdictional",
+          "pass": true,
+          "rationale": "Strengthens Eastern Bloc AI capability concentration; affects global AI compute distribution"
+        }
+      ],
+      "tierRationale": "Tier 3: Intra-Bloc Coordination (Eastern). Official Chinese government documentation frames the initiative as domestic economic development, digital economy support, and regional resource optimisation. Policy documents do not explicitly name the United States or Western entities as targets for dependency reduction. National infrastructure programme channelling computing resources from eastern to western China across eight national computing hubs and ten data centre clusters.",
+      "blocAnalysis": [
+        {
+          "bloc": "Western",
+          "involvement": "No",
+          "role": ""
+        },
+        {
+          "bloc": "Eastern",
+          "involvement": "Yes",
+          "role": "China (sole implementer)"
+        },
+        {
+          "bloc": "Non-Aligned",
+          "involvement": "No",
+          "role": ""
+        }
+      ],
+      "primarySources": [
+        {
+          "id": "P1",
+          "desc": "Gov.cn — RMB 43.5B direct investment confirmed",
+          "url": "https://english.www.gov.cn/news/202408/29/content_WS66d03a1ac6d0868f4e8ea539.html",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429071432/https://english.www.gov.cn/news/202408/29/content_WS66d03a1ac6d0868f4e8ea539.html"
+        },
+        {
+          "id": "P2",
+          "desc": "Gov.cn — 60% of new computing capacity concentrated in 8 hubs",
+          "url": "https://english.www.gov.cn/news/202312/27/content_WS658b72afc6d0868f4e8e28ba.html",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429070419/https://english.www.gov.cn/news/202312/27/content_WS658b72afc6d0868f4e8e28ba.html"
+        },
+        {
+          "id": "P3",
+          "desc": "Gov.cn — Computing power expansion plans",
+          "url": "https://english.www.gov.cn/news/202508/28/content_WS68b00fe2c6d0868f4e8f522a.html",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429071819/https://english.www.gov.cn/news/202508/28/content_WS68b00fe2c6d0868f4e8f522a.html"
+        }
+      ],
+      "corroboratingSources": [
+        {
+          "id": "C1",
+          "desc": "Futunn News — 80.8% intelligent computing share",
+          "url": "https://news.futunn.com/en/post/56125572/hong-kong-stock-concept-tracking-the-scale-of-intelligent-computing",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429084346/https://news.futunn.com/en/post/56125572/hong-kong-stock-concept-tracking-the-scale-of-intelligent-computing"
+        },
+        {
+          "id": "C2",
+          "desc": "DC Pulse — EDWC strategic analysis",
+          "url": "https://dcpulse.com/article/china-cloud-edwc-eastern-data-western-computing",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429061225/https://dcpulse.com/article/china-cloud-edwc-eastern-data-western-computing"
+        },
+        {
+          "id": "C3",
+          "desc": "Data Center Dynamics — $6.1B investment figure confirmed",
+          "url": "https://www.datacenterdynamics.com/en/news/china-has-spent-61bn-building-data-centers-in-the-past-two-years/",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429143631/https://www.datacenterdynamics.com/en/news/china-has-spent-61bn-building-data-centers-in-the-past-two-years/"
+        },
+        {
+          "id": "C4",
+          "desc": "China Briefing — Cross-regional computing plan",
+          "url": "https://www.china-briefing.com/news/china-data-centers-new-cross-regional-plan-to-boost-computing-power-across-regions/",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429130846/https://www.china-briefing.com/news/china-data-centers-new-cross-regional-plan-to-boost-computing-power-across-regions/"
+        }
+      ],
+      "relatedEvents": [
+        {
+          "id": "03",
+          "relationship": "Both represent China's AI infrastructure investment strategy"
+        },
+        {
+          "id": "41",
+          "relationship": "Policy framework for EDWC expansion"
+        }
+      ],
+      "industryPrimary": "Cloud, Data Centres & Connectivity Infrastructure",
+      "industrySecondary": [
+        {
+          "tag": "Energy & Power Infrastructure",
+          "mechanism": "The EDWC plan mandates coordinated development of renewable energy infrastructure to power western data centre hubs."
+        }
+      ],
+      "environmentalNexusTags": [
+        {
+          "type": "ENT-2",
+          "name": "Environmental Enablement",
+          "mechanism": "EDWC mandates renewable energy integration for western computing hubs, with binding implementation through GB 40879-2021 and provincial enforcement.",
+          "evidenceBasis": "Documented",
+          "sources": [
+            {
+              "citation": "NDRC EDWC Programme Document (发改高技〔2021〕709号)",
+              "type": "primary",
+              "url": "https://www.ndrc.gov.cn/xxgk/zcfb/tz/202105/t20210526_1280838.html",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429044858/https://www.ndrc.gov.cn/xxgk/zcfb/tz/202105/t20210526_1280838.html"
+            },
+            {
+              "citation": "GB 40879-2021 (数据中心能效限定值及能效等级), Standardization Administration of China",
+              "type": "primary",
+              "url": "https://openstd.samr.gov.cn/bzgk/gb/newGbInfo?hcno=4AAF5CA9387980A1FEA1FA47ABA503BA",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429043625/https://openstd.samr.gov.cn/bzgk/std/newGbInfo?hcno=4AAF5CA9387980A1FEA1FA47ABA503BA"
+            }
+          ]
+        },
+        {
+          "type": "ENT-5",
+          "name": "Environmental Coordination",
+          "mechanism": "EDWC programme generates binding environmental operational requirements on compute infrastructure through GB 40879-2021 mandatory PUE standards and provincial administrative-approval enforcement.",
+          "evidenceBasis": "Documented",
+          "pathway": "A",
+          "sources": [
+            {
+              "citation": "[EB Benchmark] (Pathway A) Evidence Chain",
+              "type": "primary",
+              "url": "https://doi.org/10.5281/zenodo.18427582",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429040553/https://zenodo.org/records/19366463"
+            },
+            {
+              "citation": "Chinese Cascade Model",
+              "type": "primary",
+              "url": "https://doi.org/10.5281/zenodo.18427582",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429040553/https://zenodo.org/records/19366463"
+            }
+          ]
+        }
+      ],
+      "versionDate": "2026-05-22",
+      "basel5_factors_met": 5
+    },
+    {
+      "id": "02",
+      "name": "TSMC Japan Kumamoto Fab (JASM)",
+      "lat": 32.85,
+      "lng": 130.8,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Infrastructure",
+      "sample": false,
+      "date": "December 2024",
+      "location": "Kikuyo Town, Kumamoto Prefecture, Japan",
+      "scope": "Kikuyo Town, Kumamoto Prefecture, Japan",
+      "description": "Advanced-logic semiconductor fab producing 12/16 nm FinFET and 22/28 nm logic chips for automotive and image-sensor applications. Second fab under construction extending to 6/7 nm for autonomous vehicle SoCs.",
+      "investment": "Japanese subsidies up to JPY 1.208T (~US$8B); ~US$8.6B first fab; >US$20B total complex",
+      "domain": "Energy/Infrastructure",
+      "sources": 3,
+      "corroborating": 4,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.2",
+      "industryPrimary": "Semiconductors & Equipment",
+      "environmentalNexusTags": [
+        {
+          "type": "ENT-1",
+          "name": "Resource Demand",
+          "mechanism": "TSMC JASM operates under Kumamoto prefectural groundwater preservation ordinances, consuming 7,500 metric tons of groundwater per day for UPW and cooling, documented in EIA commitments.",
+          "evidenceBasis": "Documented",
+          "vector": "Water",
+          "sources": [
+            {
+              "citation": "TSMC Kumamoto groundwater reporting, Japan Times",
+              "type": "corroborating",
+              "url": "https://www.japantimes.co.jp/business/2025/12/26/companies/tsmc-kumamoto-plant-groundwater-concerns/",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429044642/https://www.japantimes.co.jp/business/2025/12/26/companies/tsmc-kumamoto-plant-groundwater-concerns/"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "03",
+      "name": "China National Integrated Circuit Industry Investment Fund (Big Fund III)",
+      "lat": 39.9042,
+      "lng": 116.4074,
+      "bloc": "Eastern",
+      "tier": 3,
+      "type": "Infrastructure",
+      "sample": false,
+      "date": "24 May 2024",
+      "location": "Beijing, China",
+      "scope": "China (national-level investment fund)",
+      "description": "China's third and largest state-backed semiconductor investment fund at time of establishment, with RMB 344B (US$47.5B) registered capital. Targets AI chips, memory (DRAM/HBM), semiconductor equipment and materials for technological self-sufficiency.",
+      "investment": "RMB 344B (US$47.5B) registered capital; US$8.2B dedicated AI fund; 15-year duration",
+      "domain": "Energy/Infrastructure",
+      "sources": 2,
+      "corroborating": 3,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.3",
+      "industryPrimary": "Semiconductors & Equipment"
+    },
+    {
+      "id": "04",
+      "name": "IEEE P7000 Series AI Ethics Standards",
+      "lat": 40.7128,
+      "lng": -74.006,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Coordination",
+      "sample": true,
+      "date": "2021-2023",
+      "location": "New York City, USA",
+      "scope": "International (IEEE global membership)",
+      "description": "Suite of IEEE standards for ethical AI system design including P7000 (Model Process), P7001 (Transparency), P7002 (Data Privacy), and P7003 (Algorithmic Bias).",
+      "investment": "Standards Framework",
+      "domain": "Technology",
+      "sources": 4,
+      "corroborating": 3,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.2",
+      "keohane": [
+        {
+          "factor": "Type",
+          "pass": true,
+          "rationale": "Keohane Type 2 — Institutional Consensus Standard"
+        },
+        {
+          "factor": "Coordination Evidence",
+          "pass": true,
+          "rationale": "IEEE SA individual-participation process; 850+ global experts including US, EU, China, India, Japan, Korea; ISO-adopted via SC 7 (40 P-members)"
+        },
+        {
+          "factor": "Implementation",
+          "pass": true,
+          "rationale": "CertifAIEd operational with 167 assessors across 28 countries; Wiener Stadtwerke pilot completed; ISO/IEC/IEEE 24748-7000 adopted"
+        },
+        {
+          "factor": "Cross-Bloc Participation",
+          "pass": true,
+          "rationale": "Genuine cross-bloc technical coordination — both Western and Eastern blocs participated in creating the standard"
+        }
+      ],
+      "tierRationale": "Tier 3: Intra-Bloc Coordination (Western). Developed through IEEE SA’s individual-participation process with cross-bloc expert engagement from both Western and Eastern Bloc participants. CertifAIEd conformity assessment programme establishes operational reach, with ISO/IEC/IEEE 24748-7000:2022 fast-track adoption through JTC 1/SC 7 extending normative coverage. Cross-bloc development participation verified through the individual-participation model; operational conformity assessment activity, professional training infrastructure, and documented organisational adoption concentrated within Western-aligned jurisdictions including Germany, the United States, and the United Kingdom.",
+      "blocAnalysis": [
+        {
+          "bloc": "Western",
+          "involvement": "Yes",
+          "role": "US, UK, Germany, France, Japan (IEEE SA participants)"
+        },
+        {
+          "bloc": "Eastern",
+          "involvement": "Yes",
+          "role": "China, Russia (IEEE SA participants)"
+        },
+        {
+          "bloc": "Non-Aligned",
+          "involvement": "Yes",
+          "role": "India, Brazil (IEEE SA participants)"
+        }
+      ],
+      "primarySources": [
+        {
+          "id": "P1",
+          "desc": "IEEE Standards Association — P7000-2021 Standard",
+          "url": "https://standards.ieee.org/standard/7000-2021.html",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429104446/https://standards.ieee.org/ieee/7000/6781/"
+        },
+        {
+          "id": "P2",
+          "desc": "IEEE — ISO/IEC/IEEE 24748-7000",
+          "url": "https://standards.ieee.org/ieee/24748-7000/11098/",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429104134/https://standards.ieee.org/ieee/24748-7000/11098/"
+        },
+        {
+          "id": "P3",
+          "desc": "ISO — ISO/IEC 42001 AI Management Standard",
+          "url": "https://www.iso.org/standard/84893.html",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429174100/https://www.iso.org/standard/84893.html"
+        },
+        {
+          "id": "P4",
+          "desc": "ISO Committee — SC 42 Participation",
+          "url": "https://committee.iso.org/committee/45086.html?view=participation",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429060409/https://committee.iso.org/committee/45086.html?view=participation"
+        }
+      ],
+      "corroboratingSources": [
+        {
+          "id": "C1",
+          "desc": "IEEE News — IEEE 7000 announcement",
+          "url": "https://standards.ieee.org/news/ieee-7000/",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429104303/https://standards.ieee.org/news/ieee-7000/"
+        },
+        {
+          "id": "C2",
+          "desc": "IEEE — CertifAIEd Framework Vienna case study",
+          "url": "https://standards.ieee.org/beyond-standards/the-ieee-certifaied-framework-for-ai-ethics-applied-to-the-city-of-vienna/",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429104036/https://standards.ieee.org/beyond-standards/the-ieee-certifaied-framework-for-ai-ethics-applied-to-the-city-of-vienna/"
+        },
+        {
+          "id": "C3",
+          "desc": "VBE Academy — Austrian Standards AI certification",
+          "url": "https://vbe.academy/insights/post/austrian-standards-launches-first-european-certification-for-ethical-ai/",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429112834/https://vbe.academy/insights/post/austrian-standards-launches-first-european-certification-for-ethical-ai/"
+        }
+      ],
+      "relatedEvents": [
+        {
+          "id": "19",
+          "relationship": "Related ISO/IEC AI management standard"
+        }
+      ],
+      "versionDate": "2026-03-04",
+      "industryPrimary": "AI Software & Platforms",
+      "industrySecondary": [],
+      "ecosystemImplementation": [
+        {
+          "ecosystem": "US-centred",
+          "implemented": true,
+          "evidence": "CertifAIEd operational with assessors in US, UK, Germany; ISO/IEC/IEEE 24748-7000 adopted through JTC 1"
+        },
+        {
+          "ecosystem": "China-centred",
+          "implemented": false,
+          "evidence": "IEEE SA development participation; no Chinese national adoption or conformity assessment activity verified"
+        }
+      ],
+      "keohane_factors_met": 4
+    },
+    {
+      "id": "05",
+      "name": "Japan Economic Security Promotion Act (ESPA)",
+      "lat": 35.6762,
+      "lng": 139.6503,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Policy",
+      "sample": false,
+      "date": "11 May 2022",
+      "location": "Tokyo, Japan",
+      "scope": "Japan (nationwide)",
+      "description": "Comprehensive economic security legislation establishing four pillars: (1) stable supply of critical products, (2) essential infrastructure services, (3) support for critical technologies including AI/quantum, and (4) patent non-disclosure.",
+      "investment": "JPY 958.2B (~US$6.4B) critical products; JPY 500B (~US$3.3B) K Program for critical technologies",
+      "domain": "Security",
+      "sources": 3,
+      "corroborating": 4,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.3",
+      "industryPrimary": "Semiconductors & Equipment"
+    },
+    {
+      "id": "06",
+      "name": "US CHIPS and Science Act of 2022",
+      "lat": 38.9072,
+      "lng": -77.0369,
+      "bloc": "Western-Led",
+      "tier": 2,
+      "type": "Policy",
+      "sample": true,
+      "date": "August 2022",
+      "location": "Washington, DC, United States",
+      "scope": "United States (with extraterritorial provisions)",
+      "description": "Landmark US$280B legislation establishing semiconductor manufacturing incentives, research investment, and workforce development programmes. Creates extraterritorial operating restrictions on funded entities, reshaping global semiconductor supply chain geography.",
+      "investment": "US$280B authorized (US$52.7B CHIPS funding)",
+      "domain": "Energy/Infrastructure",
+      "sources": 7,
+      "corroborating": 4,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.1",
+      "basel5": [
+        {
+          "factor": "Size",
+          "pass": true,
+          "rationale": "US$280B authorized (US$52.7B direct CHIPS funding) far exceeds US$500M threshold"
+        },
+        {
+          "factor": "Interconnectedness",
+          "pass": true,
+          "rationale": "Restructures global semiconductor supply chains; attracts TSMC, Samsung, Intel expansion"
+        },
+        {
+          "factor": "Substitutability",
+          "pass": true,
+          "rationale": "Creates alternative to Asia-concentrated manufacturing; only US programme at this scale"
+        },
+        {
+          "factor": "Complexity",
+          "pass": true,
+          "rationale": "Multi-year implementation (FY2023-2027); cutting-edge process nodes"
+        },
+        {
+          "factor": "Cross-jurisdictional",
+          "pass": true,
+          "rationale": "Affects manufacturing decisions by TSMC, Samsung, Intel globally; restricts China expansion"
+        }
+      ],
+      "tierRationale": "Tier 2: Between-Bloc Fragmentation (Buildout). Section 103 guardrails explicitly prohibit funded entities from China expansion, creating binding cross-bloc operating restrictions. Meets multiple Tier 2 criteria with explicit China targeting: dependency reduction language referencing Taiwan/China risk; national security and China co-mention in White House Fact Sheet; supply chain resilience framed around China concerns. Funding conditions create between-bloc fragmentation through explicit prohibitions on recipient operations in countries of concern.",
+      "blocAnalysis": [
+        {
+          "bloc": "Western",
+          "involvement": "Yes",
+          "role": "United States (primary); attracts TSMC, Samsung, Intel"
+        },
+        {
+          "bloc": "Eastern",
+          "involvement": "No",
+          "role": ""
+        },
+        {
+          "bloc": "Non-Aligned",
+          "involvement": "No",
+          "role": ""
+        }
+      ],
+      "primarySources": [
+        {
+          "id": "P1",
+          "desc": "Public Law 117-167 (CHIPS and Science Act full text)",
+          "url": "https://www.govinfo.gov/content/pkg/PLAW-117publ167/html/PLAW-117publ167.htm",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429165155/https://www.govinfo.gov/content/pkg/PLAW-117publ167/html/PLAW-117publ167.htm"
+        },
+        {
+          "id": "P2",
+          "desc": "Congress.gov bill text",
+          "url": "https://www.congress.gov/bill/117th-congress/house-bill/4346/text",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429135719/https://www.congress.gov/bill/117th-congress/house-bill/4346/text"
+        },
+        {
+          "id": "P3",
+          "desc": "NIST CHIPS program page",
+          "url": "https://www.nist.gov/chips",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429185041/https://www.nist.gov/chips"
+        },
+        {
+          "id": "P4",
+          "desc": "NIST CHIPS America Fact Sheet",
+          "url": "https://www.nist.gov/document/chips-america-fact-sheet-federal-incentives",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429185354/https://www.nist.gov/system/files/documents/2024/04/22/Fact%20Sheet%20-%20Federal%20Incentives-updated-508C.pdf"
+        },
+        {
+          "id": "P5",
+          "desc": "White House Fact Sheet — 'counter China'",
+          "url": "https://bidenwhitehouse.archives.gov/briefing-room/statements-releases/2022/08/09/fact-sheet-chips-and-science-act-will-lower-costs-create-jobs-strengthen-supply-chains-and-counter-china/",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429053628/https://bidenwhitehouse.archives.gov/briefing-room/statements-releases/2022/08/09/fact-sheet-chips-and-science-act-will-lower-costs-create-jobs-strengthen-supply-chains-and-counter-china/"
+        },
+        {
+          "id": "P6",
+          "desc": "NIST AI Congressional Mandates",
+          "url": "https://www.nist.gov/artificial-intelligence/ai-congressional-mandates-executive-orders-and-actions",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429184819/https://www.nist.gov/artificial-intelligence/ai-congressional-mandates-executive-orders-and-actions"
+        },
+        {
+          "id": "P7",
+          "desc": "Commerce Dept CHIPS bulletin",
+          "url": "https://content.govdelivery.com/accounts/USDOC/bulletins/3c823cf",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429060519/https://content.govdelivery.com/accounts/USDOC/bulletins/3c823cf"
+        }
+      ],
+      "corroboratingSources": [
+        {
+          "id": "C1",
+          "desc": "CRS Report on CHIPS Act",
+          "url": "https://crsreports.congress.gov/product/pdf/R/R47523",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429060903/https://crsreports.congress.gov/product/pdf/R/R47523"
+        },
+        {
+          "id": "C2",
+          "desc": "National Governors Association CHIPS resources",
+          "url": "https://www.nga.org/chips-resources/",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429184752/https://www.nga.org/chips-resources/"
+        },
+        {
+          "id": "C3",
+          "desc": "US Chamber of Commerce CHIPS anniversary",
+          "url": "https://www.uschamber.com/technology/chips-and-science-act-anniversary-progress-made-but-work-remains",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429213550/https://www.uschamber.com/technology/chips-and-science-act-anniversary-progress-made-but-work-remains"
+        },
+        {
+          "id": "C4",
+          "desc": "Data Center Dynamics — SK Hynix CHIPS funding",
+          "url": "https://www.datacenterdynamics.com/en/news/sk-hynix-secures-458m-in-chips-act-funding/",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429144840/https://www.datacenterdynamics.com/en/news/sk-hynix-secures-458m-in-chips-act-funding/"
+        }
+      ],
+      "relatedEvents": [
+        {
+          "id": "10",
+          "relationship": "Coordinated export control strategy"
+        }
+      ],
+      "versionDate": "2026-03-04",
+      "industryPrimary": "Semiconductors & Equipment",
+      "industrySecondary": [
+        {
+          "tag": "Trade & Logistics",
+          "mechanism": "The Guardrails Rule prohibits CHIPS-funded entities from expanding semiconductor manufacturing in foreign countries of concern."
+        },
+        {
+          "tag": "Financial Services & Investment",
+          "mechanism": "Section 48D provides a 25% Advanced Manufacturing Investment Tax Credit and US$39B in direct subsidies."
+        }
+      ],
+      "basel5_factors_met": 5
+    },
+    {
+      "id": "07",
+      "name": "China Interim Measures for Generative AI Services",
+      "lat": 39.9042,
+      "lng": 116.4074,
+      "bloc": "Eastern",
+      "tier": 3,
+      "type": "Policy",
+      "sample": false,
+      "date": "15 August 2023",
+      "location": "Beijing, China",
+      "scope": "People's Republic of China (Mainland)",
+      "description": "First comprehensive regulation specifically targeting generative AI services in China. Establishes framework for content security, algorithm filing, and security assessments. Requires providers to uphold socialist core values while encouraging innovation in AI infrastructure.",
+      "investment": "Regulatory Framework (Penalties up to 10M RMB via Data Security Law linkage)",
+      "domain": "Technology",
+      "sources": 2,
+      "corroborating": 2,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.1",
+      "industryPrimary": "AI Software & Platforms"
+    },
+    {
+      "id": "08",
+      "name": "NIST AI Risk Management Framework (AI RMF 1.0)",
+      "lat": 39.1434,
+      "lng": -77.2014,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Coordination",
+      "sample": false,
+      "date": "26 January 2023",
+      "location": "Gaithersburg, Maryland, United States",
+      "scope": "Global (US-led with G7/OECD adoption)",
+      "description": "Voluntary, consensus-driven framework developed by NIST to manage risks associated with AI systems. Serves as foundational document for international AI governance with alignment from EU, Japan, UK, Canada, and Australia.",
+      "investment": "N/A (Framework) — Coordination Threshold: G7+ adoption demonstrated",
+      "domain": "Technology",
+      "sources": 2,
+      "corroborating": 5,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.2",
+      "industryPrimary": "AI Software & Platforms"
+    },
+    {
+      "id": "10",
+      "name": "Netherlands-Japan-US Semiconductor Export Controls Coordination",
+      "lat": 38.9072,
+      "lng": -77.0369,
+      "bloc": "Western-Led",
+      "tier": 2,
+      "type": "Coordination",
+      "sample": false,
+      "date": "July 2023",
+      "location": "Washington, DC, United States",
+      "scope": "United States, Netherlands, Japan (global impact)",
+      "description": "Coordinated trilateral agreement restricting export of advanced semiconductor manufacturing equipment to China, implemented via aligned national regulations targeting immersion lithography and advanced chip-making tools. Netherlands controls include ASML TWINSCAN NXT:2000i, NXT:2050i, and NXT:2100i DUV immersion systems.",
+      "investment": "Trade value affected >US$50M (ASML/Tokyo Electron)",
+      "domain": "Security",
+      "sources": 3,
+      "corroborating": 5,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.1",
+      "industryPrimary": "Semiconductors & Equipment"
+    },
+    {
+      "id": "11",
+      "name": "Intel CHIPS and Science Act Award",
+      "lat": 38.9072,
+      "lng": -77.0369,
+      "bloc": "Western-Led",
+      "tier": 2,
+      "type": "Policy",
+      "sample": false,
+      "date": "26 November 2024",
+      "location": "Washington, DC, United States",
+      "scope": "United States (Arizona, New Mexico, Ohio, Oregon)",
+      "description": "US Department of Commerce finalised CHIPS and Science Act incentives award to Intel Corporation, supporting commercial semiconductor manufacturing and advanced packaging across Arizona, New Mexico, Ohio, and Oregon. Largest domestic CHIPS Act award, reinforcing US-based leading-edge chip production capacity.",
+      "investment": "US$7.86 billion direct funding; US$100+ billion total investment",
+      "domain": "Energy/Infrastructure",
+      "sources": 3,
+      "corroborating": 2,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.2",
+      "industryPrimary": "Semiconductors & Equipment",
+      "environmentalNexusTags": [
+        {
+          "type": "ENT-1",
+          "name": "Resource Demand",
+          "mechanism": "Intel Ocotillo operates under Industrial User Permit No. 009 (City of Chandler) and APP P-100140 (ADEQ), with dedicated water reclamation via the Ocotillo Brine Reduction Facility.",
+          "evidenceBasis": "Documented",
+          "vector": "Water",
+          "sources": [
+            {
+              "citation": "Draft Environmental Assessment NIST-CPO/EA-003, NIST CHIPS Program Office",
+              "type": "primary",
+              "url": "https://www.nist.gov/system/files/documents/2024/07/08/Intel%20Ocotillo%20EA_DRAFT%20FINAL_VOLUME%201%208July2024.pdf",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429045115/https://www.nist.gov/system/files/documents/2024/07/08/Intel%20Ocotillo%20EA_DRAFT%20FINAL_VOLUME%201%208July2024.pdf"
+            }
+          ]
+        },
+        {
+          "type": "ENT-4",
+          "name": "Environmental Dependency",
+          "mechanism": "Intel Ocotillo fabs in Chandler, AZ operate in WRI Aqueduct 'Extremely High' water stress zone (West Salt River Valley) and require continuous water-based cooling and UPW, with municipal co-dependency documented in ADEQ permits.",
+          "evidenceBasis": "Assessed",
+          "dependencyType": "Water stress",
+          "riskIndex": "WRI Aqueduct",
+          "sources": [
+            {
+              "citation": "WRI Aqueduct Water Risk Atlas 4.0 — West Salt River Valley sub-basin",
+              "type": "corroborating",
+              "url": "https://www.wri.org/aqueduct",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429045504/https://www.wri.org/aqueduct"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "12",
+      "name": "European Chips Act",
+      "lat": 50.8503,
+      "lng": 4.3517,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Policy",
+      "sample": false,
+      "date": "21 September 2023",
+      "location": "Brussels, Belgium",
+      "scope": "European Union (27 Member States)",
+      "description": "EU-wide regulation to strengthen the semiconductor ecosystem, including advanced and AI/quantum chips, targeting ~20% global market share by 2030 and reducing supply chain vulnerabilities.",
+      "investment": "€43B+ public support; €80–85B total enabled investment",
+      "domain": "Technology",
+      "sources": 3,
+      "corroborating": 3,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.2",
+      "industryPrimary": "Semiconductors & Equipment",
+      "environmentalNexusTags": [
+        {
+          "type": "ENT-2",
+          "name": "Environmental Enablement",
+          "mechanism": "European Chips Act Article 2(11) defines qualifying 'first-of-a-kind facilities' as requiring innovation in 'energy and environmental performance,' acting as a binding definitional gatekeeper for facility recognition and state aid under Articles 13-15.",
+          "evidenceBasis": "Documented",
+          "sources": [
+            {
+              "citation": "Regulation (EU) 2023/1781, Article 2(11), 2(12), 2(13)",
+              "type": "primary",
+              "url": "https://eur-lex.europa.eu/eli/reg/2023/1781/oj/eng",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429043107/https://eur-lex.europa.eu/eli/reg/2023/1781/oj/eng"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "14",
+      "name": "China Gallium/Germanium Export Licensing",
+      "lat": 39.9042,
+      "lng": 116.4074,
+      "bloc": "Eastern-Led",
+      "tier": 2,
+      "type": "Policy",
+      "sample": true,
+      "date": "August 2023",
+      "location": "Beijing, China",
+      "scope": "Mainland China (global export impact)",
+      "description": "Export licensing controls on gallium, germanium, and related compounds affecting dominant shares of global supply. China imposed licensing controls requiring prior approval, technology disclosures, and end-user certificates per MOFCOM Announcement No. 23 of 2023, targeting critical inputs for semiconductor manufacturing.",
+      "investment": ">$3B estimated supply impact",
+      "domain": "Security",
+      "sources": 2,
+      "corroborating": 4,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true,
+        "aiDetail": "PIET (4/4 gates — Trade-Impact Confirmed)"
+      },
+      "version": "1.2",
+      "basel5": [
+        {
+          "factor": "Size",
+          "pass": true,
+          "rationale": ">90% global gallium; ~60% germanium — market concentration qualifies (US$3B+ est. trade impact)"
+        },
+        {
+          "factor": "Interconnectedness",
+          "pass": true,
+          "rationale": "Creates critical cross-border dependencies; restricts Western AI chip manufacturing inputs"
+        },
+        {
+          "factor": "Substitutability",
+          "pass": true,
+          "rationale": "Highly concentrated supply (90%+ gallium); few alternatives exist"
+        },
+        {
+          "factor": "Complexity",
+          "pass": false,
+          "rationale": "Policy instrument, not infrastructure"
+        },
+        {
+          "factor": "Cross-jurisdictional",
+          "pass": true,
+          "rationale": "Affects AI chip supply chains across multiple Western nations"
+        }
+      ],
+      "tierRationale": "Tier 2: Between-Bloc Fragmentation (Restriction — Impact-Demonstrated). Export licensing controls on gallium, germanium, and related compounds affecting over 90% of global gallium supply and approximately 60% of germanium supply per MOFCOM Announcement No. 23 of 2023. Estimated $3B+ supply impact. Explicit-Targeting test fails — Announcement No. 23 is application-agnostic with no named country or bloc. Multiple other-bloc governments issued documented policy responses to the controls, demonstrating cross-bloc fragmentation impact.",
+      "blocAnalysis": [
+        {
+          "bloc": "Western",
+          "involvement": "No",
+          "role": ""
+        },
+        {
+          "bloc": "Eastern",
+          "involvement": "Yes",
+          "role": "China (sole implementer)"
+        },
+        {
+          "bloc": "Non-Aligned",
+          "involvement": "No",
+          "role": ""
+        }
+      ],
+      "primarySources": [
+        {
+          "id": "P1",
+          "desc": "MOFCOM Press Conference — Export controls announcement",
+          "url": "https://english.mofcom.gov.cn/News/PressConference/art/2023/art_36fb2d80e4b4453891bb8fc83e2b3c4e.html",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429065438/https://english.mofcom.gov.cn/favicon.ico"
+        },
+        {
+          "id": "P2",
+          "desc": "MOFCOM Regulatory Text — Announcement No. 23 of 2023",
+          "url": "https://aqygzj.mofcom.gov.cn/qdml/art/2023/art_c2ae3d2061e14e97ba608de1ed565f78.html",
+          "accessDate": "2026-04-30",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260430095949/https://aqygzj.mofcom.gov.cn/favicon.ico"
+        }
+      ],
+      "corroboratingSources": [
+        {
+          "id": "C1",
+          "desc": "Global Policy Watch — China export restrictions analysis",
+          "url": "https://www.globalpolicywatch.com/2023/07/china-slaps-export-restrictions-on-two-critical-metals/",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429162028/https://www.globalpolicywatch.com/2023/07/china-slaps-export-restrictions-on-two-critical-metals/"
+        },
+        {
+          "id": "C2",
+          "desc": "SDxCentral — Chip shortage risk analysis",
+          "url": "https://www.sdxcentral.com/news/chinese-export-controls-on-gallium-and-germanium-could-lead-to-chip-shortages-report/",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429200202/https://www.sdxcentral.com/news/chinese-export-controls-on-gallium-and-germanium-could-lead-to-chip-shortages-report/"
+        },
+        {
+          "id": "C3",
+          "desc": "CSIS — Gallium supply chains analysis",
+          "url": "https://www.csis.org/analysis/beyond-rare-earths-chinas-growing-threat-gallium-supply-chains",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429141710/https://www.csis.org/analysis/beyond-rare-earths-chinas-growing-threat-gallium-supply-chains"
+        },
+        {
+          "id": "C4",
+          "desc": "Clark Hill — China rare earth controls legal analysis",
+          "url": "https://www.clarkhill.com/news-events/news/china-hits-pause-on-rare-earth-export-controls-and-what-it-means-for-supply-chains/",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429132441/https://www.clarkhill.com/news-events/news/china-hits-pause-on-rare-earth-export-controls-and-what-it-means-for-supply-chains/"
+        }
+      ],
+      "relatedEvents": [
+        {
+          "id": "42",
+          "relationship": "Part of China Export Control Sequence"
+        }
+      ],
+      "versionDate": "2026-03-11",
+      "aiConnectionPathway": "piet",
+      "piet": {
+        "implementationDate": "2023-08-01",
+        "assessmentDate": "2025-02-01",
+        "gatesPassed": 4,
+        "gatesRequired": 3,
+        "confidence": "Trade-Impact Confirmed",
+        "result": "4/4 gates",
+        "t2ImpactDemonstrated": true,
+        "t2Basis": "Gate 3 cleared — 6 qualifying other-bloc government responses across 3 jurisdictions (EU, Japan, Canada)",
+        "gates": [
+          {
+            "factor": "Trade Flow Disruption",
+            "pass": true,
+            "rationale": "China GAC data (via USGS MCS 2025): gallium/germanium exports fell to zero Aug–Sep 2023; >50% global decline sustained 18+ months. US bilateral exports declined >97%. No suspension or reversal; regime tightened Dec 2024.",
+            "sources": [
+              {
+                "id": "PIET-G1-1",
+                "desc": "USGS Mineral Commodity Summaries 2025 — Gallium",
+                "url": "https://pubs.usgs.gov/periodicals/mcs2025/mcs2025-gallium.pdf",
+                "type": "PRIMARY",
+                "accessDate": "2026-04-30",
+                "captureStatus": "captured",
+                "snapshotUrl": "https://web.archive.org/web/20260430102702/https://pubs.usgs.gov/periodicals/mcs2025/mcs2025-gallium.pdf"
+              },
+              {
+                "id": "PIET-G1-2",
+                "desc": "USGS Mineral Commodity Summaries 2025 — Germanium",
+                "url": "https://pubs.usgs.gov/periodicals/mcs2025/mcs2025-germanium.pdf",
+                "type": "PRIMARY",
+                "accessDate": "2026-04-30",
+                "captureStatus": "captured",
+                "snapshotUrl": "https://web.archive.org/web/20260430102737/https://pubs.usgs.gov/periodicals/mcs2025/mcs2025-germanium.pdf"
+              }
+            ],
+            "summary": ">50% global decline sustained 18+ months; US bilateral exports declined >97%",
+            "evidence": [
+              {
+                "label": "Source",
+                "value": "China GAC data via USGS Mineral Commodity Summaries 2025"
+              },
+              {
+                "label": "Metric",
+                "value": "Gallium/germanium exports fell to zero Aug–Sep 2023"
+              },
+              {
+                "label": "Duration",
+                "value": ">50% global decline sustained 18+ months"
+              },
+              {
+                "label": "Status",
+                "value": "No suspension or reversal; regime tightened Dec 2024"
+              }
+            ]
+          },
+          {
+            "factor": "Commodity Price Movement",
+            "pass": true,
+            "rationale": "Fastmarkets Rotterdam 99.99% gallium: +60–114% within 5 months, sustained 18+ months. Germanium: +56–114% by mid-2024, sustained 12+ months. Both Tier B non-exchange-traded minor metals; USGS MCS 2025 confirms 2024 annual average gallium import unit value +33%.",
+            "sources": [
+              {
+                "id": "PIET-G2-1",
+                "desc": "USGS MCS 2025 — Gallium (Argus Media annual average data)",
+                "url": "https://pubs.usgs.gov/periodicals/mcs2025/mcs2025-gallium.pdf",
+                "type": "PRIMARY",
+                "accessDate": "2026-04-30",
+                "captureStatus": "captured",
+                "snapshotUrl": "https://web.archive.org/web/20260430102702/https://pubs.usgs.gov/periodicals/mcs2025/mcs2025-gallium.pdf"
+              },
+              {
+                "id": "PIET-G2-2",
+                "desc": "USGS MCS 2025 — Germanium (Argus Media annual average data)",
+                "url": "https://pubs.usgs.gov/periodicals/mcs2025/mcs2025-germanium.pdf",
+                "type": "PRIMARY",
+                "accessDate": "2026-04-30",
+                "captureStatus": "captured",
+                "snapshotUrl": "https://web.archive.org/web/20260430102737/https://pubs.usgs.gov/periodicals/mcs2025/mcs2025-germanium.pdf"
+              }
+            ],
+            "summary": "Gallium +60–114%, germanium +56–114%, sustained 12–18+ months",
+            "evidence": [
+              {
+                "label": "Source",
+                "value": "Fastmarkets Rotterdam / USGS MCS 2025 (Argus Media data)"
+              },
+              {
+                "label": "Gallium",
+                "value": "99.99% grade: +60–114% within 5 months, sustained 18+ months"
+              },
+              {
+                "label": "Germanium",
+                "value": "+56–114% by mid-2024, sustained 12+ months"
+              },
+              {
+                "label": "Classification",
+                "value": "Tier B non-exchange-traded minor metals"
+              }
+            ]
+          },
+          {
+            "factor": "Government Policy Response",
+            "pass": true,
+            "rationale": "6 qualifying responses across 3 governments within 18 months. EU Commission White Paper COM(2024) 25 (Jan 2024) citing ‘3 July 2023…controls covering products containing gallium and germanium’; EU Council ST-6622-2024-INIT (Feb 2024); Japan METI Minister Nishimura strategy announcement (Aug 2023); Japan METI 2024 WTO Compliance Report (Jun 2024); Canada Global Affairs parliamentary briefing (Jun 2024); Canada Minister Wilkinson Wilson Center remarks (Jan 2025).",
+            "sources": [
+              {
+                "id": "PIET-G3-1",
+                "desc": "European Commission White Paper on Export Controls — COM(2024) 25 final",
+                "url": "https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:52024DC0025",
+                "type": "PRIMARY",
+                "accessDate": "2026-04-30",
+                "captureStatus": "captured",
+                "snapshotUrl": "https://web.archive.org/web/20260430101206/https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:52024DC0025"
+              },
+              {
+                "id": "PIET-G3-2",
+                "desc": "Council of the EU — ST-6622-2024-INIT",
+                "url": "https://data.consilium.europa.eu/doc/document/ST-6622-2024-INIT/en/pdf",
+                "type": "PRIMARY",
+                "accessDate": "2026-04-30",
+                "captureStatus": "captured",
+                "snapshotUrl": "https://web.archive.org/web/20260430100650/https://data.consilium.europa.eu/doc/document/ST-6622-2024-INIT/en/pdf"
+              },
+              {
+                "id": "PIET-G3-3",
+                "desc": "Japan METI Minister Nishimura press conference — 1 August 2023",
+                "url": "https://www.meti.go.jp/english/speeches/press_conferences/2023/0801001.html",
+                "type": "PRIMARY",
+                "accessDate": "2026-04-30",
+                "captureStatus": "captured",
+                "snapshotUrl": "https://web.archive.org/web/20260430112726/https://www.meti.go.jp/english/speeches/press_conferences/2023/0801001.html"
+              },
+              {
+                "id": "PIET-G3-4",
+                "desc": "Japan METI 2024 Report on WTO Compliance",
+                "url": "https://www.meti.go.jp/english/report/data/2024WTO/pdf/2024_2.pdf",
+                "type": "PRIMARY",
+                "accessDate": "2026-04-30",
+                "captureStatus": "captured",
+                "snapshotUrl": "https://web.archive.org/web/20260430112711/https://www.meti.go.jp/english/report/data/2024WTO/pdf/2024_2.pdf"
+              },
+              {
+                "id": "PIET-G3-5",
+                "desc": "Global Affairs Canada — Parliamentary briefing on China export controls",
+                "url": "https://international.canada.ca/en/global-affairs/corporate/transparency/briefing-documents/parliamentary-committee/2024-06-17-cacn",
+                "type": "PRIMARY",
+                "accessDate": "2026-04-30",
+                "captureStatus": "captured",
+                "snapshotUrl": "https://web.archive.org/web/20260430102021/https://international.canada.ca/en/global-affairs/corporate/transparency/briefing-documents/parliamentary-committee/2024-06-17-cacn"
+              },
+              {
+                "id": "PIET-G3-6",
+                "desc": "NRCan Minister Wilkinson — Woodrow Wilson Center remarks",
+                "url": "https://www.canada.ca/en/natural-resources-canada/news/2025/01/january-15-2025-woodrow-wilson-international-center-for-scholars-washington-dc.html",
+                "type": "PRIMARY",
+                "accessDate": "2026-04-30",
+                "captureStatus": "captured",
+                "snapshotUrl": "https://web.archive.org/web/20260430105051/https://www.canada.ca/en/natural-resources-canada/news/2025/01/january-15-2025-woodrow-wilson-international-center-for-scholars-washington-dc.html"
+              }
+            ],
+            "summary": "6 qualifying responses across 3 governments (EU, Japan, Canada) within 18 months",
+            "evidence": [
+              {
+                "label": "Count",
+                "value": "6 qualifying responses, 3 jurisdictions, 18-month window"
+              },
+              {
+                "label": "EU",
+                "value": "COM(2024) 25 White Paper (Jan 2024); Council ST-6622-2024-INIT (Feb 2024)"
+              },
+              {
+                "label": "Japan",
+                "value": "METI Minister strategy announcement (Aug 2023); METI WTO Compliance Report (Jun 2024)"
+              },
+              {
+                "label": "Canada",
+                "value": "Global Affairs parliamentary briefing (Jun 2024); Minister Wilkinson Wilson Center remarks (Jan 2025)"
+              }
+            ]
+          },
+          {
+            "factor": "Named Entity Commercial Disclosure",
+            "pass": true,
+            "rationale": "AXT Inc. (NASDAQ: AXTI) — 4 SEC filings (10-Q Q3 2023, 10-Q Q2 2023, 10-K FY2023, 10-Q Q3 2024) naming MOFCOM July 3 2023 controls, August 1 2023 effective date, export permit requirements for subsidiary Tongmei, and operational impact on business, financial condition, and results of operations.",
+            "sources": [
+              {
+                "id": "PIET-G4-1",
+                "desc": "AXT Inc. Form 10-Q — Quarter ending September 30, 2023 (SEC EDGAR)",
+                "url": "https://www.sec.gov/Archives/edgar/data/0001051627/000155837023018573/axti-20230930x10q.htm",
+                "type": "PRIMARY",
+                "accessDate": "2026-04-30",
+                "captureStatus": "captured",
+                "snapshotUrl": "https://web.archive.org/web/20260430114246/https://www.sec.gov/Archives/edgar/data/1051627/000155837023018573/axti-20230930x10q.htm"
+              }
+            ],
+            "summary": "AXT Inc. (AXTI, NASDAQ) 10-K filings: names restriction as material risk, 50%+ revenue impact",
+            "evidence": [
+              {
+                "label": "Entity",
+                "value": "AXT Inc. (AXTI, NASDAQ)"
+              },
+              {
+                "label": "Filing",
+                "value": "10-K Annual Reports FY2023–2024 (SEC)"
+              },
+              {
+                "label": "Disclosure",
+                "value": "Names ‘China’s export restrictions on gallium and germanium’ as material risk"
+              },
+              {
+                "label": "Impact",
+                "value": "50%+ revenue impact; facility restructuring (Beijing subsidiary closure, Liaoning JV)"
+              }
+            ]
+          }
+        ]
+      },
+      "industryPrimary": "Mining & Critical Minerals",
+      "industrySecondary": [
+        {
+          "tag": "Semiconductors & Equipment",
+          "mechanism": "Gallium and germanium are critical semiconductor manufacturing inputs."
+        },
+        {
+          "tag": "Trade & Logistics",
+          "mechanism": "MOFCOM establishes export licensing regime requiring provincial-level approval and end-user certifications."
+        }
+      ],
+      "basel5_factors_met": 4
+    },
+    {
+      "id": "15",
+      "name": "G7 Hiroshima AI Process",
+      "lat": 34.3853,
+      "lng": 132.4553,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Coordination",
+      "sample": false,
+      "date": "1 December 2023",
+      "location": "Hiroshima, Japan",
+      "scope": "G7 members (Canada, France, Germany, Italy, Japan, UK, US) plus EU",
+      "description": "G7-launched coordination process to develop inclusive international governance for advanced AI systems, including foundation models and generative AI. OECD Hiroshima AI Process Reporting Framework operational at transparency.oecd.ai, with 20 organisations from 10 countries participating.",
+      "investment": "Non-binding coordination framework (significance via multi-sovereign participation)",
+      "domain": "Technology",
+      "sources": 6,
+      "corroborating": 6,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.2",
+      "industryPrimary": "AI Software & Platforms"
+    },
+    {
+      "id": "16",
+      "name": "U.S. AI Safety Institute (USAISI)",
+      "lat": 39.1434,
+      "lng": -77.2014,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Policy",
+      "sample": false,
+      "date": "1 November 2023",
+      "location": "Gaithersburg, Maryland, United States",
+      "scope": "United States (headquartered at NIST); international coordination via AI Safety Institute Network",
+      "description": "US Artificial Intelligence Safety Institute operating as federal research and standards-setting organisation within NIST. TRAINS Taskforce comprises DOD (CDAO, NSA), DOE (10 National Laboratories), DHS (CISA), and HHS (NIH) for national security AI testing.",
+      "investment": "US$10M initial funding (FY 2024); 280+ consortium members; 11 international partners; TRAINS Taskforce (Nov 2024)",
+      "domain": "Technology",
+      "sources": 3,
+      "corroborating": 4,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.2",
+      "industryPrimary": "AI Software & Platforms"
+    },
+    {
+      "id": "17",
+      "name": "UK AI Security Institute",
+      "lat": 51.5074,
+      "lng": -0.1278,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Policy",
+      "sample": false,
+      "date": "14 February 2025",
+      "location": "London, United Kingdom",
+      "scope": "United Kingdom",
+      "description": "Rebranded from UK AI Safety Institute to UK AI Security Institute in February 2025. New mandate focuses on national security, counter-AI threats, criminal misuse prevention, and cyber defence.",
+      "investment": "£100M+ initial investment; £8.5M annual funding (DSIT R&D Allocations)",
+      "domain": "Security",
+      "sources": 3,
+      "corroborating": 4,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.1",
+      "industryPrimary": "Defence & Aerospace"
+    },
+    {
+      "id": "18",
+      "name": "TSMC Arizona CHIPS and Science Act Award",
+      "lat": 33.4484,
+      "lng": -112.074,
+      "bloc": "Western-Led",
+      "tier": 2,
+      "type": "Infrastructure",
+      "sample": false,
+      "date": "15 November 2024",
+      "location": "Phoenix, Arizona, United States",
+      "scope": "Phoenix, Arizona, United States",
+      "description": "CHIPS Act award facilitating TSMC's first advanced-node manufacturing presence in the United States. Fab 21 (Phase 1) operational Q4 2024, producing chips for Apple, AMD, and Nvidia. Represents the largest foreign direct investment in US semiconductor history at time of award finalization.",
+      "investment": "US$165B total investment; US$6.6B CHIPS funding; US$5B federal loan",
+      "domain": "Energy/Infrastructure",
+      "sources": 2,
+      "corroborating": 3,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.4",
+      "industryPrimary": "Semiconductors & Equipment",
+      "environmentalNexusTags": [
+        {
+          "type": "ENT-1",
+          "name": "Resource Demand",
+          "mechanism": "TSMC Fab 21 operates under Draft EA NIST-CPO/EA-002 specifying 17.29 MGD total water demand, with mandated Industrial Reclamation Water Plant achieving ≥95% recycling.",
+          "evidenceBasis": "Documented",
+          "vector": "Water",
+          "sources": [
+            {
+              "citation": "Draft Environmental Assessment NIST-CPO/EA-002, NIST CHIPS Program Office",
+              "type": "primary",
+              "url": "https://www.nist.gov/system/files/documents/2024/06/04/TSMC%20Draft%20EA%20June%203%202024%20.pdf",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429045126/https://www.nist.gov/system/files/documents/2024/06/04/TSMC%20Draft%20EA%20June%203%202024%20.pdf"
+            }
+          ]
+        },
+        {
+          "type": "ENT-4",
+          "name": "Environmental Dependency",
+          "mechanism": "TSMC Fab 21 in Phoenix operates in WRI Aqueduct 'Extremely High' zone and requires 17.29 MGD water demand as documented in NIST-CPO/EA-002.",
+          "evidenceBasis": "Assessed",
+          "dependencyType": "Water stress",
+          "riskIndex": "WRI Aqueduct",
+          "sources": [
+            {
+              "citation": "WRI Aqueduct Water Risk Atlas 4.0 — West Salt River Valley sub-basin",
+              "type": "corroborating",
+              "url": "https://www.wri.org/aqueduct",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429045504/https://www.wri.org/aqueduct"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "19",
+      "name": "ISO/IEC 42001:2023 AI Management System Standard",
+      "lat": 46.2044,
+      "lng": 6.1432,
+      "bloc": "Cross-Bloc",
+      "tier": 1,
+      "type": "Coordination",
+      "sample": false,
+      "date": "15 December 2023",
+      "location": "Geneva, Switzerland",
+      "scope": "International (39 P-member nations; 63 total SC 42 members)",
+      "description": "First international standard for AI Management Systems (AIMS), establishing requirements for organisations developing, providing, or using AI-based products/services. Developed through ISO/IEC JTC 1/SC 42 consensus process. Active certification schemes operational across multiple jurisdictions, including AWS, SDAIA, and major conformity assessment bodies.",
+      "investment": "39 P-member countries; 51-page standard; 20+ published AI standards in SC 42 portfolio; active certifications (AWS, SDAIA, DNV, SGS, BSI, TÜV SÜD)",
+      "domain": "Technology",
+      "sources": 3,
+      "corroborating": 4,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.2",
+      "industryPrimary": "AI Software & Platforms",
+      "ecosystemImplementation": [
+        {
+          "ecosystem": "US-centred",
+          "implemented": true,
+          "evidence": "Certification operational — AWS, Anthropic, Google Cloud, Microsoft, Darktrace through ANAB/UKAS-accredited bodies"
+        },
+        {
+          "ecosystem": "China-centred",
+          "implemented": true,
+          "evidence": "Adopted as GB/T 45081-2024; certification through SGS China, BSI China, Amtivo, TÜV Rheinland"
+        }
+      ]
+    },
+    {
+      "id": "21",
+      "name": "Five Eyes Joint AI Security Guidelines",
+      "lat": 51.5074,
+      "lng": -0.1278,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Coordination",
+      "sample": false,
+      "date": "15 April 2024",
+      "location": "London, United Kingdom",
+      "scope": "International — Five Eyes nations (USA, UK, Australia, Canada, New Zealand)",
+      "description": "Joint cybersecurity guidance from Five Eyes alliance agencies providing best practices for securely deploying AI systems. First release from NSA's Artificial Intelligence Security Center (AISC), established September 2023.",
+      "investment": "Voluntary guidance framework; 7 co-authoring agencies; 11-page document",
+      "domain": "Security",
+      "sources": 3,
+      "corroborating": 5,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.1",
+      "industryPrimary": "Defence & Aerospace"
+    },
+    {
+      "id": "22",
+      "name": "Microsoft-G42 Strategic Investment (IGAA)",
+      "lat": 24.4539,
+      "lng": 54.3773,
+      "bloc": "Western-Led",
+      "tier": 2,
+      "type": "Corporate",
+      "sample": true,
+      "date": "April 2024",
+      "location": "Abu Dhabi, UAE",
+      "scope": "UAE (primary); Middle East, Central Asia, Africa (expansion); US (oversight)",
+      "description": "Microsoft strategic investment in G42 (UAE AI company), acquiring minority stake and board seat. Partnership includes binding Intergovernmental Assurance Agreement (IGAA) developed with US and UAE governments establishing AI safety, cybersecurity, and export control standards. Investment completed with G42 Chinese divestment finalised.",
+      "investment": "US$1.5B Microsoft equity; US$15.2B UAE AI investment programme; 200MW datacentre; 81,900 GPUs",
+      "domain": "Trade",
+      "sources": 3,
+      "corroborating": 5,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.3",
+      "versionDate": "2026-03-04",
+      "genesisDate": "2024-04-16",
+      "genesis": {
+        "description": "Microsoft invests $1.5B in G42 (UAE AI company), acquires minority stake, joins board. Partnership includes binding Intergovernmental Assurance Agreement (IGAA) developed with US and UAE governments establishing AI safety, cybersecurity, and export control standards.",
+        "investment": "$1.5B equity (2024); $15.2B total UAE investment (2023-2029); 200MW datacenter expansion; 81,900 GPUs"
+      },
+      "rollingUpdates": [
+        {
+          "id": "PU-22-001",
+          "version": "1.1",
+          "date": "2024-06-24",
+          "description": "Investment conditions completed: G42 Chinese divestment finalised (February 2024, $10B+ including ByteDance stake); Huawei equipment removal from data centres confirmed by White House.",
+          "changedFields": [
+            "investmentStatus"
+          ],
+          "sources": [
+            {
+              "desc": "Fortune - White House Confirms Divestment",
+              "url": "https://fortune.com/asia/2024/06/25/white-house-explains-microsoft-investment-uae-ai-champion-g42-pushed-out-huawei/",
+              "date": "2024-06-24",
+              "type": "PRIMARY",
+              "accessDate": "2026-04-30",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260430101335/https://fortune.com/asia/2024/06/25/white-house-explains-microsoft-investment-uae-ai-champion-g42-pushed-out-huawei/"
+            },
+            {
+              "desc": "Reuters - Microsoft-G42 Deal Huawei Ties Cut",
+              "url": "https://www.reuters.com/technology/microsoft-g42-deal-positive-because-it-cut-huawei-ties-white-house-official-says-2024-06-24/",
+              "date": "2024-06-24",
+              "type": "CORROBORATING",
+              "accessDate": "2026-04-30",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260430114034/https://www.reuters.com/technology/microsoft-g42-deal-positive-because-it-cut-huawei-ties-white-house-official-says-2024-06-24/"
+            },
+            {
+              "desc": "CSIS Analysis - UAE AI Ambitions (G42 Divestment Details)",
+              "url": "https://www.csis.org/analysis/united-arab-emirates-ai-ambitions",
+              "date": "2025-01-27",
+              "type": "CORROBORATING",
+              "accessDate": "2026-04-30",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260430105854/https://www.csis.org/analysis/united-arab-emirates-ai-ambitions"
+            }
+          ],
+          "previousValues": {
+            "description": "Microsoft invests $1.5B in G42 (UAE AI company), acquires minority stake, joins board. Partnership includes binding Intergovernmental Assurance Agreement (IGAA) developed with US and UAE governments establishing AI safety, cybersecurity, and export control standards.",
+            "investment": "$1.5B equity (2024); $15.2B total UAE investment (2023-2029); 200MW datacenter expansion; 81,900 GPUs"
+          }
+        }
+      ],
+      "basel5": [
+        {
+          "factor": "Size",
+          "pass": true,
+          "rationale": "US$1.5B Microsoft equity; 81,900 GPUs (both independently qualify; US$15.2B UAE national AI programme context)"
+        },
+        {
+          "factor": "Interconnectedness",
+          "pass": true,
+          "rationale": "Creates US-UAE cross-border dependencies; Azure integration"
+        },
+        {
+          "factor": "Substitutability",
+          "pass": true,
+          "rationale": "G42 is UAE's leading AI company; dominant regional position"
+        },
+        {
+          "factor": "Complexity",
+          "pass": true,
+          "rationale": "Multi-year data centre buildout; IGAA governance framework"
+        },
+        {
+          "factor": "Cross-jurisdictional",
+          "pass": true,
+          "rationale": "Affects UAE, US, and expansion regions; blocks \"countries of concern\""
+        }
+      ],
+      "tierRationale": "Tier 2: Between-Bloc Fragmentation (Buildout). Microsoft's US$1.5B equity investment in UAE's G42 with binding Intergovernmental Assurance Agreement co-developed by US and UAE governments. Meets Tier 2 Buildout Criterion 3 (Operating Restrictions): IGAA explicitly prohibits expansion into \"countries of concern\" and required G42's divestment of Chinese technology holdings including Huawei partnerships. Creates parallel AI infrastructure in Non-Aligned UAE (200MW datacenter expansion, 81,900 GPUs) with explicit operating restrictions preventing integration with China. Friend-shoring infrastructure maintaining Western technology dependency while located in Non-Aligned geography.",
+      "blocAnalysis": [
+        {
+          "bloc": "Western",
+          "involvement": "Yes",
+          "role": "Microsoft (US) provides US$1.5B equity, technology, board participation; US government co-develops IGAA"
+        },
+        {
+          "bloc": "Non-Aligned",
+          "involvement": "Yes",
+          "role": "UAE/G42 receives investment; hosts AI infrastructure expansion"
+        }
+      ],
+      "primarySources": [
+        {
+          "id": "P1",
+          "desc": "Microsoft Official Blog — Microsoft and G42 partner to accelerate AI innovation",
+          "url": "https://blogs.microsoft.com/blog/2024/04/15/microsoft-and-g42-partner-to-accelerate-ai-innovation-in-uae-and-beyond/",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429054203/https://blogs.microsoft.com/blog/2024/04/15/microsoft-and-g42-partner-to-accelerate-ai-innovation-in-uae-and-beyond/"
+        },
+        {
+          "id": "P2",
+          "desc": "Microsoft News — Microsoft invests US$1.5 billion in Abu Dhabi's G42",
+          "url": "https://news.microsoft.com/source/2024/04/16/microsoft-invests-1-5-billion-in-abu-dhabis-g42-to-accelerate-ai-development-and-gl/",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429084448/https://news.microsoft.com/source/2024/04/16/microsoft-invests-1-5-billion-in-abu-dhabis-g42-to-accelerate-ai-development-and-global-expansion/"
+        },
+        {
+          "id": "P3",
+          "desc": "Microsoft Blog (Brad Smith) — Microsoft's US$15.2 billion investment in the UAE",
+          "url": "https://blogs.microsoft.com/on-the-issues/2025/11/03/microsofts-15-2-billion-usd-investment-in-the-uae/",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429054244/https://blogs.microsoft.com/on-the-issues/2025/11/03/microsofts-15-2-billion-usd-investment-in-the-uae/"
+        }
+      ],
+      "corroboratingSources": [
+        {
+          "id": "C1",
+          "desc": "Reuters — Microsoft to invest US$1.5 bln in Emirati AI firm G42",
+          "url": "https://www.reuters.com/markets/deals/microsoft-invest-15-bln-emirati-ai-firm-g42-new-york-times-reports-2024-04-16/",
+          "accessDate": "2026-04-30",
+          "captureStatus": "existing",
+          "snapshotUrl": "http://web.archive.org/web/20241102084409/https://www.reuters.com/markets/deals/microsoft-invest-15-bln-emirati-ai-firm-g42-new-york-times-reports-2024-04-16/"
+        },
+        {
+          "id": "C2",
+          "desc": "New York Times — Microsoft Invests in G42, an Emirati A.I. Firm",
+          "url": "https://www.nytimes.com/2024/04/16/technology/microsoft-g42-uae-ai.html",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429192112/https://www.nytimes.com/2024/04/16/technology/microsoft-g42-uae-ai.html"
+        },
+        {
+          "id": "C3",
+          "desc": "ComputerWeekly — Microsoft's US$15.2bn investment in the UAE",
+          "url": "https://www.computerweekly.com/news/366634005/Microsofts-152bn-investment-in-the-UAE-A-strategic-bet-on-AI-talent-and-trust",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429135235/https://www.computerweekly.com/news/366634005/Microsofts-152bn-investment-in-the-UAE-A-strategic-bet-on-AI-talent-and-trust"
+        },
+        {
+          "id": "C4",
+          "desc": "Data Center Dynamics — Microsoft and Core42 to build sovereign cloud and AI infrastructure",
+          "url": "https://www.datacenterdynamics.com/en/news/microsoft-and-core42-to-build-sovereign-cloud-and-ai-infrastructure-for-abu-dhabi/",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429144306/https://www.datacenterdynamics.com/en/news/microsoft-and-core42-to-build-sovereign-cloud-and-ai-infrastructure-for-abu-dhabi/"
+        },
+        {
+          "id": "C5",
+          "desc": "TechInformed — Microsoft-G42 announce 200 megawatt UAE data center expansion",
+          "url": "https://techinformed.com/microsoft-g42-announce-200-megawatt-uae-data-center-expansion/",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429110313/https://techinformed.com/microsoft-g42-announce-200-megawatt-uae-data-center-expansion/"
+        }
+      ],
+      "relatedEvents": [
+        {
+          "id": "52",
+          "relationship": "GAIIP"
+        }
+      ],
+      "industryPrimary": "Cloud, Data Centres & Connectivity Infrastructure",
+      "industrySecondary": [
+        {
+          "tag": "Trade & Logistics",
+          "mechanism": "IGAA requires G42 to divest from China and comply with U.S. trade and security laws."
+        },
+        {
+          "tag": "Financial Services & Investment",
+          "mechanism": "IGAA governs US$1.5B Microsoft equity investment with board seat and US$1B AI developer fund."
+        }
+      ],
+      "environmentalNexusTags": [
+        {
+          "type": "ENT-1",
+          "name": "Resource Demand",
+          "mechanism": "Stargate UAE data centre confirmed at 200MW initial capacity (scaling to 1GW), documented in May 2025 Stargate UAE initiative announcement.",
+          "evidenceBasis": "Documented",
+          "vector": "Energy",
+          "sources": [
+            {
+              "citation": "Cisco Stargate UAE initiative announcement, May 2025",
+              "type": "primary",
+              "url": "https://newsroom.cisco.com/c/r/newsroom/en/us/a/y2025/m05/cisco-joins-stargate-uae-initiative.html",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429043529/https://newsroom.cisco.com/c/r/newsroom/en/us/a/y2025/m05/cisco-joins-stargate-uae-initiative.html"
+            }
+          ]
+        },
+        {
+          "type": "ENT-4",
+          "name": "Environmental Dependency",
+          "mechanism": "Stargate UAE data centre in Abu Dhabi operates in WRI Aqueduct 'Extremely High' zone with water-cooled chiller systems operated by Khazna Data Centers.",
+          "evidenceBasis": "Assessed",
+          "dependencyType": "Water stress",
+          "riskIndex": "WRI Aqueduct",
+          "sources": [
+            {
+              "citation": "Khazna Data Centers cooling technology documentation",
+              "type": "corroborating",
+              "url": "https://khaznadatacenters.com/thought-leadership/growth-of-data-centers-in-the-middle-east/",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429043451/https://khaznadatacenters.com/thought-leadership/growth-of-data-centers-in-the-middle-east/"
+            }
+          ]
+        }
+      ],
+      "basel5_factors_met": 5
+    },
+    {
+      "id": "24",
+      "name": "OECD AI Principles (2024 Update)",
+      "lat": 48.8566,
+      "lng": 2.3522,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Coordination",
+      "sample": false,
+      "date": "3 May 2024",
+      "location": "Paris, France",
+      "scope": "Global (47 OECD Member and non-Member adherents, including EU)",
+      "description": "OECD Council meeting at Ministerial level revised the 2019 AI Principles, addressing generative AI, safety, information integrity, environmental sustainability, and responsible business conduct across the AI system lifecycle.",
+      "investment": "International policy coordination; non-binding framework with 47 adherents; basis for 1,020+ AI policy initiatives in 70+ jurisdictions",
+      "domain": "Technology",
+      "sources": 2,
+      "corroborating": 4,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.1",
+      "industryPrimary": "AI Software & Platforms"
+    },
+    {
+      "id": "25",
+      "name": "Xi-Putin Comprehensive Strategic Partnership (AI Section)",
+      "lat": 39.9042,
+      "lng": 116.4074,
+      "bloc": "Eastern",
+      "tier": 3,
+      "type": "Coordination",
+      "sample": false,
+      "date": "16 May 2024",
+      "location": "Beijing, China",
+      "scope": "China, Russia (Bilateral)",
+      "description": "Comprehensive bilateral agreement signed during President Putin's state visit to Beijing, including dedicated AI section committing to joint governance standards, military AI dialogue, and cooperation within BRICS/SCO frameworks. Partnership framework operationalised through detailed joint statement and 20+ cooperation agreements covering AI, biosecurity, digital infrastructure, and cross-border payments.",
+      "investment": "N/A (Policy Framework)",
+      "domain": "Security",
+      "sources": 4,
+      "corroborating": 2,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.2",
+      "industryPrimary": "Defence & Aerospace"
+    },
+    {
+      "id": "26",
+      "name": "Saudi National Data and AI Strategy (SDAIA)",
+      "lat": 24.7136,
+      "lng": 46.6753,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Infrastructure",
+      "sample": false,
+      "date": "June 2025",
+      "location": "Riyadh, Saudi Arabia",
+      "scope": "Saudi Arabia (Riyadh headquarters, regional data centres)",
+      "description": "SDAIA launched comprehensive national AI infrastructure including headquarters, regional data centres, and R&D facilities. Part of Vision 2030 establishing Saudi Arabia as a regional AI hub through sovereign compute capacity development.",
+      "investment": "SAR 8 billion (USD 2.13 billion) total; headquarters 200,000 m²; regional data centres 100,000 m²; 1.5 GW national capacity target by 2030",
+      "domain": "Energy/Infrastructure",
+      "sources": 4,
+      "corroborating": 5,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.1",
+      "industryPrimary": "Cloud, Data Centres & Connectivity Infrastructure",
+      "environmentalNexusTags": [
+        {
+          "type": "ENT-1",
+          "name": "Resource Demand",
+          "mechanism": "SDAIA targets 1.5 GW national data centre capacity by 2030, documented in sovereign programme specifications.",
+          "evidenceBasis": "Documented",
+          "vector": "Energy",
+          "sources": [
+            {
+              "citation": "Saudi Arabia National Data Center Strategy, MCIT/SDAIA",
+              "type": "primary",
+              "url": "https://www.trade.gov/market-intelligence/saudi-arabia-ict-new-data-center-strategy-accelerate-ai-and-cloud-expansion",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429211921/https://www.trade.gov/market-intelligence/saudi-arabia-ict-new-data-center-strategy-accelerate-ai-and-cloud-expansion"
+            }
+          ]
+        },
+        {
+          "type": "ENT-4",
+          "name": "Environmental Dependency",
+          "mechanism": "SDAIA Hexagon in Riyadh operates in WRI Aqueduct 'Extremely High' water stress zone (Wadi Hanifah / Central Arabian sub-basin) with extreme ambient temperatures preventing free cooling, mandating continuous mechanical chilling and driving adoption of DLC architecture to avoid evaporative water dependency.",
+          "evidenceBasis": "Assessed",
+          "dependencyType": "Extreme weather",
+          "riskIndex": "WRI Aqueduct",
+          "sources": [
+            {
+              "citation": "SDAIA Hexagon facility specifications",
+              "type": "corroborating",
+              "url": "https://saudigazette.com.sa/article/657881/SAUDI-ARABIA/Saudi-Arabia-launches-Hexagon-the-worlds-largest-Tier-IV-government-data-center",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429043748/https://saudigazette.com.sa/article/657881/SAUDI-ARABIA/Saudi-Arabia-launches-Hexagon-the-worlds-largest-Tier-IV-government-data-center"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "27",
+      "name": "International Network of AI Safety Institutes (INAISI)",
+      "lat": 37.7749,
+      "lng": -122.4194,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Coordination",
+      "sample": false,
+      "date": "21 November 2024",
+      "location": "San Francisco, United States",
+      "scope": "Global; 10 nations + European Commission",
+      "description": "International coordination mechanism launching formal AI safety institute network. Founded on Seoul Statement (May 2024); inaugural meeting San Francisco November 2024. Members: Australia, Canada, EU, France, Japan, Kenya, South Korea, Singapore, UK, USA.",
+      "investment": "US$11M+ committed (USAID US$3.8M, Australia CSIRO US$1.42M/yr, South Korea US$7.2M/4yr)",
+      "domain": "Technology",
+      "sources": 2,
+      "corroborating": 4,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.2",
+      "industryPrimary": "AI Software & Platforms"
+    },
+    {
+      "id": "29",
+      "name": "BRICS AI Alliance Network",
+      "lat": 55.7558,
+      "lng": 37.6173,
+      "bloc": "Eastern",
+      "tier": 3,
+      "type": "Coordination",
+      "sample": false,
+      "date": "11 December 2024",
+      "location": "Moscow, Russia",
+      "scope": "Multi-national: Russia, China, India, Brazil, South Africa, Iran, UAE, Serbia, Indonesia",
+      "description": "Multilateral coordination initiative uniting national AI associations from BRICS countries and partner states for joint AI research, technology development, and regulatory cooperation. Russian AI Alliance serves as Secretariat administrator (elected December 2024); 17 associations from 14 countries operational; Global AI Horizons foresight project launched with 200+ scientists across 25 countries.",
+      "investment": "20+ companies from 6 member states; 50+ institutions expected; no confirmed budget",
+      "domain": "Technology",
+      "sources": 3,
+      "corroborating": 5,
+      "confidence": "B",
+      "checkpoints": {
+        "ai": true,
+        "threshold": false,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.3",
+      "industryPrimary": "AI Software & Platforms"
+    },
+    {
+      "id": "30",
+      "name": "EU AI Act",
+      "lat": 50.8503,
+      "lng": 4.3517,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Policy",
+      "sample": false,
+      "date": "1 August 2024",
+      "location": "Brussels, Belgium",
+      "scope": "European Union - 27 Member States, with extraterritorial application",
+      "description": "World's first comprehensive horizontal legal framework regulating artificial intelligence, establishing risk-based rules for AI system development, deployment, and use. Article 5 prohibitions cover 8 prohibited AI practices including subliminal manipulation, social scoring, and certain biometric identification, with full regulatory enforcement operational.",
+      "investment": "N/A (Regulatory framework; penalties up to €35M or 7% global turnover, enforceable August 2, 2025)",
+      "domain": "Technology",
+      "sources": 3,
+      "corroborating": 4,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.2",
+      "industryPrimary": "AI Software & Platforms",
+      "environmentalNexusTags": [
+        {
+          "type": "ENT-2",
+          "name": "Environmental Enablement",
+          "mechanism": "EU AI Act Article 53 and Annex XI impose binding energy documentation requirements on GPAI providers as operative legislative provisions.",
+          "evidenceBasis": "Documented",
+          "sources": [
+            {
+              "citation": "Regulation (EU) 2024/1689, Annex XI, Section 1(2)(d) and (e)",
+              "type": "primary",
+              "url": "https://eur-lex.europa.eu/eli/reg/2024/1689/oj/eng",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429043131/https://eur-lex.europa.eu/eli/reg/2024/1689/oj/eng"
+            }
+          ]
+        },
+        {
+          "type": "ENT-5",
+          "name": "Environmental Coordination",
+          "mechanism": "EU AI Act Article 53 and Annex XI create legally binding energy documentation requirements for GPAI providers, enforceable with penalties up to €35M or 7% global turnover.",
+          "evidenceBasis": "Documented",
+          "pathway": "A",
+          "sources": [
+            {
+              "citation": "Regulation (EU) 2024/1689, Article 101(1)",
+              "type": "primary",
+              "url": "https://eur-lex.europa.eu/eli/reg/2024/1689/oj/eng",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429043131/https://eur-lex.europa.eu/eli/reg/2024/1689/oj/eng"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "31",
+      "name": "IndiaAI Mission GPU Deployment",
+      "lat": 19.033,
+      "lng": 73.0297,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Infrastructure",
+      "sample": false,
+      "date": "March 2024",
+      "location": "Navi Mumbai, India",
+      "scope": "India (National)",
+      "description": "National initiative approved by Union Cabinet to democratise AI computing power through public-private partnerships, supporting startups, researchers, and academic institutions across India. Part of broader IndiaAI Mission targeting indigenous AI capability development.",
+      "investment": "₹10,372 Crore (~US$1.2B) total; ₹4,563 Crore (~US$540M) for compute; 34,333 GPUs approved",
+      "domain": "Energy/Infrastructure",
+      "sources": 4,
+      "corroborating": 5,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.1",
+      "industryPrimary": "Cloud, Data Centres & Connectivity Infrastructure",
+      "environmentalNexusTags": [
+        {
+          "type": "ENT-1",
+          "name": "Resource Demand",
+          "mechanism": "IndiaAI Mission compute deploys via empanelled operators including Yotta NM1 (210 MW documented) in Navi Mumbai.",
+          "evidenceBasis": "Documented",
+          "vector": "Energy",
+          "sources": [
+            {
+              "citation": "Yotta NM1 facility specifications",
+              "type": "corroborating"
+            }
+          ]
+        },
+        {
+          "type": "ENT-4",
+          "name": "Environmental Dependency",
+          "mechanism": "IndiaAI Mission primary deployment hub (Navi Mumbai) is classified 'Extremely High' baseline water stress by WRI Aqueduct, with data centre cooling operations dependent on regional water infrastructure.",
+          "evidenceBasis": "Assessed",
+          "dependencyType": "Water stress",
+          "riskIndex": "WRI Aqueduct",
+          "sources": [
+            {
+              "citation": "WRI Aqueduct Water Risk Atlas 4.0 — Ulhas River / Panvel sub-basin",
+              "type": "corroborating",
+              "url": "https://www.wri.org/aqueduct",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429045504/https://www.wri.org/aqueduct"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "32",
+      "name": "UK-US AI Safety Partnership",
+      "lat": 38.9072,
+      "lng": -77.0369,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Coordination",
+      "sample": false,
+      "date": "1 April 2024",
+      "location": "Washington, DC, United States",
+      "scope": "Bilateral – United Kingdom and United States",
+      "description": "First bilateral AI safety agreement, establishing formal partnership between UK and US AI Safety Institutes to collaborate on AI safety testing, research, and pre-deployment evaluation of advanced AI models.",
+      "investment": "UK AISI: £100M (~US$125M) initial investment; US AISI: Part of NIST with 280+ consortium organizations",
+      "domain": "Technology",
+      "sources": 3,
+      "corroborating": 4,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.1",
+      "industryPrimary": "AI Software & Platforms"
+    },
+    {
+      "id": "33",
+      "name": "Japan Leading-edge Semiconductor Technology Center (LSTC)",
+      "lat": 35.6762,
+      "lng": 139.6503,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Coordination",
+      "sample": false,
+      "date": "December 2022",
+      "location": "Tokyo, Japan",
+      "scope": "Japan (Tokyo, Hokkaido), USA (New York, California)",
+      "description": "Strategic bilateral coordination establishing the Leading-edge Semiconductor Technology Center (LSTC) in Japan to collaborate with US partners (IBM, NSTC, Tenstorrent) on developing 2nm logic semiconductor manufacturing technology and edge-AI accelerators. Rapidus 2nm prototype verified, advancing toward mass production.",
+      "investment": "JPY 1.72 trillion total government support; 2nm mass production target 2027",
+      "domain": "Technology",
+      "sources": 2,
+      "corroborating": 2,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.3",
+      "industryPrimary": "Semiconductors & Equipment"
+    },
+    {
+      "id": "34",
+      "name": "China TC260 Basic Security Requirements for Generative AI Services",
+      "lat": 39.9042,
+      "lng": 116.4074,
+      "bloc": "Eastern",
+      "tier": 3,
+      "type": "Policy",
+      "sample": false,
+      "date": "1 March 2024",
+      "location": "Beijing, China",
+      "scope": "People's Republic of China",
+      "description": "Technical document issued by China's National Information Security Standardization Technical Committee (TC260) specifying basic security requirements for generative AI services, covering training data, model security, and safety measures. Accompanied by mandatory AIGC labelling regulations (CAC Measures + GB 45438-2025) establishing content identification requirements for AI-generated media.",
+      "investment": "N/A (Policy/standard); applies to all generative AI service providers in China",
+      "domain": "Technology",
+      "sources": 2,
+      "corroborating": 5,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.2",
+      "industryPrimary": "AI Software & Platforms"
+    },
+    {
+      "id": "38",
+      "name": "Malaysia National Semiconductor Strategy",
+      "lat": 3.1319,
+      "lng": 101.6841,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Policy",
+      "sample": false,
+      "date": "May 2024",
+      "location": "Kuala Lumpur, Malaysia",
+      "scope": "Malaysia (National)",
+      "description": "Comprehensive national roadmap comprising three phases to position Malaysia as a global powerhouse in semiconductor manufacturing, IC design, and advanced packaging. Backed by RM25 billion in confirmed government fiscal support (disbursing via annual budgets), with RM70.7 billion in private investment attracted by November 2025 and a RM500 billion total investment programme target.",
+      "investment": "RM500 billion (US$106B) investment target; RM25 billion (US$5.3B) fiscal support",
+      "domain": "Technology",
+      "sources": 4,
+      "corroborating": 6,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.2",
+      "industryPrimary": "Semiconductors & Equipment"
+    },
+    {
+      "id": "39",
+      "name": "Canada Sovereign AI Compute Strategy",
+      "lat": 45.4215,
+      "lng": -75.6972,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Policy",
+      "sample": false,
+      "date": "5 December 2024",
+      "location": "Ottawa, Canada",
+      "scope": "National (Canada-wide)",
+      "description": "Federal policy and investment framework establishing US$2 billion over five years to build domestic AI compute infrastructure. Encompasses private data centre capacity, national supercomputing expansion, and SME compute access programmes supporting Canadian AI sovereignty objectives.",
+      "investment": "CAD $2 billion total; allocated across three programmes",
+      "domain": "Energy/Infrastructure",
+      "sources": 5,
+      "corroborating": 3,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.1",
+      "industryPrimary": "Cloud, Data Centres & Connectivity Infrastructure",
+      "environmentalNexusTags": [
+        {
+          "type": "ENT-2",
+          "name": "Environmental Enablement",
+          "mechanism": "SCIP evaluation framework mandates proponents 'demonstrate a plan to minimize the environmental footprint of the project, including sustainable design, energy efficiency' as a binding evaluation criterion for sovereign compute funding.",
+          "evidenceBasis": "Documented",
+          "sources": [
+            {
+              "citation": "Canada SCIP Programme Guidelines, ISED",
+              "type": "primary",
+              "url": "https://ised-isde.canada.ca/site/ised/en/ai-sovereign-compute-infrastructure-program",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429080951/https://ised-isde.canada.ca/site/ised/en/ai-sovereign-compute-infrastructure-program"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "40",
+      "name": "US EO 14105 Outbound Investment Restrictions",
+      "lat": 38.9072,
+      "lng": -77.0369,
+      "bloc": "Western-Led",
+      "tier": 2,
+      "type": "Policy",
+      "sample": false,
+      "date": "2 January 2025",
+      "location": "Washington, DC, United States",
+      "scope": "United States (outbound investors), Countries of Concern (China, Hong Kong, Macau)",
+      "description": "Presidential Executive Order and Treasury regulations establishing a national security programme to prohibit or require notification of certain outbound US investments into semiconductors, quantum information technologies, and artificial intelligence in countries of concern. Outbound Investment Security Programme operational with prohibition and notification requirements.",
+      "investment": "Regulatory restriction (no direct budget); regulates U.S. person transactions; IEEPA enforcement authority",
+      "domain": "Security",
+      "sources": 3,
+      "corroborating": 3,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.2",
+      "industryPrimary": "Financial Services & Investment"
+    },
+    {
+      "id": "41",
+      "name": "China Computing Power Infrastructure Plan",
+      "lat": 39.9042,
+      "lng": 116.4074,
+      "bloc": "Eastern",
+      "tier": 3,
+      "type": "Policy",
+      "sample": false,
+      "date": "9 October 2023",
+      "location": "Beijing, China",
+      "scope": "National (China-wide); 8 regional computing hubs; 30+ cities developing AI compute centres",
+      "description": "National government initiative to increase computing power capacity via Eastern Data Western Computing strategy. Rapid intelligent computing expansion supporting large AI model development across China's national computing infrastructure network.",
+      "investment": "RMB 200B+ total (~US$28B); US$6.1B+ direct government investment (EDWC); 725.3 EFLOPS intelligent computing capacity (2024 operational); 74.1% YoY growth; 1,509 registered large AI models (mid-2025); US$19B AI computing market (2024), +87% YoY; 10.85M standard racks deployed (mid-2025); 1,680 exabytes storage (2025 operational)",
+      "domain": "Energy/Infrastructure",
+      "sources": 3,
+      "corroborating": 6,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.3",
+      "industryPrimary": "Cloud, Data Centres & Connectivity Infrastructure",
+      "environmentalNexusTags": [
+        {
+          "type": "ENT-2",
+          "name": "Environmental Enablement",
+          "mechanism": "Computing Power Plan mandates renewable energy integration and source-grid-load-storage for computing hubs, with binding implementation through GB 40879-2021 and provincial enforcement.",
+          "evidenceBasis": "Documented",
+          "sources": [
+            {
+              "citation": "GB 40879-2021 (数据中心能效限定值及能效等级), Standardization Administration of China",
+              "type": "primary",
+              "url": "https://openstd.samr.gov.cn/bzgk/gb/newGbInfo?hcno=4AAF5CA9387980A1FEA1FA47ABA503BA",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429043625/https://openstd.samr.gov.cn/bzgk/std/newGbInfo?hcno=4AAF5CA9387980A1FEA1FA47ABA503BA"
+            }
+          ]
+        },
+        {
+          "type": "ENT-5",
+          "name": "Environmental Coordination",
+          "mechanism": "Computing Power Plan generates binding environmental operational requirements on computing infrastructure through the same cascade mechanism as EDWC.",
+          "evidenceBasis": "Documented",
+          "pathway": "A",
+          "sources": [
+            {
+              "citation": "cascade model confirmed across 4 provinces, 2 enforcement pathways",
+              "type": "primary",
+              "url": "https://doi.org/10.5281/zenodo.18427582",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429040553/https://zenodo.org/records/19366463"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "42",
+      "name": "China Rare Earth Technology Export Ban",
+      "lat": 39.9042,
+      "lng": 116.4074,
+      "bloc": "Eastern-Led",
+      "tier": 2,
+      "type": "Policy",
+      "sample": false,
+      "date": "4 April 2025",
+      "location": "Beijing, China",
+      "scope": "Global; affects all exports of Chinese rare earth materials with AI chip restrictions",
+      "description": "China imposed export controls on rare earth elements in two phases. Phase 1 (April 2025, MOFCOM/GAC Announcement No. 18/2025) imposed licensing on seven medium and heavy REEs. Phase 2 (October 2025, Notice No. 61/2025) introduced AI chip end-use thresholds (14nm logic, 256-layer memory) and extraterritorial de minimis provisions.",
+      "investment": "Policy mechanism; affects >90% of global rare earth processing chain (China's share of RE mining is 60–70%; processing/refining exceeds 85%)",
+      "domain": "Security",
+      "sources": 3,
+      "corroborating": 6,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.1",
+      "industryPrimary": "Mining & Critical Minerals"
+    },
+    {
+      "id": "44",
+      "name": "Singapore National AI Strategy 2.0",
+      "lat": 1.3521,
+      "lng": 103.8198,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Policy",
+      "sample": false,
+      "date": "4 December 2023",
+      "location": "Singapore",
+      "scope": "Singapore (city-state), with regional and global outreach",
+      "description": "Singapore's second national AI strategy launched by DPM Lawrence Wong, outlining 15 courses of action across 3 systems and 10 enablers. Smart Nation 2.0 establishes framework for AI governance, infrastructure development, talent cultivation, and industry transformation.",
+      "investment": "S$1+ billion over 5 years (~US$744M); S$500M for AI compute; S$270M supercomputer (Oct 2024); S$120M AI for Science",
+      "domain": "Technology",
+      "sources": 4,
+      "corroborating": 7,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.2",
+      "industryPrimary": "AI Software & Platforms",
+      "environmentalNexusTags": [
+        {
+          "type": "ENT-2",
+          "name": "Environmental Enablement",
+          "mechanism": "NAIS 2.0 Action 10 mandates 'sufficient carbon budget and power allocated to support data centres that house GPUs' with a binding roadmap toward 'net-zero, green data centres powered by renewable energy.'",
+          "evidenceBasis": "Documented",
+          "sources": [
+            {
+              "citation": "Singapore National AI Strategy 2.0, System 3 / Enabler 7 / Action 10",
+              "type": "primary",
+              "url": "https://file.go.gov.sg/nais2023.pdf",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429043154/https://file.go.gov.sg/nais2023.pdf"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "45",
+      "name": "South Korea K-Cloud Project",
+      "lat": 35.1595,
+      "lng": 126.8526,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Infrastructure",
+      "sample": false,
+      "date": "26 June 2023",
+      "location": "Gwangju, South Korea",
+      "scope": "South Korea (nationwide)",
+      "description": "Government-led initiative to develop homegrown AI semiconductors and establish AI computing infrastructure independent of foreign processors. Coordinated by Ministry of Science and ICT with Samsung, SK Hynix, Naver, KT. Six-year programme (2025-2030) targeting domestic NPU and PIM chip development.",
+      "investment": "KRW 403.1B total budget (2025-2030); KRW 342.6B government funding; 2025 R&D budget KRW 37B",
+      "domain": "Energy/Infrastructure",
+      "sources": 1,
+      "corroborating": 4,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.3",
+      "industryPrimary": "Semiconductors & Equipment"
+    },
+    {
+      "id": "46",
+      "name": "UAE MGX AI Investment Fund",
+      "lat": 24.4552,
+      "lng": 54.3787,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Corporate",
+      "sample": false,
+      "date": "March 2024",
+      "location": "Abu Dhabi, UAE",
+      "scope": "UAE (Abu Dhabi); Global partnerships",
+      "description": "State-backed technology investment vehicle established by Abu Dhabi to deploy capital in AI infrastructure, semiconductors, and advanced technologies. Operates under Artificial Intelligence and Advanced Technology Council (AIATC).",
+      "investment": "US$100 billion target AUM",
+      "domain": "Trade",
+      "sources": 3,
+      "corroborating": 3,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.1",
+      "industryPrimary": "Financial Services & Investment"
+    },
+    {
+      "id": "47",
+      "name": "Taiwan Chip-based Industrial Innovation Program (CbI)",
+      "lat": 25.033,
+      "lng": 121.5654,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Policy",
+      "sample": false,
+      "date": "May 2024",
+      "location": "Taipei, Taiwan",
+      "scope": "Taiwan (national)",
+      "description": "Cross-ministry government programme launched by NSTC to integrate generative AI with semiconductor chip technology. Multi-year strategy advancing Taiwan's AI infrastructure and chip-based innovation across research, industry, and public sector applications.",
+      "investment": "NT$300 billion (~US$9.3 billion) over 2024-2033",
+      "domain": "Technology",
+      "sources": 2,
+      "corroborating": 6,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.1",
+      "industryPrimary": "Semiconductors & Equipment"
+    },
+    {
+      "id": "49",
+      "name": "Saudi Arabia Alat Manufacturing Initiative",
+      "lat": 24.7136,
+      "lng": 46.6753,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Infrastructure",
+      "sample": false,
+      "date": "February 2024",
+      "location": "Riyadh, Saudi Arabia",
+      "scope": "Saudi Arabia (Riyadh headquarters; multiple manufacturing facilities)",
+      "description": "PIF-backed conglomerate launched by Crown Prince Mohammed bin Salman to transform Saudi Arabia into global hub for electronics, semiconductors, robotics, and AI infrastructure manufacturing. Operational programmes include KACST research partnership, National Semiconductor Hub, and a target of 50 semiconductor design companies by 2030.",
+      "investment": "US$100 billion total (by 2030); SR1B+ deep tech VC fund",
+      "domain": "Energy/Infrastructure",
+      "sources": 5,
+      "corroborating": 3,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.2",
+      "industryPrimary": "Semiconductors & Equipment"
+    },
+    {
+      "id": "51",
+      "name": "India CG Power-Renesas-Stars Microelectronics Joint Venture",
+      "lat": 22.99,
+      "lng": 72.38,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Infrastructure",
+      "sample": false,
+      "date": "29 February 2024",
+      "location": "Sanand, Gujarat, India",
+      "scope": "Sanand, Gujarat (OSAT); Noida and Bengaluru (Design Centres)",
+      "description": "Joint venture between CG Power (India), Renesas Electronics (Japan), and Stars Microelectronics (Thailand) to establish semiconductor OSAT facilities in Gujarat with ₹7,600 crore investment. Includes India's first 3nm chip design centres.",
+      "investment": "₹7,600 crore (~US$870M) total; ₹3,501 crore (~US$420M) government subsidy",
+      "domain": "Energy/Infrastructure",
+      "sources": 2,
+      "corroborating": 2,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.1",
+      "industryPrimary": "Semiconductors & Equipment",
+      "environmentalNexusTags": [
+        {
+          "type": "ENT-1",
+          "name": "Resource Demand",
+          "mechanism": "CG Power-Renesas-Stars OSAT facility operates under MoEFCC Environmental Clearance specifying 17,549 KLD total water requirement.",
+          "evidenceBasis": "Documented",
+          "vector": "Water",
+          "sources": [
+            {
+              "citation": "MoEFCC Environmental Clearance, Parivesh Portal",
+              "type": "primary",
+              "url": "https://www.scribd.com/document/925180831/Ind-Ahm-Project",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429045351/https://www.scribd.com/document/925180831/Ind-Ahm-Project"
+            }
+          ]
+        },
+        {
+          "type": "ENT-4",
+          "name": "Environmental Dependency",
+          "mechanism": "CG Power OSAT in Sanand operates in CGWB-classified 'Over-exploited' aquifer zone (113.55% extraction) with documented 17,549 KLD water requirement.",
+          "evidenceBasis": "Assessed",
+          "dependencyType": "Water stress",
+          "riskIndex": "CGWB NAQUIM",
+          "sources": [
+            {
+              "citation": "CGWB Dynamic Ground Water Resources Assessment — Gandhinagar district",
+              "type": "corroborating",
+              "url": "http://cgwb.gov.in",
+              "accessDate": "2026-04-29",
+              "captureStatus": "existing",
+              "snapshotUrl": "http://web.archive.org/web/20250609180756/https://www.cgwb.gov.in/"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "52",
+      "name": "Global AI Infrastructure Investment Partnership (GAIIP)",
+      "lat": 24.4526,
+      "lng": 54.3787,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Coordination",
+      "sample": false,
+      "date": "17 September 2024",
+      "location": "Abu Dhabi, UAE",
+      "scope": "United States (primary); U.S. partner countries (secondary)",
+      "description": "Multinational coordination agreement between BlackRock, Global Infrastructure Partners, Microsoft, and MGX for AI data centre and energy infrastructure investment. NVIDIA provides technical advisory support. March 2025 expansion added xAI and NVIDIA as formal partners.",
+      "investment": "US$30 billion initial capital; up to US$100 billion with debt financing",
+      "domain": "Trade",
+      "sources": 2,
+      "corroborating": 3,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.2",
+      "industryPrimary": "Cloud, Data Centres & Connectivity Infrastructure"
+    },
+    {
+      "id": "53",
+      "name": "UN GA AI Capacity-building Resolution (A/RES/78/311)",
+      "lat": 40.7505,
+      "lng": -73.969,
+      "bloc": "Eastern",
+      "tier": 3,
+      "type": "Coordination",
+      "sample": false,
+      "date": "1 July 2024",
+      "location": "New York City, USA",
+      "scope": "Global — UN General Assembly (143 co-sponsors)",
+      "description": "UN General Assembly resolution \"Enhancing International Cooperation on Capacity-building of Artificial Intelligence\" (A/RES/78/311) proposed by China with 143 co-sponsors. UNESCO readiness assessment active across 60 Member States; complemented by China AI Capacity-Building Action Plan for Good and for All.",
+      "investment": "N/A (Policy/Coordination — Consensus Adoption, Non-binding)",
+      "domain": "Technology",
+      "sources": 2,
+      "corroborating": 3,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.2",
+      "industryPrimary": "AI Software & Platforms"
+    },
+    {
+      "id": "54",
+      "name": "UN GA Resolution on Safe AI (A/RES/78/265)",
+      "lat": 40.7505,
+      "lng": -73.969,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Coordination",
+      "sample": false,
+      "date": "21 March 2024",
+      "location": "New York City, USA",
+      "scope": "Global — 193 UN Member States",
+      "description": "UN General Assembly Resolution \"Seizing the opportunities of safe, secure and trustworthy artificial intelligence systems for sustainable development\" (A/RES/78/265). First-ever UN General Assembly resolution on AI, adopted by consensus with more than 100 co-sponsors including China.",
+      "investment": "N/A (Non-financial coordination framework; Non-binding)",
+      "domain": "Technology",
+      "sources": 3,
+      "corroborating": 4,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.1",
+      "industryPrimary": "AI Software & Platforms"
+    },
+    {
+      "id": "56",
+      "name": "Africa Declaration on Artificial Intelligence",
+      "lat": -1.9441,
+      "lng": 30.0619,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Coordination",
+      "sample": false,
+      "date": "4 April 2025",
+      "location": "Kigali, Rwanda",
+      "scope": "Pan-African — 54 AU member states + Smart Africa",
+      "description": "Continental AI governance framework signed by 54 signatories establishing shared principles for AI development, sovereignty, and inclusion. Includes Africa AI Council governance structure, Africa AI Fund (US$60B mobilisation target), and distributed computing infrastructure commitment.",
+      "investment": "US$60 billion (mobilisation target — public, private, philanthropic blend)",
+      "domain": "Technology",
+      "sources": 3,
+      "corroborating": 6,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.2",
+      "industryPrimary": "AI Software & Platforms"
+    },
+    {
+      "id": "57",
+      "name": "AU Continental AI Strategy",
+      "lat": 9.0331,
+      "lng": 38.7444,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Policy",
+      "sample": false,
+      "date": "19 July 2024",
+      "location": "Addis Ababa, Ethiopia",
+      "scope": "African Union — 55 Member States (Continental)",
+      "description": "Continental strategy establishing an Africa-centric, development-oriented framework for AI governance, aligning with AU Agenda 2063 and SDGs. Defines five focus areas and fifteen action areas across governance, sectoral adoption, capacity building, risk minimisation, investment, and cooperation.",
+      "investment": "Policy Framework; five-year implementation (2025-2030)",
+      "domain": "Technology",
+      "sources": 2,
+      "corroborating": 4,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.1",
+      "industryPrimary": "AI Software & Platforms"
+    },
+    {
+      "id": "58",
+      "name": "Russia National AI Strategy Update (Decree No. 124)",
+      "lat": 55.7571,
+      "lng": 37.6187,
+      "bloc": "Eastern",
+      "tier": 3,
+      "type": "Policy",
+      "sample": false,
+      "date": "15 February 2024",
+      "location": "Moscow, Russia",
+      "scope": "Russian Federation",
+      "description": "Comprehensive update to Russia's \"National Strategy for the Development of Artificial Intelligence until 2030.\" Mandates integration of generative AI, large language models, and \"sovereign\" AI solutions into state platforms, directing government corporations to update their strategies by September 2024.",
+      "investment": "Policy Framework; concurrent Data Economy national project (to 2030) allocated ~700B RUB (~US$7.6B) for broader digital infrastructure; AI-specific funding is a subset",
+      "domain": "Technology",
+      "sources": 3,
+      "corroborating": 2,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.2",
+      "industryPrimary": "AI Software & Platforms"
+    },
+    {
+      "id": "61",
+      "name": "TII Falcon Foundation",
+      "lat": 25.2048,
+      "lng": 55.2708,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Infrastructure",
+      "sample": false,
+      "date": "13 February 2024",
+      "location": "Dubai, UAE",
+      "scope": "Global (UAE-based, international stakeholder engagement)",
+      "description": "The Technology Innovation Institute (TII), the applied research pillar of Abu Dhabi's Advanced Technology Research Council (ATRC), launched the Falcon Foundation—a non-profit entity dedicated to advancing open-source generative AI models and building sustainable ecosystems around open-source AI projects.",
+      "investment": "US$300 million commitment from TII as founding member",
+      "domain": "Technology",
+      "sources": 2,
+      "corroborating": 3,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.2",
+      "industryPrimary": "AI Software & Platforms"
+    },
+    {
+      "id": "62",
+      "name": "Bpifrance AI Plan (2025-2029)",
+      "lat": 48.8566,
+      "lng": 2.3522,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Policy",
+      "sample": false,
+      "date": "February 2025",
+      "location": "Paris, France",
+      "scope": "France (National)",
+      "description": "Comprehensive €10 billion investment plan by France's public investment bank to support the AI ecosystem, including foundation models, AI infrastructure, and deeptech startups, running from 2025 to 2029.",
+      "investment": "€10 Billion (~US$10.8B)",
+      "domain": "Technology",
+      "sources": 2,
+      "corroborating": 3,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.0",
+      "industryPrimary": "AI Software & Platforms"
+    },
+    {
+      "id": "64",
+      "name": "Chile National Data Centers Plan",
+      "lat": -33.4489,
+      "lng": -70.6693,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Policy",
+      "sample": false,
+      "date": "5 December 2024",
+      "location": "Santiago, Chile",
+      "scope": "Chile (National)",
+      "description": "Chilean government's strategic plan to position Chile as Latin America's leading data centre hub, with regulatory frameworks and infrastructure investments to attract hyperscaler investment, including from Google, AWS, and Microsoft.",
+      "investment": "US$15B+ projected investment; 3+ hyperscaler commitments",
+      "domain": "Energy/Infrastructure",
+      "sources": 2,
+      "corroborating": 2,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.3",
+      "industryPrimary": "Cloud, Data Centres & Connectivity Infrastructure"
+    },
+    {
+      "id": "66",
+      "name": "China Global AI Governance Initiative (GAGI)",
+      "lat": 39.9042,
+      "lng": 116.4074,
+      "bloc": "Eastern",
+      "tier": 3,
+      "type": "Coordination",
+      "sample": false,
+      "date": "18 October 2023",
+      "location": "Beijing, China",
+      "scope": "Global (80+ countries; headquarters planned for Shanghai)",
+      "description": "China's comprehensive multilateral framework for international AI governance, development, and cooperation. Includes: Global AI Governance Initiative principles (October 2023), Global AI Governance Action Plan with 13-point framework (July 2025), and proposed World Artificial Intelligence Cooperation Organization.",
+      "investment": "Multi-nation coordination: 80+ countries (Group of Friends); 143 UN resolution co-sponsors",
+      "domain": "Technology",
+      "sources": 3,
+      "corroborating": 2,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.2",
+      "industryPrimary": "AI Software & Platforms"
+    },
+    {
+      "id": "67",
+      "name": "Seoul Declaration for Safe, Innovative and Inclusive AI",
+      "lat": 37.5665,
+      "lng": 126.978,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Coordination",
+      "sample": false,
+      "date": "21 May 2024",
+      "location": "Seoul, South Korea",
+      "scope": "Australia, Canada, EU, France, Germany, Italy, Japan, Republic of Korea, Singapore, United Kingdom, United States (11 sovereign entities)",
+      "description": "International declaration adopted at the AI Seoul Summit co-hosted by South Korea and the UK, building on the Bletchley Declaration to promote global cooperation on AI safety, innovation, and inclusivity. Establishes commitments for interoperable AI governance frameworks and international cooperation on AI safety science.",
+      "investment": "Multilateral agreement among 11 sovereign entities",
+      "domain": "Technology",
+      "sources": 3,
+      "corroborating": 5,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.2",
+      "industryPrimary": "AI Software & Platforms"
+    },
+    {
+      "id": "68",
+      "name": "DeepSeek-R1 Model Release",
+      "lat": 30.2741,
+      "lng": 120.1551,
+      "bloc": "Eastern",
+      "tier": 3,
+      "type": "Corporate",
+      "sample": false,
+      "date": "20 January 2025",
+      "location": "Hangzhou, China",
+      "scope": "Global (Open-source release with Western cloud platform adoption)",
+      "description": "Chinese AI lab DeepSeek released R1, an open-source reasoning model achieving performance comparable to OpenAI o1 at significantly lower cost. Subsequently adopted by major Western cloud providers (AWS, Azure, GCP) as managed model offerings, demonstrating cross-bloc technology diffusion.",
+      "investment": "671B parameters; MIT License; 1M+ downloads; 550+ derivatives; deployed across AWS Bedrock, Azure AI Foundry, Google Cloud Vertex AI",
+      "domain": "Technology",
+      "sources": 2,
+      "corroborating": 2,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.2",
+      "industryPrimary": "AI Software & Platforms"
+    },
+    {
+      "id": "69",
+      "name": "Qwen3 Model Family Release",
+      "lat": 30.2741,
+      "lng": 120.1551,
+      "bloc": "Eastern",
+      "tier": 3,
+      "type": "Corporate",
+      "sample": false,
+      "date": "28 April 2025",
+      "location": "Hangzhou, China",
+      "scope": "Global (119 languages; Singapore government adoption via SEA-LION)",
+      "description": "Alibaba Cloud released Qwen3, a family of open-source language models with native support for 119 languages. Subsequently adopted by Singapore's AI Singapore (AISG) as foundation for SEA-LION regional language models.",
+      "investment": "Multiple model sizes (0.6B to 235B parameters); Apache 2.0 License; 119 languages",
+      "domain": "Technology",
+      "sources": 2,
+      "corroborating": 2,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.1",
+      "industryPrimary": "AI Software & Platforms"
+    },
+    {
+      "id": "70",
+      "name": "Micron Technology CHIPS and Science Act Award",
+      "lat": 43.18666,
+      "lng": -76.16218,
+      "bloc": "Western-Led",
+      "tier": 2,
+      "type": "Infrastructure",
+      "sample": false,
+      "date": "December 2024",
+      "location": "Clay, New York, United States",
+      "scope": "United States (New York + Idaho; Virginia PMT pending)",
+      "description": "US Department of Commerce finalised CHIPS Act incentives award to Micron Technology for leading-edge memory semiconductor manufacturing. Micron is the only US-based manufacturer of memory chips. Official release explicitly links DRAM to High-Bandwidth Memory (HBM) \"critical for enabling new AI models.\"",
+      "investment": "US$6.165B direct CHIPS funding; US$125B total investment (NY+ID)",
+      "domain": "Energy/Infrastructure",
+      "sources": 3,
+      "corroborating": 1,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.1",
+      "industryPrimary": "Semiconductors & Equipment",
+      "environmentalNexusTags": [
+        {
+          "type": "ENT-1",
+          "name": "Resource Demand",
+          "mechanism": "Micron Clay operates under FEIS EISX-006-55-CPO-001 and NYSDEC Lake Ontario Water Withdrawal Permit authorising 48 MGD delivery infrastructure.",
+          "evidenceBasis": "Documented",
+          "vector": "Water",
+          "sources": [
+            {
+              "citation": "Draft Environmental Impact Statement EISX-006-55-CPO-001, NIST CHIPS Program Office / OCIDA",
+              "type": "primary",
+              "url": "https://ongoved.com",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429043557/https://ongoved.com/"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "71",
+      "name": "Viettel Hoa Lac Data Centre",
+      "lat": 21.0033,
+      "lng": 105.5389,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Infrastructure",
+      "sample": false,
+      "date": "April 2024",
+      "location": "Hanoi, Vietnam (Hoa Lac Hi-Tech Park)",
+      "scope": "Vietnam national",
+      "description": "Vietnam's largest data centre at time of inauguration, purpose-built for AI development with NVIDIA GPU integration via strategic partnership. Ho Chi Minh City High-Tech Data Centre expansion significantly increasing national AI compute capacity.",
+      "investment": "VND 10T (~US$401M) Hoa Lac facility; 6,000 NVIDIA GPUs; 30MW initial capacity; 140MW HCM City expansion",
+      "domain": "Energy/Infrastructure",
+      "sources": 2,
+      "corroborating": 2,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.1",
+      "industryPrimary": "Cloud, Data Centres & Connectivity Infrastructure",
+      "environmentalNexusTags": [
+        {
+          "type": "ENT-1",
+          "name": "Resource Demand",
+          "mechanism": "Viettel HCM City data centre expansion has documented 140MW power capacity.",
+          "evidenceBasis": "Documented",
+          "vector": "Energy",
+          "sources": [
+            {
+              "citation": "Event description — documented in WEO event canonical JSON",
+              "type": "primary"
+            }
+          ]
+        },
+        {
+          "type": "ENT-4",
+          "name": "Environmental Dependency",
+          "mechanism": "Viettel data centres in Vietnam (ND-GAIN Rank 101, Vulnerability 0.468) utilise water-cooled chillers, with documented typhoon/flood risk (Typhoon Yagi 2024) threatening cooling infrastructure.",
+          "evidenceBasis": "Assessed",
+          "dependencyType": "Extreme weather",
+          "riskIndex": "ND-GAIN",
+          "sources": [
+            {
+              "citation": "ND-GAIN Country Index — Vietnam",
+              "type": "corroborating",
+              "url": "https://gain.nd.edu/our-work/country-index/",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429043231/https://gain.nd.edu/our-work/country-index/"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "72",
+      "name": "True IDC Thailand Data Centre",
+      "lat": 12.6814,
+      "lng": 101.2816,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Infrastructure",
+      "sample": false,
+      "date": "May 2025",
+      "location": "Rayong, Thailand (Eastern Economic Corridor)",
+      "scope": "Thailand national / ASEAN regional hub",
+      "description": "Thailand's first AI Hyperscale Data Centre, purpose-built for AI processing and GPU workloads. Features NVIDIA H100 infrastructure via SIAM.AI CLOUD partnership and Microsoft Azure cloud region partnership, with Western institutional financing.",
+      "investment": "US$560M GIP/BlackRock financing; THB 10B corporate investment",
+      "domain": "Energy/Infrastructure",
+      "sources": 2,
+      "corroborating": 2,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.0",
+      "industryPrimary": "Cloud, Data Centres & Connectivity Infrastructure"
+    },
+    {
+      "id": "76",
+      "name": "Huawei PanGu 3.0 Foundation Model Suite",
+      "lat": 22.657501,
+      "lng": 114.055939,
+      "bloc": "Eastern",
+      "tier": 3,
+      "type": "Corporate",
+      "sample": false,
+      "date": "July 2023",
+      "location": "Shenzhen, China (Huawei HQ; launched at HDC.Cloud 2023 Dongguan)",
+      "scope": "China national / Global enterprise",
+      "description": "Huawei's sector-specific foundation model suite for government, finance, manufacturing, mining, and meteorology. PanGu Models 5.5 encompasses NLP, computer vision, multimodal, prediction, and scientific computing capabilities. Deployed across enterprise digitalisation scenarios with ECMWF adoption for operational weather forecasting.",
+      "investment": "Not disclosed (Huawei internal development); 400+ scenarios across 10+ industries",
+      "domain": "Technology",
+      "sources": 2,
+      "corroborating": 4,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.3",
+      "industryPrimary": "AI Software & Platforms"
+    },
+    {
+      "id": "77",
+      "name": "EuroHPC Leonardo Supercomputer",
+      "lat": 44.4858,
+      "lng": 11.26,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Infrastructure",
+      "sample": false,
+      "date": "24 November 2022",
+      "location": "Bologna, Italy",
+      "scope": "Italy (host) + Austria, Greece, Hungary, Slovakia, Slovenia (consortium)",
+      "description": "EuroHPC Joint Undertaking pre-exascale supercomputer hosted at CINECA in Bologna, Italy. LISA (Leonardo Improved Supercomputing Architecture) upgrade adds dedicated AI partition targeting LLM development and multimodal generative AI workloads. Part of the EU strategic investment in high-performance computing infrastructure.",
+      "investment": "€268.2 million total; 250 Petaflops; 13,824 A100 GPUs + 1,328 H100 GPUs",
+      "domain": "Energy/Infrastructure",
+      "sources": 2,
+      "corroborating": 2,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.2",
+      "industryPrimary": "Cloud, Data Centres & Connectivity Infrastructure"
+    },
+    {
+      "id": "78",
+      "name": "EuroHPC MareNostrum 5",
+      "lat": 41.38944,
+      "lng": 2.11611,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Infrastructure",
+      "sample": false,
+      "date": "21 December 2023",
+      "location": "Barcelona, Spain",
+      "scope": "Spain (host) + Portugal, Turkey (consortium)",
+      "description": "EuroHPC MareNostrum 5 supercomputer hosted at Barcelona Supercomputing Center (BSC), Spain. MareNostrum 5 ranked 8th globally at time of implementation (November 2023), featuring heterogeneous architecture with dedicated AI accelerator partition designed specifically for large-scale generative AI model training.",
+      "investment": "€202 million total (€151M EuroHPC JU); 314 Petaflops; Top500 #8 at implementation",
+      "domain": "Energy/Infrastructure",
+      "sources": 2,
+      "corroborating": 2,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.1",
+      "industryPrimary": "Cloud, Data Centres & Connectivity Infrastructure"
+    },
+    {
+      "id": "79",
+      "name": "xAI Colossus Supercomputer",
+      "lat": 35.0606,
+      "lng": -90.15662,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Corporate",
+      "sample": false,
+      "date": "22 July 2024",
+      "location": "Memphis, Tennessee, United States",
+      "scope": "United States",
+      "description": "xAI's purpose-built AI training facility in Memphis, Tennessee, representing the largest single-site GPU deployment globally at time of implementation. Dedicated to training xAI's Grok AI models with ongoing capacity expansion targeting further scaling of compute infrastructure.",
+      "investment": "~US$3-4 billion estimated; 200,000 GPUs; 1M GPU target announced",
+      "domain": "Energy/Infrastructure",
+      "sources": 2,
+      "corroborating": 2,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.3",
+      "industryPrimary": "Cloud, Data Centres & Connectivity Infrastructure",
+      "environmentalNexusTags": [
+        {
+          "type": "ENT-1",
+          "name": "Resource Demand",
+          "mechanism": "xAI Colossus has documented ~397MW total power capacity (150MW TVA grid + ~247MW onsite gas turbines).",
+          "evidenceBasis": "Documented",
+          "vector": "Energy",
+          "sources": [
+            {
+              "citation": "Event description — documented in WEO event canonical JSON",
+              "type": "primary"
+            }
+          ]
+        },
+        {
+          "type": "ENT-3",
+          "name": "Environmental Consequence",
+          "mechanism": "EPA NSPS ruling (January 2026) classified xAI Colossus gas turbines as stationary sources under the Clean Air Act, followed by formal 60-day Notice of Intent to sue (February 2026) citing violations of PSD, BACT, and NESHAP Subpart YYYY for operating up to 495MW of unpermitted generation capacity.",
+          "evidenceBasis": "Documented",
+          "activationStatus": "Active (Acute)",
+          "sources": [
+            {
+              "citation": "EPA NSPS Final Rule, Federal Register, January 15, 2026",
+              "type": "primary",
+              "url": "https://www.federalregister.gov/documents/2026/01/15/2026-00677/new-source-performance-standards-review-for-stationary-combustion-turbines-and-stationary-gas",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429044420/https://unblock.federalregister.gov/"
+            },
+            {
+              "citation": "SELC/Earthjustice/NAACP 60-day Notice of Intent to Sue, February 13, 2026",
+              "type": "primary",
+              "url": "https://earthjustice.org/wp-content/uploads/2026/02/2026.02.13-final-xai-southaven-noi-with-exhibit-a.pdf",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429043025/https://earthjustice.org/wp-content/uploads/2026/02/2026.02.13-final-xai-southaven-noi-with-exhibit-a.pdf"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "80",
+      "name": "Condor Galaxy 1 (CG-1) AI Supercomputer",
+      "lat": 37.3773,
+      "lng": -121.9531,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Corporate",
+      "sample": false,
+      "date": "19 July 2023",
+      "location": "Santa Clara, California, USA",
+      "scope": "UAE (G42) + USA (Cerebras) partnership",
+      "description": "Cerebras Systems and G42 joint AI supercomputer deployment, the first large-scale Wafer-Scale Engine cluster. Deployed at Colovore data centre in Santa Clara, California under U.S. law. Condor Galaxy network comprises three U.S.-based systems (CG-1, CG-2, CG-3) funded through UAE–U.S. strategic partnership, establishing significant cross-border AI compute capacity.",
+      "investment": "US$900 million total programme; 16 ExaFLOPS combined network",
+      "domain": "Energy/Infrastructure",
+      "sources": 2,
+      "corroborating": 3,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.1.2",
+      "industryPrimary": "Semiconductors & Equipment"
+    },
+    {
+      "id": "83",
+      "name": "Amkor Technology CHIPS and Science Act Award",
+      "lat": 33.725,
+      "lng": -112.29,
+      "bloc": "Western-Led",
+      "tier": 2,
+      "type": "Infrastructure",
+      "sample": false,
+      "date": "20 December 2024",
+      "location": "Peoria, Arizona, United States",
+      "scope": "United States",
+      "description": "US Department of Commerce finalised CHIPS and Science Act incentives award to Amkor Technology for advanced semiconductor packaging facility in Peoria, Arizona. First US-based advanced packaging facility capable of 2.5D technology for AI chips (GPUs), addressing critical supply chain bottleneck for AI semiconductor manufacturing.",
+      "investment": "US$407M direct funding; US$2B total project; 2.5D advanced packaging for AI chips",
+      "domain": "Energy/Infrastructure",
+      "sources": 3,
+      "corroborating": 2,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.1",
+      "industryPrimary": "Semiconductors & Equipment",
+      "environmentalNexusTags": [
+        {
+          "type": "ENT-1",
+          "name": "Resource Demand",
+          "mechanism": "Amkor Peoria operates under City of Peoria Class A Industrial Wastewater Discharge Permit and CHIPS PMT mandating 20% water intensity reduction and PFAS sampling.",
+          "evidenceBasis": "Documented",
+          "vector": "Water",
+          "sources": [
+            {
+              "citation": "CHIPS Preliminary Memorandum of Terms, NIST CHIPS Program Office",
+              "type": "primary",
+              "url": "https://www.nist.gov/chips/amkor-technology-inc-arizona-peoria",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429045243/https://www.nist.gov/chips/amkor-technology-inc-arizona-peoria"
+            }
+          ]
+        },
+        {
+          "type": "ENT-4",
+          "name": "Environmental Dependency",
+          "mechanism": "Amkor Peoria operates in WRI Aqueduct 'Extremely High' zone (Agua Fria sub-basin) with water-dependent advanced packaging processes documented in Class A discharge permit.",
+          "evidenceBasis": "Assessed",
+          "dependencyType": "Water stress",
+          "riskIndex": "WRI Aqueduct",
+          "sources": [
+            {
+              "citation": "WRI Aqueduct Water Risk Atlas 4.0 — Agua Fria / West Salt River Valley sub-basin",
+              "type": "corroborating",
+              "url": "https://www.wri.org/aqueduct",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429045504/https://www.wri.org/aqueduct"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "84",
+      "name": "01.AI Yi Model Family Release",
+      "lat": 39.9042,
+      "lng": 116.4074,
+      "bloc": "Eastern",
+      "tier": 3,
+      "type": "Corporate",
+      "sample": false,
+      "date": "2 November 2023",
+      "location": "Beijing, China",
+      "scope": "China (global open-source distribution)",
+      "description": "01.AI, founded by AI pioneer Kai-Fu Lee, released the Yi open-source model family. Yi-34B ranked first among pre-trained base LLMs on Hugging Face Open LLM Leaderboard at launch. Bilingual Chinese/English models released under a licence permitting academic research use, with commercial use requiring application to 01.AI.",
+      "investment": "US$1B+ valuation; Yi-6B, Yi-34B, Yi-1.5 (6B/9B/34B); academic research licence (commercial use by application)",
+      "domain": "Technology",
+      "sources": 2,
+      "corroborating": 2,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.3",
+      "industryPrimary": "AI Software & Platforms"
+    },
+    {
+      "id": "85",
+      "name": "Google Gemma Model Family Release",
+      "lat": 37.422,
+      "lng": -122.0841,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Corporate",
+      "sample": false,
+      "date": "21 February 2024",
+      "location": "Mountain View, California, USA",
+      "scope": "United States (global open-source distribution)",
+      "description": "Google released Gemma, a family of lightweight open-weights models built from research underlying the Gemini model series. Released under permissive terms for responsible AI development, Gemma enables developers and researchers worldwide to build AI applications. Available via Hugging Face, Kaggle, and Google Cloud.",
+      "investment": "Gemma 3 (1B/4B/12B/27B parameters); 150M+ downloads; 70,000+ derivative models",
+      "domain": "Technology",
+      "sources": 2,
+      "corroborating": 2,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.2",
+      "industryPrimary": "AI Software & Platforms"
+    },
+    {
+      "id": "86",
+      "name": "Microsoft Phi-3 Model Family Release",
+      "lat": 47.6423,
+      "lng": -122.1378,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Corporate",
+      "sample": false,
+      "date": "23 April 2024",
+      "location": "Redmond, Washington, USA",
+      "scope": "United States (global open-source distribution)",
+      "description": "Microsoft released Phi, a family of small language models demonstrating competitive performance at reduced parameter scales. Released under MIT open-source licence, Phi models are designed for edge deployment and resource-constrained environments. Available via Azure AI Model Catalog, Hugging Face, and Ollama.",
+      "investment": "Phi-4-reasoning (latest); 3.8B to 14B parameters; MIT open-source licence",
+      "domain": "Technology",
+      "sources": 1,
+      "corroborating": 3,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.2",
+      "industryPrimary": "AI Software & Platforms"
+    },
+    {
+      "id": "87",
+      "name": "US Executive Order 14179 — Removing Barriers to American Leadership in AI",
+      "lat": 38.8977,
+      "lng": -77.0365,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Policy",
+      "sample": false,
+      "date": "23 January 2025",
+      "location": "Washington, D.C., United States",
+      "scope": "United States (Federal)",
+      "description": "Foundational executive order establishing Trump administration AI policy framework. Rescinds Biden-era EO 14110 safety requirements; replaces with innovation-first, deregulatory approach. Mandates AI Action Plan development (delivered July 2025) and OMB memoranda revision. Policy objectives: \"human flourishing, economic competitiveness, and national security.\"",
+      "investment": "N/A (Policy Framework)",
+      "domain": "Technology",
+      "sources": 4,
+      "corroborating": 0,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.1",
+      "industryPrimary": "AI Software & Platforms"
+    },
+    {
+      "id": "88",
+      "name": "Samsung Electronics CHIPS and Science Act Award",
+      "lat": 30.1766,
+      "lng": -97.756,
+      "bloc": "Western-Led",
+      "tier": 2,
+      "type": "Infrastructure",
+      "sample": false,
+      "date": "20 December 2024",
+      "location": "Taylor, Texas, United States",
+      "scope": "United States",
+      "description": "US Department of Commerce finalised CHIPS and Science Act incentives award to Samsung Electronics for advanced semiconductor manufacturing facility in Taylor, Texas. Leading-edge logic production (4nm/2nm processes) for mobile, 5G, HPC, and AI applications.",
+      "investment": "US$4.745B direct funding; US$37B+ total project; leading-edge 4nm/2nm logic",
+      "domain": "Energy/Infrastructure",
+      "sources": 2,
+      "corroborating": 2,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.1",
+      "industryPrimary": "Semiconductors & Equipment",
+      "environmentalNexusTags": [
+        {
+          "type": "ENT-1",
+          "name": "Resource Demand",
+          "mechanism": "Samsung Taylor operates under PUC Docket No. 55256 (water service area transfer of 814.56 acres from Manville WSC to City of Taylor) and Project Funding Agreement specifying water/sewer infrastructure.",
+          "evidenceBasis": "Documented",
+          "vector": "Water",
+          "sources": [
+            {
+              "citation": "PUC Texas Docket No. 55256",
+              "type": "primary",
+              "url": "https://interchange.puc.texas.gov/Documents/55256_31_1392171.PDF",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429043421/https://interchange.puc.texas.gov/Documents/55256_31_1392171.PDF"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "89",
+      "name": "Texas Instruments CHIPS and Science Act Award",
+      "lat": 33.6407,
+      "lng": -96.6053,
+      "bloc": "Western-Led",
+      "tier": 2,
+      "type": "Infrastructure",
+      "sample": false,
+      "date": "20 December 2024",
+      "location": "Sherman, Texas, United States",
+      "scope": "United States (Texas, Utah)",
+      "description": "US Department of Commerce finalised CHIPS and Science Act incentives award to Texas Instruments for mature-node semiconductor manufacturing across facilities in Sherman, Texas and Lehi, Utah. Addresses critical supply chain vulnerabilities in analog and embedded processing chips essential for automotive, industrial, and edge computing applications.",
+      "investment": "US$1.61B direct funding; US$18B+ total project; mature-node 65nm-130nm analog/embedded",
+      "domain": "Energy/Infrastructure",
+      "sources": 2,
+      "corroborating": 2,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.1",
+      "industryPrimary": "Semiconductors & Equipment",
+      "environmentalNexusTags": [
+        {
+          "type": "ENT-4",
+          "name": "Environmental Dependency",
+          "mechanism": "TI Lehi operates in WRI Aqueduct 'High' water stress zone (Jordan River / Utah Lake sub-basin) with continuous evaporative cooling tower dependency, extracting groundwater under Utah Division of Water Rights permits WR 55-646, 55-1644, and 55-2640 (2,109 ML documented extraction 2025).",
+          "evidenceBasis": "Assessed",
+          "dependencyType": "Water stress",
+          "riskIndex": "WRI Aqueduct",
+          "sources": [
+            {
+              "citation": "Utah Division of Water Rights, Industrial Water Supplier System ID 2197",
+              "type": "primary",
+              "url": "https://waterrights.utah.gov/asp_apps/viewEditIND/indView.asp?SYSTEM_ID=2197",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429044246/https://waterrights.utah.gov/asp_apps/viewEditIND/indView.asp?SYSTEM_ID=2197"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "90",
+      "name": "GlobalFoundries CHIPS and Science Act Award",
+      "lat": 42.8864,
+      "lng": -73.8283,
+      "bloc": "Western-Led",
+      "tier": 2,
+      "type": "Infrastructure",
+      "sample": false,
+      "date": "20 November 2024",
+      "location": "Malta, New York, United States",
+      "scope": "United States (New York, Vermont)",
+      "description": "US Department of Commerce finalised CHIPS and Science Act incentives award to GlobalFoundries for current-generation semiconductor manufacturing. Expansion of Malta, NY and Essex Junction, Vermont facilities producing chips for automotive, IoT, aerospace, defence, and smart mobile devices. GlobalFoundries holds Trusted Foundry accreditation for US government classified work.",
+      "investment": "US$1.5B direct funding; US$13B+ total project; current-generation automotive/IoT/defense",
+      "domain": "Energy/Infrastructure",
+      "sources": 2,
+      "corroborating": 2,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.2",
+      "industryPrimary": "Semiconductors & Equipment",
+      "environmentalNexusTags": [
+        {
+          "type": "ENT-1",
+          "name": "Resource Demand",
+          "mechanism": "GlobalFoundries Malta operates under NYSDEC Water Withdrawal Permit WWA# 11,633 and SEQRA findings documenting 10.7 MGD primary water demand.",
+          "evidenceBasis": "Documented",
+          "vector": "Water",
+          "sources": [
+            {
+              "citation": "NYSDEC Water Withdrawal Permit WWA# 11,633 (12th Modification)",
+              "type": "primary",
+              "url": "https://documents.dps.ny.gov/public/Common/ViewDoc.aspx?DocRefId={993D2DB2-5281-42CB-97EE-CB710377B8C4}",
+              "accessDate": "2026-04-30",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260430095702/https://documents.dps.ny.gov/public/Common/ViewDoc.aspx?DocRefId=%7B993D2DB2-5281-42CB-97EE-CB710377B8C4%7D"
+            },
+            {
+              "citation": "Town of Malta SEQRA Statement of Findings",
+              "type": "primary",
+              "url": "https://www.townofmaltany.gov/Archive/ViewFile/Item/2711",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429045426/https://www.townofmaltany.gov/Archive/ViewFile/Item/2711"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "91",
+      "name": "LUMI Supercomputer",
+      "lat": 64.2243,
+      "lng": 27.733,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Infrastructure",
+      "sample": true,
+      "date": "13 June 2022",
+      "location": "Kajaani, Finland",
+      "scope": "EuroHPC JU (11-country consortium: Finland, Belgium, Czech Republic, Denmark, Estonia, Iceland, Netherlands, Norway, Poland, Sweden, Switzerland)",
+      "description": "European High-Performance Computing Joint Undertaking (EuroHPC JU) pre-exascale supercomputer inaugurated in Kajaani, Finland. Third fastest supercomputer globally at implementation (November 2022 Top500). Hosted by CSC – IT Center for Science. AMD-based architecture with 379.70 PFlops peak performance. Supports European AI ecosystem development and scientific computing.",
+      "investment": "€202M total (€101M EuroHPC JU + €101M consortium); Top500 #3 at implementation (Nov 2022), currently #9 (Nov 2025)",
+      "domain": "Energy/Infrastructure",
+      "sources": 4,
+      "corroborating": 4,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.1",
+      "basel5": [
+        {
+          "factor": "Size",
+          "pass": true,
+          "rationale": "Top500 #3 at implementation (November 2022); supercomputer ranking establishes significance"
+        },
+        {
+          "factor": "Interconnectedness",
+          "pass": true,
+          "rationale": "11-country consortium; serves pan-European AI research ecosystem"
+        },
+        {
+          "factor": "Substitutability",
+          "pass": true,
+          "rationale": "Unique pre-exascale capacity in Northern Europe; no comparable alternative"
+        },
+        {
+          "factor": "Complexity",
+          "pass": true,
+          "rationale": "Pre-exascale architecture; AMD MI250X GPUs; 379.70 PFlops"
+        },
+        {
+          "factor": "Cross-jurisdictional",
+          "pass": true,
+          "rationale": "11-country consortium under EU regulatory framework (Council Regulation 2021/1173)"
+        }
+      ],
+      "f1_annotation": "F1 qualification via Top500 pathway (#3 at implementation November 2022); currently #9 (November 2025)",
+      "tierRationale": "Tier 3: Intra-Bloc Coordination (Western). EuroHPC Joint Undertaking pre-exascale supercomputer established under Council Regulation (EU) 2021/1173 with 11-country consortium including Finland (host), Belgium, Czech Republic, Denmark, Estonia, Iceland, Netherlands, Norway, Poland, Sweden, and Switzerland. Official EuroHPC JU documentation frames LUMI as supporting European digital sovereignty, AI ecosystem development, and scientific competitiveness. All consortium members are Western-aligned (EU/EEA members or Switzerland participating in EU institutional frameworks). No cross-bloc restrictions or explicit Eastern Bloc references in governing documentation.",
+      "blocAnalysis": [
+        {
+          "bloc": "Western",
+          "involvement": "Yes",
+          "role": "11-country consortium (FI, BE, CZ, DK, EE, IS, NL, NO, PL, SE, CH)"
+        },
+        {
+          "bloc": "Eastern",
+          "involvement": "No",
+          "role": ""
+        },
+        {
+          "bloc": "Non-Aligned",
+          "involvement": "No",
+          "role": ""
+        }
+      ],
+      "primarySources": [
+        {
+          "id": "P1",
+          "desc": "EuroHPC JU — LUMI Inauguration",
+          "url": "https://www.eurohpc-ju.europa.eu/inauguration-lumi-fastest-greenest-supercomputer-europe-2022-06-13_en",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429153107/https://www.eurohpc-ju.europa.eu/inauguration-lumi-fastest-greenest-supercomputer-europe-2022-06-13_en"
+        },
+        {
+          "id": "P2",
+          "desc": "CSC — LUMI Specifications",
+          "url": "https://www.lumi-supercomputer.eu/",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429180416/https://lumi-supercomputer.eu/"
+        },
+        {
+          "id": "P3",
+          "desc": "Council Regulation (EU) 2021/1173",
+          "url": "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32021R1173",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429072026/https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX%3A32021R1173"
+        },
+        {
+          "id": "P4",
+          "desc": "Top500 — LUMI November 2022",
+          "url": "https://www.top500.org/system/180048/",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429211357/https://www.top500.org/system/180048/"
+        }
+      ],
+      "corroboratingSources": [
+        {
+          "id": "C1",
+          "desc": "HPCwire — LUMI Inauguration Coverage",
+          "url": "https://www.hpcwire.com/2022/06/13/lumi-europes-most-powerful-supercomputer-is-inaugurated-in-finland/",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429170902/https://www.hpcwire.com/2022/06/13/lumi-europes-most-powerful-supercomputer-is-inaugurated-in-finland/"
+        },
+        {
+          "id": "C2",
+          "desc": "European Commission — LUMI Press Release",
+          "url": "https://ec.europa.eu/commission/presscorner/detail/en/ip_22_3635",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429063652/https://ec.europa.eu/commission/presscorner/pageNotFound"
+        },
+        {
+          "id": "C3",
+          "desc": "Nature — LUMI Scientific Applications",
+          "url": "https://www.nature.com/articles/d41586-022-01649-8",
+          "accessDate": "2026-04-29",
+          "captureStatus": "dead_source"
+        },
+        {
+          "id": "C4",
+          "desc": "Science Business — EuroHPC LUMI Analysis",
+          "url": "https://sciencebusiness.net/news/lumi-supercomputer-inaugurated-finland",
+          "accessDate": "2026-04-29",
+          "captureStatus": "captured",
+          "snapshotUrl": "https://web.archive.org/web/20260429102012/https://sciencebusiness.net/news/lumi-supercomputer-inaugurated-finland"
+        }
+      ],
+      "relatedEvents": [],
+      "industryPrimary": "Cloud, Data Centres & Connectivity Infrastructure",
+      "industrySecondary": [
+        {
+          "tag": "Energy & Power Infrastructure",
+          "mechanism": "Vattenfall supplies 100% renewable hydroelectric power; waste heat provides ~20% of city heating."
+        }
+      ],
+      "versionDate": "2026-05-22",
+      "basel5_factors_met": 5
+    },
+    {
+      "id": "92",
+      "name": "Deucalion Supercomputer",
+      "lat": 41.4433,
+      "lng": -8.2964,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Infrastructure",
+      "sample": false,
+      "date": "6 September 2023",
+      "location": "Guimarães, Portugal",
+      "scope": "EuroHPC JU (Portugal national system)",
+      "description": "European High-Performance Computing Joint Undertaking (EuroHPC JU) petascale supercomputer inaugurated in Guimarães, Portugal. Hosted by University of Minho/MACC. ARM-based architecture pioneering European Processor Initiative (EPI) technology. First Top500 entry June 2024 (#219). Supports Portuguese AI research ecosystem and serves as EPI testbed.",
+      "investment": "€20M total (€7M EuroHPC JU + €13M Portugal); Top500 #219 at first entry (June 2024), currently #323 (Nov 2025)",
+      "domain": "Energy/Infrastructure",
+      "sources": 4,
+      "corroborating": 3,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.2",
+      "f1_annotation": "F1 qualification via Top500 pathway (#219 at first entry June 2024); currently #323 (November 2025)",
+      "industryPrimary": "Semiconductors & Equipment"
+    },
+    {
+      "id": "93",
+      "name": "China Administrative Provisions on Algorithm Recommendation",
+      "lat": 39.9042,
+      "lng": 116.4074,
+      "sample": false,
+      "date": "1 March 2022",
+      "location": "Beijing, China",
+      "bloc": "Eastern",
+      "tier": 3,
+      "type": "Policy",
+      "eventType": "Policy",
+      "domain": "Technology",
+      "scope": "People's Republic of China (Mainland)",
+      "investment": "Regulatory Framework (Penalties RMB 10,000-100,000; 30+ algorithms filed August 2022)",
+      "sources": 3,
+      "corroborating": 2,
+      "confidence": "A",
+      "description": "World's first comprehensive binding regulatory framework for recommendation algorithms. Establishes mandatory algorithm filing system, transparency requirements, and user control mechanisms for AI-powered content curation. Regulates generation/synthesis, personalized recommendation, ranking/selection, retrieval/filtering, and dispatching/decision-making algorithm technologies. Creates foundational regulatory infrastructure that subsequent AI regulations (Deep Synthesis, Generative AI Interim Measures) operationalise via explicit statutory cross-references. Joint issuance by CAC, MIIT, MPS, and SAMR.",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.2",
+      "verificationCheckpoints": {
+        "aiConnection": true,
+        "quantitativeThreshold": true,
+        "implementationStatus": true,
+        "currencyWindow": true
+      },
+      "confidenceTier": "A",
+      "industryPrimary": "AI Software & Platforms"
+    },
+    {
+      "id": "94",
+      "name": "China Administrative Provisions on Deep Synthesis",
+      "lat": 39.9042,
+      "lng": 116.4074,
+      "sample": false,
+      "date": "10 January 2023",
+      "location": "Beijing, China",
+      "bloc": "Eastern",
+      "tier": 3,
+      "type": "Policy",
+      "eventType": "Policy",
+      "domain": "Technology",
+      "scope": "People's Republic of China (Mainland)",
+      "investment": "Regulatory Framework (1,919 deep synthesis service algorithms filed across 7 batches (as of August 2024); enforcement via Data Security Law/PIPL)",
+      "sources": 3,
+      "corroborating": 1,
+      "confidence": "A",
+      "description": "Comprehensive regulation targeting AI-generated synthetic media including deepfakes. Article 23 provides detailed legal definitions covering six AI technology categories: text generation, speech synthesis, audio generation, biometric editing (face-swap, voice cloning), image/video generation, and virtual scene generation. Establishes mandatory content labelling requirements, consent frameworks for biometric data, and algorithm filing procedures. Article 19 explicitly requires compliance with Algorithm Recommendation Provisions' filing system. Joint issuance by CAC, MIIT, and MPS.",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.2",
+      "verificationCheckpoints": {
+        "aiConnection": true,
+        "quantitativeThreshold": true,
+        "implementationStatus": true,
+        "currencyWindow": true
+      },
+      "confidenceTier": "A",
+      "industryPrimary": "AI Software & Platforms"
+    },
+    {
+      "id": "95",
+      "name": "Doubao (ByteDance)",
+      "lat": 39.9847,
+      "lng": 116.3046,
+      "sample": false,
+      "date": "15 August 2023",
+      "location": "Beijing, China (ByteDance HQ)",
+      "bloc": "Eastern",
+      "tier": 3,
+      "type": "Corporate",
+      "eventType": "Corporate",
+      "domain": "Technology",
+      "scope": "People's Republic of China (Mainland)",
+      "investment": "Not disclosed (ByteDance internal development); 116M MAU (March 2025); China's #1 AIGC platform by user base",
+      "sources": 3,
+      "corroborating": 1,
+      "confidence": "A",
+      "description": "ByteDance's flagship AI assistant platform powered by the Doubao Large Language Model, achieving 116M MAU by March 2025 to become China's largest AIGC application. Multimodal capabilities include conversational AI, image generation (Seedream), and video generation (Seedance). Originally registered as Yunque (云雀) under CAC algorithm filing system, later rebranded as Doubao (豆包). Among first batch of 8 enterprises approved for public GenAI services on August 31, 2023.",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.1",
+      "verificationCheckpoints": {
+        "aiConnection": true,
+        "quantitativeThreshold": true,
+        "implementationStatus": true,
+        "currencyWindow": true
+      },
+      "confidenceTier": "A",
+      "industryPrimary": "AI Software & Platforms"
+    },
+    {
+      "id": "96",
+      "name": "UNIDO AIM Global Centre of Excellence (Shanghai)",
+      "lat": 31.16,
+      "lng": 121.35,
+      "bloc": "Eastern",
+      "tier": 3,
+      "type": "Coordination",
+      "sample": false,
+      "date": "4 July 2024",
+      "location": "Shanghai, China",
+      "scope": "Global (UNIDO: 170+ member states; AIM Global: 200+ members from 70+ countries)",
+      "description": "UNIDO-China joint centre for AI capacity building and technology transfer to Global South, hosted at Shanghai Artificial Intelligence Research Institute (SAIRI). Inaugurated at World Artificial Intelligence Conference 2024 with Phase II launched September 2025. Active programmes with Ethiopia, Kazakhstan, Philippines, Thailand, Mongolia, and Cambodia.",
+      "investment": "Trust Fund established September 2025; 200+ AIM Global alliance members (network-wide); 70+ countries engaged",
+      "domain": "Technology",
+      "sources": 4,
+      "corroborating": 2,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.2",
+      "industryPrimary": "AI Software & Platforms",
+      "ecosystemImplementation": [
+        {
+          "ecosystem": "US-centred",
+          "implemented": false,
+          "evidence": "Western-aligned UNIDO members participate through institutional membership; no US-centred ecosystem operational engagement"
+        },
+        {
+          "ecosystem": "China-centred",
+          "implemented": true,
+          "evidence": "MIIT bilateral partnership with institutional hosting at SAIRI; ministerial-level governance operational"
+        }
+      ]
+    },
+    {
+      "id": "99",
+      "name": "Amazon–Talen Energy Susquehanna PPA",
+      "lat": 41.0917,
+      "lng": -76.1489,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Corporate",
+      "sample": false,
+      "date": "11 June 2025",
+      "location": "Pennsylvania, United States",
+      "scope": "United States (PJM Interconnection region: PA, NJ, DE, MD, VA, WV, OH, DC, NC, KY, IN, IL, MI)",
+      "description": "Amazon Web Services and Talen Energy execute restructured power purchase agreement for nuclear-generated electricity from Susquehanna Nuclear Station. Grid-connected nuclear-hyperscaler PPA model post-FERC ruling, establishing precedent for hyperscaler-nuclear partnerships supporting AI and cloud operations.",
+      "investment": "US$18 billion contract value over 17 years; 1,920 MW capacity at full ramp by 2032; part of Amazon's US$20 billion Pennsylvania investment programme",
+      "domain": "Energy/Infrastructure",
+      "sources": 3,
+      "corroborating": 3,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.2",
+      "industryPrimary": "Energy & Power Infrastructure",
+      "environmentalNexusTags": [
+        {
+          "type": "ENT-1",
+          "name": "Resource Demand",
+          "mechanism": "Amazon-Talen 17-year nuclear PPA for 1,920MW from Susquehanna Nuclear Station.",
+          "evidenceBasis": "Documented",
+          "vector": "Energy-PPA",
+          "sources": [
+            {
+              "citation": "Talen Energy investor presentation",
+              "type": "primary",
+              "url": "https://ir.talenenergy.com/static-files/b6df3768-fe1d-4efe-84d5-68bc230b8438",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429043433/https://ir.talenenergy.com/static-files/b6df3768-fe1d-4efe-84d5-68bc230b8438"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "100",
+      "name": "JUPITER Supercomputer",
+      "lat": 50.906,
+      "lng": 6.41,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Infrastructure",
+      "sample": false,
+      "date": "June 2025",
+      "location": "Jülich, Germany",
+      "scope": "Pan-European (EuroHPC JU member states)",
+      "description": "Europe's first exascale supercomputer becomes operational at Forschungszentrum Jülich, achieving 1 ExaFLOP/s performance and ranking #4 globally on TOP500 at time of implementation. GPU-accelerated booster module with 24,000 NVIDIA GH200 superchips designed for AI training and large-scale simulations.",
+      "investment": "€500 million total investment (EuroHPC JU 50%, German Federal BMBF 25%, NRW State 25%); ~24,000 NVIDIA GH200 Grace Hopper Superchips; ~16 MW power consumption",
+      "domain": "Energy/Infrastructure",
+      "sources": 2,
+      "corroborating": 4,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.0",
+      "industryPrimary": "Cloud, Data Centres & Connectivity Infrastructure"
+    },
+    {
+      "id": "101",
+      "name": "ISO/IEC 42006:2025 Requirements for AI Management System Certification Bodies",
+      "lat": 46.2044,
+      "lng": 6.1432,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Coordination",
+      "sample": false,
+      "date": "July 2025",
+      "location": "Geneva, Switzerland",
+      "scope": "Global (ISO 169 member nations; IEC 89 member nations)",
+      "description": "International standard establishing requirements for bodies providing audit and certification of AI Management Systems (AIMS) per ISO/IEC 42001:2023. Published by ISO/IEC JTC 1/SC 42 with 39 participating member nations.",
+      "investment": "N/A — International technical standard (certification framework)",
+      "domain": "Technology",
+      "sources": 3,
+      "corroborating": 3,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.0",
+      "industryPrimary": "AI Software & Platforms",
+      "ecosystemImplementation": [
+        {
+          "ecosystem": "US-centred",
+          "implemented": true,
+          "evidence": "ANAB accredited 9 US certification bodies; UKAS and RvA accreditation operational in UK and Netherlands"
+        },
+        {
+          "ecosystem": "China-centred",
+          "implemented": false,
+          "evidence": "SAC P-member development participation; no Chinese accreditation or certification body activity verified"
+        }
+      ]
+    },
+    {
+      "id": "102",
+      "name": "SCO Member States AI Cooperation Programme Roadmap",
+      "lat": 30.5728,
+      "lng": 104.0668,
+      "bloc": "Eastern",
+      "tier": 3,
+      "type": "Coordination",
+      "sample": false,
+      "date": "12 June 2025",
+      "location": "Chengdu, China",
+      "scope": "SCO member states (10 nations: China, Russia, India, Pakistan, Kazakhstan, Kyrgyzstan, Tajikistan, Uzbekistan, Iran, Belarus) — ~3.2 billion population",
+      "description": "Shanghai Cooperation Organisation adopts roadmap for AI cooperation at 9th Science & Technology Ministers Meeting in Chengdu, subsequently endorsed by Tianjin Declaration (September 2025). Establishes framework for AI infrastructure interconnectivity, investment cooperation, talent cultivation, governance coordination, and technical standards harmonisation across Eurasian region.",
+      "investment": "N/A — Multilateral governance framework; implementation via SCO Interbank Consortium and member state programmes",
+      "domain": "Technology",
+      "sources": 4,
+      "corroborating": 3,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.1",
+      "industryPrimary": "AI Software & Platforms"
+    },
+    {
+      "id": "103",
+      "name": "OpenAI GPT-4 LLM Release",
+      "lat": 37.7749,
+      "lng": -122.4194,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Corporate",
+      "sample": false,
+      "date": "14 March 2023",
+      "location": "San Francisco, United States",
+      "scope": "Global (170+ countries via ChatGPT Plus and API)",
+      "description": "OpenAI released GPT-4, a frontier multimodal large language model, via the ChatGPT Plus platform and API. The model powered a platform exceeding 100M MAU at launch, with adoption by 92% of Fortune 500 companies and availability in 170+ countries, establishing it as the leading Western closed-source AI model.",
+      "investment": "~1.7T estimated parameters; 170+ country availability; 92% Fortune 500 adoption; 100M+ WAU (November 2023); 400M+ WAU (February 2025); Microsoft strategic investment context (US$13B+ cumulative)",
+      "domain": "Technology",
+      "sources": 2,
+      "corroborating": 2,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.1",
+      "industryPrimary": "AI Software & Platforms"
+    },
+    {
+      "id": "104",
+      "name": "Baidu ERNIE Bot Platform Release",
+      "lat": 39.9042,
+      "lng": 116.4074,
+      "bloc": "Eastern",
+      "tier": 3,
+      "type": "Corporate",
+      "sample": false,
+      "date": "31 August 2023",
+      "location": "Beijing, China",
+      "scope": "People's Republic of China (Mainland)",
+      "description": "Baidu publicly released ERNIE Bot, a frontier generative AI chatbot powered by the ERNIE large language model, following regulatory approval under China's Interim Measures for Generative AI. The platform reached 100M users within four months and is supported by the PaddlePaddle ecosystem of 8M developers and 220,000 enterprises at launch.",
+      "investment": "100M users within 4 months (December 2023); 430M users as of November 2024; PaddlePaddle ecosystem: 8M developers and 220,000 enterprises at launch, growing to 10.7M developers, 235,000 enterprises, and 860,000+ models by end-2023",
+      "domain": "Technology",
+      "sources": 2,
+      "corroborating": 2,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.1",
+      "industryPrimary": "AI Software & Platforms"
+    },
+    {
+      "id": "105",
+      "name": "US DoD CDAO",
+      "lat": 38.8719,
+      "lng": -77.0563,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Policy",
+      "sample": false,
+      "date": "1 June 2022",
+      "location": "Washington, D.C., United States",
+      "scope": "United States Department of Defense (all AI systems across DoD)",
+      "description": "US Department of Defense established the Chief Digital and Artificial Intelligence Office at full operating capability, consolidating JAIC, DDS, CDO, and Advana under a single authority with directive power over all DoD AI adoption, strategy, and policy. FY2023 budget of US$320.4M; oversight of 685+ AI-related projects.",
+      "investment": "US$320.4M FY2023 budget; 685+ AI-related projects; consolidation of 4 predecessor organisations (JAIC, DDS, CDO, Advana)",
+      "domain": "Security",
+      "sources": 2,
+      "corroborating": 2,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.1",
+      "industryPrimary": "Defence & Aerospace"
+    },
+    {
+      "id": "106",
+      "name": "France AMIAD (Defence AI Agency)",
+      "lat": 48.0453,
+      "lng": -1.7437,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Policy",
+      "sample": false,
+      "date": "1 May 2024",
+      "location": "Bruz, France",
+      "scope": "French Ministry of Armed Forces (all defence AI applications)",
+      "description": "France established the Ministerial Agency for Defence Artificial Intelligence (AMIAD) by decree, creating a dedicated operational agency to develop and deploy AI solutions for the armed forces. Annual budget of €300M; €2B allocated for 2024–2030; 300 technical staff; dedicated ASGARD supercomputer.",
+      "investment": "€300M annual budget; €2B allocation 2024–2030; 300 technical/research personnel; dedicated ASGARD supercomputer (operational September 2025)",
+      "domain": "Security",
+      "sources": 2,
+      "corroborating": 2,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.2",
+      "industryPrimary": "Defence & Aerospace"
+    },
+    {
+      "id": "107",
+      "name": "ISO/IEC 22989:2022 — AI Concepts and Terminology",
+      "lat": 46.2044,
+      "lng": 6.1432,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Coordination",
+      "sample": false,
+      "date": "July 2022",
+      "location": "Geneva, Switzerland",
+      "scope": "International (ISO/IEC JTC 1/SC 42 — 39 P-member nations)",
+      "description": "International standard establishing foundational concepts and terminology for artificial intelligence, providing the shared vocabulary referenced by the entire ISO/IEC SC 42 AI standards portfolio. Developed through JTC 1/SC 42 multi-nation consensus process.",
+      "investment": "SC 42: 39 P-member nations; foundational terminology standard cross-referenced by ISO/IEC 23894, 42001, 5338, 23053, 25059, 38507, TR 5469, 8183, 42006",
+      "domain": "Technology",
+      "sources": 2,
+      "corroborating": 2,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.0",
+      "industryPrimary": "AI Software & Platforms",
+      "ecosystemImplementation": [
+        {
+          "ecosystem": "US-centred",
+          "implemented": true,
+          "evidence": "Normative dependency via 42001 certification ecosystem; ANSI, BSI, DIN national catalogue adoption"
+        },
+        {
+          "ecosystem": "China-centred",
+          "implemented": false,
+          "evidence": "SAC P-member development participation; no Chinese national standard adoption verified"
+        }
+      ]
+    },
+    {
+      "id": "108",
+      "name": "Anthropic Claude 3 Model Release",
+      "lat": 37.7749,
+      "lng": -122.4194,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Corporate",
+      "sample": false,
+      "date": "4 March 2024",
+      "location": "San Francisco, United States",
+      "scope": "Global (159 countries via API)",
+      "description": "Anthropic released the Claude 3 model family (Opus, Sonnet, Haiku), achieving frontier benchmark performance (#1 on multiple evaluations) and API availability across 159 countries, establishing a major Western closed-source AI capability.",
+      "investment": "Claude 3 family (Opus/Sonnet/Haiku); 159 country availability; #1 Chatbot Arena ranking at launch; MMLU 86.8%, GPQA 50.4%, HumanEval 84.9%; ASL-2 safety classification; Amazon Bedrock and Google Cloud Vertex AI integration",
+      "domain": "Technology",
+      "sources": 2,
+      "corroborating": 2,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.1",
+      "industryPrimary": "AI Software & Platforms"
+    },
+    {
+      "id": "109",
+      "name": "Google Gemini 1.0 Model Release",
+      "lat": 37.3861,
+      "lng": -122.0839,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Corporate",
+      "sample": false,
+      "date": "6 December 2023",
+      "location": "Mountain View, United States",
+      "scope": "Global (170+ countries via Google Bard and API)",
+      "description": "Google released Gemini 1.0, a frontier multimodal AI model family (Ultra, Pro, Nano) available in 170+ countries, integrated into Google Bard and enterprise platforms, establishing Google's leading position in multimodal AI capability.",
+      "investment": "Gemini Ultra/Pro/Nano model family; 170+ country availability; multimodal capability (text, image, audio, video, code); Gemini Ultra claimed to exceed human expert performance on MMLU; integrated into Google Bard, Vertex AI, Google Workspace",
+      "domain": "Technology",
+      "sources": 2,
+      "corroborating": 2,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.1",
+      "industryPrimary": "AI Software & Platforms"
+    },
+    {
+      "id": "113",
+      "name": "NATO DARB",
+      "lat": 50.8766,
+      "lng": 4.4205,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Coordination",
+      "sample": false,
+      "date": "12 October 2022",
+      "location": "Brussels, Belgium (NATO HQ)",
+      "scope": "NATO Alliance (30 member states)",
+      "description": "NATO Defence Ministers established the Data and Artificial Intelligence Review Board to operationalise responsible AI principles and develop certification standards for military AI use across 30 NATO member states.",
+      "investment": "30 NATO member states; each member designates national nominee; operational body developing RAI (Responsible AI) certification standard for military AI applications",
+      "domain": "Security",
+      "sources": 2,
+      "corroborating": 2,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.1",
+      "industryPrimary": "Defence & Aerospace"
+    },
+    {
+      "id": "114",
+      "name": "Meta Llama 2 Model Release",
+      "lat": 37.453,
+      "lng": -122.1817,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Corporate",
+      "sample": false,
+      "date": "18 July 2023",
+      "location": "Menlo Park, United States",
+      "scope": "Global (open-weight distribution via HuggingFace and Meta AI portal)",
+      "description": "Meta released Llama 2, a family of open-weight large language models (7B/13B/70B parameters), under a community licence enabling global derivative creation and enterprise adoption across both Western and Eastern blocs.",
+      "investment": "7B/13B/70B parameter variants; Llama family: 350M+ downloads (August 2024), 1.2B+ downloads (April 2025); 60,000+ derivative models on HuggingFace; community licence (non-OSI); enterprise adoption (AT&T, DoorDash, Goldman Sachs, Shopify, Zoom)",
+      "domain": "Technology",
+      "sources": 2,
+      "corroborating": 2,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.1",
+      "industryPrimary": "AI Software & Platforms"
+    },
+    {
+      "id": "115",
+      "name": "China Antimony & Superhard Materials Export Controls",
+      "lat": 39.9042,
+      "lng": 116.4074,
+      "bloc": "Eastern-Led",
+      "tier": 2,
+      "type": "Policy",
+      "sample": false,
+      "date": "September 2024",
+      "location": "Beijing, China",
+      "scope": "Mainland China (global export impact)",
+      "description": "Export licensing controls on antimony, superhard materials, and associated production equipment per MOFCOM/GAC Announcement No. 33/2024. Controls capture antimony ores, high-purity antimony oxides (≥99.99%), organoantimonics (>99.999%), indium antimonide single crystals, hexapress equipment, and MPCVD equipment. China controls ~48% of global antimony ore production.",
+      "investment": ">US$500M estimated supply impact; antimony prices reached US$57,778/t by April 2025 (Fastmarkets MMTA Grade II Rotterdam)",
+      "domain": "Trade",
+      "sources": 1,
+      "corroborating": 2,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true,
+        "aiDetail": "PIET (4/4 gates — Trade-Impact Confirmed)"
+      },
+      "version": "1.1",
+      "aiConnectionPathway": "piet",
+      "industryPrimary": "Mining & Critical Minerals"
+    },
+    {
+      "id": "116",
+      "name": "SenseTime AI Data Centre (AIDC) Shanghai Lingang",
+      "lat": 30.8902,
+      "lng": 121.9356,
+      "bloc": "Eastern",
+      "tier": 3,
+      "type": "Corporate",
+      "sample": false,
+      "date": "January 2022",
+      "location": "Lingang New Area, Shanghai Free Trade Zone, China",
+      "scope": "Shanghai (national AI compute contribution)",
+      "description": "Purpose-built AI data centre operated by SenseTime (HKEX: 0020) for AI model training. 130,000 sqm facility with 5,000 cabinets, scaling from 3,740 PFLOPS (2022) to 8,100 PFLOPS (2024) to 25,000+ PFLOPS national managed total (as of August 2025). Trains SenseTime's Ri Ri Xin (日日新) LLMs. Hardware mix of NVIDIA GPUs and domestic chips (Huawei Ascend, Cambricon) with >50% domestic target (announced 2022 for 2024 completion). Designated under MIIT 智算中心 framework. Serves 40+ core customers.",
+      "investment": "~RMB 5.6B (~US$800M)",
+      "domain": "Energy/Infrastructure",
+      "sources": 2,
+      "corroborating": 1,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.1",
+      "industryPrimary": "Cloud, Data Centres & Connectivity Infrastructure",
+      "environmentalNexusTags": [
+        {
+          "type": "ENT-2",
+          "name": "Environmental Enablement",
+          "mechanism": "SenseTime AIDC operates under mandatory GB 40879-2021 PUE standards via MIIT 智算中心 designation, with Shanghai municipal power rationing (6kW standard rack quotas) and Lingang-specific efficiency subsidies conditioning operational parameters.",
+          "evidenceBasis": "Documented",
+          "sources": [
+            {
+              "citation": "Shanghai Municipal Commission of Economy and Information Technology data centre policy",
+              "type": "primary",
+              "url": "https://sheitc.sh.gov.cn/xxfw/20210407/3774163f0b3f4bb399e15ad592f7c2f8.html",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429044022/https://sheitc.sh.gov.cn/xxfw/20210407/3774163f0b3f4bb399e15ad592f7c2f8.html"
+            },
+            {
+              "citation": "GB 40879-2021 (数据中心能效限定值及能效等级)",
+              "type": "primary",
+              "url": "https://openstd.samr.gov.cn/bzgk/gb/newGbInfo?hcno=4AAF5CA9387980A1FEA1FA47ABA503BA",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429043625/https://openstd.samr.gov.cn/bzgk/std/newGbInfo?hcno=4AAF5CA9387980A1FEA1FA47ABA503BA"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "117",
+      "name": "Kimi K2 Model Release",
+      "lat": 39.9042,
+      "lng": 116.4074,
+      "bloc": "Eastern",
+      "tier": 3,
+      "type": "Corporate",
+      "sample": false,
+      "date": "11 July 2025",
+      "location": "Beijing, China",
+      "scope": "Global (open-source release deployed on Western inference platforms)",
+      "description": "Moonshot AI released Kimi K2-Instruct, a 1.04-trillion-parameter mixture-of-experts language model with 32 billion activated parameters and 384 experts, trained on 15.5 trillion tokens using Multi-head Latent Attention (MLA) architecture. Released under Modified MIT License.",
+      "investment": "1.04T total parameters; 32B activated; 15.5T training tokens; Modified MIT License",
+      "domain": "Technology",
+      "sources": 2,
+      "corroborating": 2,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.0",
+      "industryPrimary": "AI Software & Platforms"
+    },
+    {
+      "id": "118",
+      "name": "Qwen3-Coder Model Release",
+      "lat": 30.2741,
+      "lng": 120.1551,
+      "bloc": "Eastern",
+      "tier": 3,
+      "type": "Corporate",
+      "sample": false,
+      "date": "22 July 2025",
+      "location": "Hangzhou, China",
+      "scope": "Global (open-source release deployed on Western cloud platforms)",
+      "description": "Alibaba Cloud released Qwen3-Coder-480B-A35B-Instruct, a 480-billion-parameter mixture-of-experts agentic code model with 35 billion activated parameters. Trained on 7.5 trillion tokens including approximately 600 billion repository-level coding tokens, the model supports 256K native context length and is released under the Apache 2.0 licence.",
+      "investment": "480B total parameters; 35B activated; 7.5T training tokens; Apache 2.0 License",
+      "domain": "Technology",
+      "sources": 2,
+      "corroborating": 2,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.0",
+      "industryPrimary": "AI Software & Platforms"
+    },
+    {
+      "id": "119",
+      "name": "DeepSeek-V3.1 Model Release",
+      "lat": 30.2741,
+      "lng": 120.1551,
+      "bloc": "Eastern",
+      "tier": 3,
+      "type": "Corporate",
+      "sample": false,
+      "date": "21 August 2025",
+      "location": "Hangzhou, China",
+      "scope": "Global (open-source release deployed on Western cloud platforms)",
+      "description": "DeepSeek released V3.1, a 671-billion-parameter mixture-of-experts hybrid model with 37 billion activated parameters. Built via 840 billion tokens of continued pretraining on the V3 base architecture, V3.1 introduces hybrid Think/Non-Think inference modes allowing toggling between chain-of-thought reasoning and direct answers. Released under the MIT License.",
+      "investment": "671B total parameters; 37B activated; 14.8T base + 840B continued pretraining tokens; MIT License",
+      "domain": "Technology",
+      "sources": 2,
+      "corroborating": 2,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.0",
+      "industryPrimary": "AI Software & Platforms"
+    },
+    {
+      "id": "120",
+      "name": "US BIS Advanced Computing Semiconductor IFR",
+      "lat": 38.8951,
+      "lng": -77.0364,
+      "bloc": "Western-Led",
+      "tier": 2,
+      "type": "Policy",
+      "sample": false,
+      "date": "November 2023",
+      "location": "Washington, DC, United States",
+      "scope": "United States (extraterritorial — ~40 jurisdictions via FDP rule)",
+      "description": "BIS interim final rule (88 FR 73458) updating October 2022 export controls on advanced computing integrated circuits, revising controlled performance thresholds (TPP/PD) under ECCN 3A090. Expands the Advanced Computing Foreign Direct Product Rule from PRC/Macau to Country Groups D:1, D:4, and D:5.",
+      "investment": "Regulatory restriction (no direct financial allocation); EAR enforcement with civil/criminal penalties; extraterritorial FDP rule covering ~40 jurisdictions",
+      "domain": "Security",
+      "sources": 2,
+      "corroborating": 0,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.0",
+      "industryPrimary": "Semiconductors & Equipment"
+    },
+    {
+      "id": "121",
+      "name": "China Graphite Export Controls (MOFCOM/GAC No. 39/2023)",
+      "lat": 39.9042,
+      "lng": 116.4074,
+      "bloc": "Eastern",
+      "tier": 3,
+      "type": "Policy",
+      "sample": false,
+      "date": "1 December 2023",
+      "location": "Beijing, China",
+      "domain": "Trade",
+      "confidence": "A",
+      "version": "1.2",
+      "aiConnectionPathway": "piet",
+      "checkpoints": {
+        "ai": true,
+        "aiDetail": "PIET (3/4 gates — Trade-Impact Confirmed)",
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "description": "Export licensing controls on specified graphite materials and products per MOFCOM/GAC Joint Announcement No. 39/2023. Controls capture high-purity synthetic graphite, natural flake graphite, spherical graphite, and expanded graphite defined by HS code specifications. China produces approximately 77% of global natural graphite.",
+      "investment": "N/A (regulatory instrument). Trade disruption: flake graphite exports declined 93.93% MoM December 2023; fine flake graphite prices decreased approximately 19% in 2024",
+      "scope": "Mainland China (global export impact)",
+      "sources": 2,
+      "corroborating": 2,
+      "industryPrimary": "Mining & Critical Minerals"
+    },
+    {
+      "id": "122",
+      "name": "China MOFCOM Dual-Use Export Ban (No. 46/2024)",
+      "lat": 39.9042,
+      "lng": 116.4074,
+      "bloc": "Eastern-Led",
+      "tier": 2,
+      "type": "Policy",
+      "sample": false,
+      "date": "3 December 2024",
+      "location": "Beijing, China",
+      "domain": "Security",
+      "confidence": "A",
+      "version": "1.1",
+      "aiConnectionPathway": "piet",
+      "checkpoints": {
+        "ai": true,
+        "aiDetail": "PIET (3/4 gates — Trade-Impact Confirmed)",
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "description": "MOFCOM Announcement No. 46/2024 establishing export controls explicitly targeting the United States. Article 1 prohibits export of all dual-use items to US military users or military end-uses. Article 2 bans in principle the export of gallium, germanium, antimony, and superhard materials to the US. Extraterritorial clause extends liability worldwide. Article 2 suspended from 9 November 2025 to 27 November 2026 via Announcement No. 72/2025; Article 1 remains in force.",
+      "investment": "N/A (regulatory instrument). Market impact: antimony prices surged >300% to US$59,750/t; US imports of germanium fell to zero; antimony shipments ceased",
+      "scope": "National (China) targeting the United States",
+      "sources": 2,
+      "corroborating": 3,
+      "industryPrimary": "Mining & Critical Minerals"
+    },
+    {
+      "id": "123",
+      "name": "SK Hynix CHIPS and Science Act Award",
+      "lat": 40.4237,
+      "lng": -86.9212,
+      "bloc": "Western-Led",
+      "tier": 2,
+      "type": "Infrastructure",
+      "sample": false,
+      "date": "19 December 2024",
+      "location": "West Lafayette, Indiana, United States",
+      "domain": "Energy/Infrastructure",
+      "confidence": "A",
+      "version": "1.0",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "description": "US Department of Commerce CHIPS and Science Act incentives award to SK Hynix for high-bandwidth memory advanced packaging fabrication facility in West Lafayette, Indiana. World's leading HBM producer building first US-based advanced packaging facility. Mass production expected second half of 2028.",
+      "investment": "US$3.87B total investment (US$458M direct federal funding + US$500M loans under CHIPS Incentives Program)",
+      "scope": "United States (global AI hardware supply chain)",
+      "sources": 2,
+      "corroborating": 2,
+      "industryPrimary": "Semiconductors & Equipment",
+      "environmentalNexusTags": [
+        {
+          "type": "ENT-1",
+          "name": "Resource Demand",
+          "mechanism": "SK Hynix West Lafayette operates under IDEM Industrial Wastewater Discharge Permit with documented 2.8M gallons/day average water usage.",
+          "evidenceBasis": "Documented",
+          "vector": "Water",
+          "sources": [
+            {
+              "citation": "SK Hynix West Lafayette facility documentation",
+              "type": "primary",
+              "url": "https://neuron.prf.org/wp-content/uploads/2025/04/Leaflet-for-SK-hynix-West-Lafayette_FINAL.pdf",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429043516/https://neuron.prf.org/wp-content/uploads/2025/04/Leaflet-for-SK-hynix-West-Lafayette_FINAL.pdf"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "124",
+      "name": "ISO/IEC 42005:2025 AI System Impact Assessment",
+      "lat": 46.2044,
+      "lng": 6.1432,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Coordination",
+      "sample": false,
+      "date": "28 May 2025",
+      "location": "Geneva, Switzerland",
+      "domain": "Technology",
+      "confidence": "A",
+      "version": "1.0",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "description": "International standard providing guidance for AI system impact assessments covering intended and unintended consequences across the AI lifecycle. Published by ISO/IEC JTC 1/SC 42 with 48 participating national member bodies. Includes informative annexes mapping to ISO/IEC 42001 and ISO/IEC 23894.",
+      "investment": "Full International Standard status; 48 P-member national bodies",
+      "scope": "International (ISO/IEC member nations)",
+      "sources": 2,
+      "corroborating": 2,
+      "industryPrimary": "AI Software & Platforms",
+      "ecosystemImplementation": [
+        {
+          "ecosystem": "US-centred",
+          "implemented": true,
+          "evidence": "Emerging adoption — AvISO use during 42001 certification, Intertek Academy training, ITCERTS assessor examination"
+        },
+        {
+          "ecosystem": "China-centred",
+          "implemented": false,
+          "evidence": "SAC P-member development participation; no Chinese adoption or operational use verified"
+        }
+      ]
+    },
+    {
+      "id": "125",
+      "name": "UK Isambard-AI Phase 2 National Supercomputer",
+      "lat": 51.5054,
+      "lng": -2.5426,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Infrastructure",
+      "sample": false,
+      "date": "17 July 2025",
+      "location": "Bristol, United Kingdom",
+      "domain": "Energy/Infrastructure",
+      "confidence": "A",
+      "version": "1.0",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "description": "UK Government Isambard-AI Phase 2 supercomputer at the National Composites Centre, Bristol, delivering 5,448 NVIDIA GH200 Grace Hopper Superchips. Funded through UKRI/DSIT as part of the AI Research Resource (AIRR) programme. UK's most powerful public compute facility, ranked 11th globally on TOP500.",
+      "investment": "£225M (~US$302M); 5,448 GH200 GPUs; 21+ ExaFLOPs AI performance",
+      "scope": "United Kingdom (national AI research resource)",
+      "sources": 3,
+      "corroborating": 1,
+      "industryPrimary": "Cloud, Data Centres & Connectivity Infrastructure"
+    },
+    {
+      "id": "126",
+      "name": "Stargate Joint Venture",
+      "lat": 32.4487,
+      "lng": -99.7331,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Corporate",
+      "sample": false,
+      "date": "21 January 2025",
+      "location": "Abilene, Texas, United States (flagship); multi-site US",
+      "scope": "United States — 6+ sites across Texas, New Mexico, Ohio, Wisconsin, Michigan. Venture-wide scope under Stargate LLC with Abilene as primary documented location.",
+      "description": "Stargate LLC is a US AI infrastructure joint venture with US$450B+ committed investment across 6+ sites, backed by equity from SoftBank, OpenAI, Oracle, and MGX. The Abilene, Texas flagship campus (1,100 acres, 1.2 GW power capacity) deploys NVIDIA GB200 racks and has been operational since September 2025. Additional sites span New Mexico, Ohio, Wisconsin, and Michigan, with 8+ GW total planned capacity.",
+      "investment": "US$450B+ committed investment; initial equity: SoftBank US$19B, OpenAI US$19B, Oracle US$7B, MGX US$7B. Abilene campus park investment at GW-scale data centre buildout.",
+      "domain": "Energy/Infrastructure",
+      "sources": 7,
+      "corroborating": 2,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.0",
+      "industryPrimary": "Cloud, Data Centres & Connectivity Infrastructure",
+      "environmentalNexusTags": [
+        {
+          "type": "ENT-1",
+          "name": "Resource Demand",
+          "mechanism": "Stargate Abilene campus has documented 1.2 GW power capacity.",
+          "evidenceBasis": "Documented",
+          "vector": "Energy",
+          "sources": [
+            {
+              "citation": "Event description — documented in WEO event canonical JSON",
+              "type": "primary"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "127",
+      "name": "Meta Llama 3 Model Family Release",
+      "lat": 37.453,
+      "lng": -122.1817,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Corporate",
+      "sample": false,
+      "date": "18 April 2024",
+      "location": "Menlo Park, California, United States",
+      "scope": "Global — model weights publicly available on Hugging Face and 25+ cloud platforms. Llama 3.1 405B added July 2024 as rolling update within same model family.",
+      "description": "Meta released Llama 3 on 18 April 2024 with 8B and 70B parameter open-weight models trained on 15 trillion tokens. Released under the Meta Llama 3 Community License permitting commercial use with a 700 million MAU threshold. Llama 3.1 (July 2024) added the 405B parameter model. Over 1 billion total downloads reported by March 2025.",
+      "investment": "Training infrastructure: 16,000+ NVIDIA H100 GPUs, 30.84 million GPU-hours. Corporate R&D allocation — specific investment figure not publicly disclosed.",
+      "domain": "Technology",
+      "sources": 3,
+      "corroborating": 3,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.0",
+      "industryPrimary": "AI Software & Platforms"
+    },
+    {
+      "id": "128",
+      "name": "China Mobile Intelligent Computing Centre (Hohhot)",
+      "lat": 40.5826,
+      "lng": 111.6596,
+      "bloc": "Eastern",
+      "tier": 3,
+      "type": "Infrastructure",
+      "sample": false,
+      "date": "28 April 2024",
+      "location": "Horinger New Area, Hohhot, Inner Mongolia, China",
+      "scope": "China — national-scale AI training computing pool within East Data West Compute (东数西算) Inner Mongolia hub node. Single-facility scope under China Mobile operation.",
+      "description": "China Mobile Intelligent Computing Centre (Hohhot) is the largest single-body intelligent computing centre operated by a global telecoms operator. The facility deploys approximately 20,000 AI acceleration cards with 6.7 EFLOPS (FP16) intelligent computing power. AI chip localisation rate exceeds 85%, integrating 5 domestic chip architectures. Cold-plate liquid cooling achieves PUE of 1.15.",
+      "investment": "Smart computing project total investment RMB 4.66 billion (~US$640M). Part of China Mobile Hohhot data centre campus with overall campus infrastructure investment ~RMB 40 billion (~US$5.5 billion) since 2012. Regional electricity cost 0.365 RMB/kWh. Green electricity share ~80% (smart computing centre; 69% is 2024 full campus annual average).",
+      "domain": "Energy/Infrastructure",
+      "sources": 2,
+      "corroborating": 3,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "aiDetail": "OEP (Pathway C — Strong)",
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.1",
+      "aiConnectionPathway": "oep",
+      "industryPrimary": "Cloud, Data Centres & Connectivity Infrastructure",
+      "environmentalNexusTags": [
+        {
+          "type": "ENT-2",
+          "name": "Environmental Enablement",
+          "mechanism": "China Mobile Hohhot operates under mandatory PUE standards (GB 40879-2021) and Inner Mongolia provincial energy efficiency requirements via administrative-hierarchy enforcement.",
+          "evidenceBasis": "Documented",
+          "sources": [
+            {
+              "citation": "GB 40879-2021 (数据中心能效限定值及能效等级)",
+              "type": "primary",
+              "url": "https://openstd.samr.gov.cn/bzgk/gb/newGbInfo?hcno=4AAF5CA9387980A1FEA1FA47ABA503BA",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429043625/https://openstd.samr.gov.cn/bzgk/std/newGbInfo?hcno=4AAF5CA9387980A1FEA1FA47ABA503BA"
+            }
+          ]
+        },
+        {
+          "type": "ENT-4",
+          "name": "Environmental Dependency",
+          "mechanism": "China Mobile Hohhot operates in WRI Aqueduct 'High to Extremely High' zone with cold-plate liquid cooling requiring evaporative heat rejection via secondary cooling loops.",
+          "evidenceBasis": "Assessed",
+          "dependencyType": "Water stress",
+          "riskIndex": "WRI Aqueduct",
+          "sources": [
+            {
+              "citation": "China Mobile corporate communications — cold-plate liquid cooling (冷板式液冷), PUE 1.15, 69% green electricity",
+              "type": "corroborating"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "129",
+      "name": "Google Gemini 1.5 Pro Model Release",
+      "lat": 37.3861,
+      "lng": -122.0839,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Corporate",
+      "sample": false,
+      "date": "23 May 2024",
+      "location": "Mountain View, California, USA",
+      "scope": "Global (200+ countries via API and consumer interface)",
+      "description": "Google released Gemini 1.5 Pro, a Mixture-of-Experts architecture AI model with a 1 million token context window and native multimodal capability across text, image, audio, and video. Generally available via API from 23 May 2024, with Workspace integration from June 2024.",
+      "investment": "350M monthly active users (March 2025); 200+ countries and territories; MoE architecture with 1M token context window; multimodal (text, image, audio, video, code); Workspace enterprise integration",
+      "domain": "Technology",
+      "sources": 3,
+      "corroborating": 2,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.0",
+      "industryPrimary": "AI Software & Platforms"
+    },
+    {
+      "id": "130",
+      "name": "European AI Office",
+      "lat": 50.8503,
+      "lng": 4.3517,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Policy",
+      "sample": false,
+      "date": "16 June 2024",
+      "location": "Brussels, Belgium",
+      "scope": "Supranational — 27 EU Member States",
+      "description": "The European Commission established the European AI Office within DG CONNECT via Commission Decision C(2024) 390, becoming operational on 16 June 2024. The Office enforces rules for general-purpose AI models under the EU AI Act, with investigation, evaluation, and penalty powers.",
+      "investment": "Funded through Digital Europe Programme (Specific Objective 2 — Artificial Intelligence); 140+ staff target; enforcement powers including fines up to 3% of worldwide turnover or €15 million",
+      "domain": "Technology",
+      "sources": 3,
+      "corroborating": 0,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.0",
+      "industryPrimary": "AI Software & Platforms"
+    },
+    {
+      "id": "131",
+      "name": "Canadian AI Safety Institute (CAISI)",
+      "lat": 45.4215,
+      "lng": -75.6972,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Policy",
+      "sample": false,
+      "date": "12 November 2024",
+      "location": "Ottawa, Canada",
+      "scope": "National (leveraging Amii, Mila, Vector Institute)",
+      "description": "The Government of Canada launched the Canadian Artificial Intelligence Safety Institute on 12 November 2024, with CAD $50 million over five years. CAISI operates a dual-track structure: Stream 1 through CIFAR for investigator-led research and Stream 2 through NRC for government-directed research.",
+      "investment": "CAD $50M over 5 years (from Budget 2024 US$2.4B AI package); dual-track: US$27M CIFAR contribution (Stream 1) + NRC government-directed research (Stream 2); INAISI founding member",
+      "domain": "Technology",
+      "sources": 2,
+      "corroborating": 2,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.0",
+      "industryPrimary": "AI Software & Platforms"
+    },
+    {
+      "id": "132",
+      "name": "Microsoft-Constellation Crane Clean Energy Center Nuclear PPA",
+      "lat": 40.1532,
+      "lng": -76.7247,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Corporate",
+      "sample": false,
+      "date": "20 September 2024",
+      "location": "Londonderry Township, Pennsylvania, USA",
+      "domain": "Energy/Infrastructure",
+      "industryPrimary": "Energy & Power Infrastructure",
+      "description": "Microsoft's 20-year power purchase agreement with Constellation Energy to restart Three Mile Island Unit 1, rebranded Crane Clean Energy Center, providing 835 MW of carbon-free nuclear baseload power for data centre operations in the PJM Interconnection grid. Target operational date 2028.",
+      "investment": "US$1.6B capital expenditure; 835 MW capacity; 20-year PPA term; PJM Interconnection (13 states + DC); licence extension to 2054",
+      "scope": "United States (PJM Interconnection region)",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.1",
+      "sources": 2,
+      "corroborating": 3,
+      "confidence": "A",
+      "environmentalNexusTags": [
+        {
+          "type": "ENT-1",
+          "name": "Resource Demand",
+          "mechanism": "Microsoft 20-year PPA with Constellation for 835MW nuclear baseload from Crane Clean Energy Center.",
+          "evidenceBasis": "Documented",
+          "vector": "Energy-PPA",
+          "sources": [
+            {
+              "citation": "Constellation Energy / Microsoft TMI restart announcement",
+              "type": "corroborating",
+              "url": "https://www.utilitydive.com/news/constellation-three-mile-island-nuclear-power-plant-microsoft-data-center-ppa/727652/",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429045437/https://www.utilitydive.com/news/constellation-three-mile-island-nuclear-power-plant-microsoft-data-center-ppa/727652/"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "133",
+      "name": "Amazon-X-energy Xe-100 SMR Investment",
+      "lat": 39.084,
+      "lng": -77.1528,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Corporate",
+      "sample": false,
+      "date": "16 October 2024",
+      "location": "Rockville, Maryland, USA",
+      "domain": "Energy/Infrastructure",
+      "industryPrimary": "Energy & Power Infrastructure",
+      "description": "Amazon's approximately US$500M anchor investment in X-energy's Series C-1 financing round to develop Xe-100 advanced small modular reactors and TRISO-X fuel for AI data centre power. Initial 320 MW deployment planned with Energy Northwest at Columbia Generating Station site, Washington state.",
+      "investment": "~US$500M Series C-1 (upsized to US$700M by Feb 2025); 320 MW initial deployment (4 Xe-100 modules); 5 GW target by 2039",
+      "scope": "United States (Washington state initial; national deployment target)",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.1",
+      "sources": 2,
+      "corroborating": 1,
+      "confidence": "A",
+      "environmentalNexusTags": [
+        {
+          "type": "ENT-1",
+          "name": "Resource Demand",
+          "mechanism": "Amazon anchor investment targets 320MW initial Xe-100 SMR deployment for data centre power.",
+          "evidenceBasis": "Documented",
+          "vector": "Energy",
+          "sources": [
+            {
+              "citation": "X-energy Series C-1 financing announcement",
+              "type": "corroborating",
+              "url": "https://www.neimagazine.com/news/amazon-invests-in-nuclear-energy/",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429045057/https://www.neimagazine.com/news/amazon-invests-in-nuclear-energy/"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "134",
+      "name": "US DoD Replicator Initiative (Tranche 1)",
+      "lat": 38.8719,
+      "lng": -77.0563,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Policy",
+      "sample": false,
+      "date": "6 May 2024",
+      "location": "United States (DoD-wide)",
+      "domain": "Security",
+      "industryPrimary": "Defence & Aerospace",
+      "description": "US Department of Defense programme to field all-domain attritable autonomous systems at scale, led by the Defense Innovation Unit. Tranche 1 selected systems include AeroVironment Switchblade-600, Anduril Altius-600 and Ghost-X, and Performance Drone Works C-100, acquired through Commercial Solutions Openings. CDAO provides enterprise policy and software architecture enablement.",
+      "investment": "~US$500M FY2024 (US$300M reprogramming + US$200M existing authorities); ~US$1B total FY2024–25; target multiple thousands of autonomous systems",
+      "scope": "United States Department of Defense (all-domain)",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.1",
+      "sources": 2,
+      "corroborating": 2,
+      "confidence": "A"
+    },
+    {
+      "id": "135",
+      "name": "AUKUS Pillar II TORVICE AI Trial",
+      "lat": -31.6,
+      "lng": 137.0,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Coordination",
+      "sample": false,
+      "date": "October 2023",
+      "location": "Cultana Training Area, South Australia",
+      "domain": "Security",
+      "industryPrimary": "Defence & Aerospace",
+      "description": "AUKUS Pillar II trilateral AI-enabled electronic warfare trial at Cultana Training Area, South Australia. UK and US robotic ground vehicles tested as autonomous Multi-Domain Launchers and UGVs under electronic warfare, electro-optical, and PNT attacks by Australian defence scientists. Part of the RAAIT programme.",
+      "investment": "Trilateral military trial: 3 nations; UK + US robotic vehicles; Australian EW red-team capability; RAAIT Project Agreement signed November 2023",
+      "scope": "International — AUKUS nations (Australia, United Kingdom, United States)",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.0",
+      "sources": 3,
+      "corroborating": 1,
+      "confidence": "A"
+    },
+    {
+      "id": "136",
+      "name": "Destination Earth (DestinE) Phase 1",
+      "lat": 50.8505,
+      "lng": 4.3488,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Coordination",
+      "sample": false,
+      "date": "10 June 2024",
+      "location": "Distributed: Finland (LUMI), Spain (MareNostrum 5), Italy (Leonardo), Luxembourg (MeluXina)",
+      "domain": "Technology",
+      "industryPrimary": "AI Software & Platforms",
+      "description": "EU programme creating high-resolution Earth system digital twins using dedicated EuroHPC supercomputer infrastructure and machine learning. European Commission leads, with ECMWF (Digital Twin Engine), ESA (Core Service Platform), and EUMETSAT (Data Lake) as entrusted entities. EuroHPC JU Governing Board Decision 30/2022 allocates dedicated compute resources.",
+      "investment": "€150M Phase 1 funding; 5% of EuroHPC JU compute time on LUMI, Leonardo, MareNostrum 5; 3,500+ registered users; up to 1 PB/day output",
+      "scope": "EU member states (distributed across EuroHPC infrastructure)",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.1",
+      "sources": 4,
+      "corroborating": 3,
+      "confidence": "A",
+      "environmentalNexusTags": [
+        {
+          "type": "ENT-5",
+          "name": "Environmental Coordination",
+          "mechanism": "DestinE Phase 1 deploys dedicated EuroHPC compute allocations for Earth system digital twins as the programme's explicit primary purpose at EU sovereign/multilateral scale.",
+          "evidenceBasis": "Documented",
+          "pathway": "B",
+          "sources": [
+            {
+              "citation": "European Commission DestinE programme documentation",
+              "type": "primary",
+              "url": "https://ec.europa.eu/commission/presscorner/detail/nl/ip_22_1977",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429043043/https://ec.europa.eu/commission/presscorner/detail/nl/ip_22_1977"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "138",
+      "name": "Brazil PBIA 2024–2028 (National AI Plan)",
+      "lat": -15.7801,
+      "lng": -47.9292,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Policy",
+      "sample": false,
+      "date": "12 November 2024",
+      "location": "Brasília, Brazil",
+      "scope": "Brazil (National)",
+      "description": "National artificial intelligence plan approved by the National Council for Science and Technology (CCT Resolution No. 4), allocating BRL 23.03 billion (~US$3.9B) over 2024–2028 across four axes: enterprise AI innovation, AI infrastructure development including Santos Dumont supercomputer upgrade and sovereign cloud, AI-enabled public services, and AI training and capacity building.",
+      "investment": "BRL 23.03 billion (~US$3.9B) over 4 years; Enterprise Innovation: BRL 13.79B; Infrastructure: BRL 5.79B; Public Services: BRL 1.76B; Training: BRL 1.15B",
+      "domain": "Technology",
+      "confidence": "B",
+      "industryPrimary": "AI Software & Platforms",
+      "sources": 2,
+      "corroborating": 2,
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.0",
+      "environmentalNexusTags": [
+        {
+          "type": "ENT-2",
+          "name": "Environmental Enablement",
+          "mechanism": "Brazil PBIA establishes the 'Pro-Infra Sustainable AI initiative' mandating 'environmental sustainability, with the use of supercomputers powered by renewable energies' within Axis 1 infrastructure programmes.",
+          "evidenceBasis": "Documented",
+          "sources": [
+            {
+              "citation": "Brazil PBIA 2024-2028, CCT Resolution No. 4",
+              "type": "primary",
+              "url": "https://www.gov.br/mcti/pt-br/acompanhe-o-mcti/cct/legislacao/arquivos/IA_para_o_Bem_de_Todos.pdf",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429162320/https://www.gov.br/mcti/pt-br/acompanhe-o-mcti/cct/legislacao/arquivos/IA_para_o_Bem_de_Todos.pdf"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "139",
+      "name": "China National AI Industry Investment Fund",
+      "lat": 31.2304,
+      "lng": 121.4737,
+      "bloc": "Eastern",
+      "tier": 3,
+      "type": "Corporate",
+      "sample": false,
+      "date": "19 January 2025",
+      "location": "Shanghai, China",
+      "scope": "China (national-level investment fund)",
+      "description": "State-backed AI industry investment fund with RMB 60.06 billion (~US$8.2B) registered capital, established as a limited partnership in Shanghai. Managed by Guozhi Investment with the National Integrated Circuit Industry Investment Fund Phase III as sole limited partner. Targets computing power, algorithms, data, and AI applications across the full supply chain.",
+      "investment": "RMB 60.06 billion (~US$8.2B)",
+      "domain": "Trade",
+      "confidence": "A",
+      "industryPrimary": "Financial Services & Investment",
+      "sources": 2,
+      "corroborating": 2,
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.1"
+    },
+    {
+      "id": "140",
+      "name": "EU IPCEI ME/CT — Microelectronics & Communication Technologies",
+      "lat": 50.8503,
+      "lng": 4.3517,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Infrastructure",
+      "sample": false,
+      "date": "8 June 2023",
+      "location": "Brussels, Belgium (EC approval); 14 EU member states (implementation)",
+      "scope": "14 EU member states (56 companies, 68 projects, 600+ indirect partners)",
+      "description": "European Commission-approved programme enabling first industrial deployment of microelectronics and communication technologies across 14 member states under the IPCEI state aid framework. Programme encompasses semiconductor fabrication including AI-designated workstreams, with confirmed facility construction at STMicroelectronics Crolles and Infineon Dresden. Approved under Article 107(3)(b) TFEU.",
+      "investment": "€8.1B public funding + €13.7B private investment (~€21.8B total); STM Crolles: €7.5B (€2.9B French aid); Infineon Dresden: €5B (€1B aid)",
+      "domain": "Energy/Infrastructure",
+      "confidence": "A",
+      "industryPrimary": "Semiconductors & Equipment",
+      "sources": 4,
+      "corroborating": 1,
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.0",
+      "environmentalNexusTags": [
+        {
+          "type": "ENT-1",
+          "name": "Resource Demand",
+          "mechanism": "IPCEI ME/CT fabs operate under ICPE authorisation (STMicro Crolles, 958 m³/h) and BImSchG permits (Infineon Dresden, 21.3M m³/year).",
+          "evidenceBasis": "Documented",
+          "vector": "Water",
+          "sources": [
+            {
+              "citation": "ICPE/DREAL Auvergne-Rhône-Alpes environmental authorisation — STMicroelectronics Crolles",
+              "type": "primary"
+            },
+            {
+              "citation": "BImSchG permits, Landesdirektion Sachsen — Infineon Technologies Dresden",
+              "type": "primary"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "141",
+      "name": "SMIC–Huawei Kirin 9000s",
+      "lat": 31.2304,
+      "lng": 121.4737,
+      "bloc": "Eastern",
+      "tier": 3,
+      "type": "Corporate",
+      "sample": false,
+      "date": "29 August 2023",
+      "location": "Shanghai, China (SMIC fab); Shenzhen, China (HiSilicon design)",
+      "scope": "China (SMIC: Shanghai; Huawei HiSilicon: Shenzhen)",
+      "description": "SMIC’s achievement of 7nm-class semiconductor manufacturing using its N+2 process node, demonstrated via Huawei’s Kirin 9000s system-on-chip deployed in the Mate 60 Pro smartphone. First non-Western foundry to demonstrate 7nm-class production capability using DUV lithography without access to EUV equipment.",
+      "investment": "N/A",
+      "domain": "Technology",
+      "confidence": "B",
+      "ai_connection_pathway": "oep",
+      "industryPrimary": "Semiconductors & Equipment",
+      "sources": 2,
+      "corroborating": 2,
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true,
+        "aiDetail": "OEP (Pathway A — Strong)"
+      },
+      "version": "1.0"
+    },
+    {
+      "id": "142",
+      "name": "PyTorch Foundation Establishment",
+      "lat": 53.3498,
+      "lng": -6.2603,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Corporate",
+      "sample": false,
+      "date": "12 September 2022",
+      "location": "Dublin, Ireland",
+      "scope": "Global (open-source framework ecosystem)",
+      "description": "Meta's transfer of the PyTorch deep learning framework to an independent Linux Foundation entity with vendor-neutral governance. The framework serves as the dominant open-source ML training and inference platform, underpinning approximately 80% of machine learning research publications.",
+      "investment": "82.5M monthly downloads; ~80% NeurIPS 2023 research framework share; 10,000+ dependent packages",
+      "domain": "Technology",
+      "sources": 2,
+      "corroborating": 2,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.0",
+      "industryPrimary": "AI Software & Platforms",
+      "environmentalNexusTags": []
+    },
+    {
+      "id": "143",
+      "name": "Frontier Supercomputer (Oak Ridge National Laboratory)",
+      "lat": 36.0103,
+      "lng": -84.2697,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Infrastructure",
+      "sample": false,
+      "date": "May 2022",
+      "location": "Oak Ridge, Tennessee, United States",
+      "scope": "United States (DOE open science programme)",
+      "description": "First exascale supercomputer globally, achieving 1.102 exaFLOPS Rmax on the TOP500. Built by HPE using AMD EPYC 7A53 CPUs and MI250X GPU accelerators across 74 cabinets with Slingshot-11 interconnect. Funded under the DOE Exascale Computing Project.",
+      "investment": "~US$600M; 1.102 exaFLOPS Rmax; 37,888 AMD MI250X GPUs; TOP500 #1 at commissioning (June 2022)",
+      "domain": "Energy/Infrastructure",
+      "sources": 2,
+      "corroborating": 2,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.0",
+      "industryPrimary": "Cloud, Data Centres & Connectivity Infrastructure",
+      "environmentalNexusTags": [
+        {
+          "type": "ENT-4",
+          "name": "Environmental Dependency",
+          "mechanism": "WRI Aqueduct 4.0 classifies Oak Ridge, Tennessee sub-basin (Powell) as Medium-High baseline water stress (20–40%); Frontier's evaporative cooling towers create water-dependent operations in a stressed watershed.",
+          "evidenceBasis": "Assessed",
+          "sources": [
+            {
+              "citation": "WRI Aqueduct Water Risk Atlas V4.0 — Oak Ridge, TN (Powell sub-basin, Medium-High 20–40%)",
+              "type": "primary",
+              "url": "https://www.wri.org/applications/aqueduct/water-risk-atlas/",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429045535/https://www.wri.org/applications/aqueduct/water-risk-atlas/#/?advanced=false&basemap=hydro&indicator=w_awr_def_tot_cat&lat=30&lng=-80&mapMode=view&month=1&opacity=0.5&ponderation=DEF&predefined=false&projection=absolute&scenario=optimistic&scope=baseline&threshold&timeScale=annual&year=baseline&zoom=3"
+            },
+            {
+              "citation": "ORNL Energy Data Set of Frontier Supercomputer — evaporative cooling towers",
+              "type": "primary",
+              "url": "https://info.ornl.gov/sites/publications/Files/Pub207081.pdf",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429043401/https://info.ornl.gov/sites/publications/Files/Pub207081.pdf"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "144",
+      "name": "El Capitan Supercomputer (Lawrence Livermore National Laboratory)",
+      "lat": 37.6819,
+      "lng": -121.7681,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Infrastructure",
+      "sample": false,
+      "date": "18 November 2024",
+      "location": "Livermore, California, United States",
+      "scope": "United States (NNSA classified network)",
+      "description": "World's fastest supercomputer at 1.742 exaFLOPS, deployed by NNSA for classified nuclear stewardship workloads. Built by HPE using AMD MI300A accelerated processing units across 11,000+ nodes, representing the first exascale system dedicated to national security computing.",
+      "investment": "~US$600M; 1.742 exaFLOPS; 11,136 AMD MI300A APU nodes; TOP500 #1 (November 2024)",
+      "domain": "Security",
+      "sources": 2,
+      "corroborating": 1,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.0",
+      "industryPrimary": "Defence & Aerospace",
+      "environmentalNexusTags": [
+        {
+          "type": "ENT-4",
+          "name": "Environmental Dependency",
+          "mechanism": "Livermore, California faces documented extreme drought risk (Alameda County Vulnerability Score 3, historical D4 exceptional drought classification) and wildfire risk; El Capitan’s evaporative cooling system circulates 5–9 million gallons of water daily through cooling towers, creating operational dependency on regional hydrological stability.",
+          "evidenceBasis": "Assessed",
+          "sources": [
+            {
+              "citation": "WRI Aqueduct Water Risk Atlas V4.0 — Livermore, CA (San Francisco Bay sub-basin, Low-Medium 10–20%)",
+              "type": "primary",
+              "url": "https://www.wri.org/applications/aqueduct/water-risk-atlas/",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429045535/https://www.wri.org/applications/aqueduct/water-risk-atlas/#/?advanced=false&basemap=hydro&indicator=w_awr_def_tot_cat&lat=30&lng=-80&mapMode=view&month=1&opacity=0.5&ponderation=DEF&predefined=false&projection=absolute&scenario=optimistic&scope=baseline&threshold&timeScale=annual&year=baseline&zoom=3"
+            },
+            {
+              "citation": "ND-GAIN Urban Adaptation Assessment — Alameda/Berkeley (Risk Score 51.52)",
+              "type": "primary",
+              "url": "https://gain-uaa.nd.edu/1600000US0606000/city_profile/",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429043208/https://gain-uaa.nd.edu/1600000US0606000/city_profile/"
+            },
+            {
+              "citation": "LLNL El Capitan Fun Facts — cooling towers, 5–9M gal/day",
+              "type": "primary",
+              "url": "https://hpc.llnl.gov/sites/default/files/El-Cap-Fun-Facts.pdf",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429043333/https://hpc.llnl.gov/sites/default/files/El-Cap-Fun-Facts.pdf"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "145",
+      "name": "Aurora Supercomputer (Argonne National Laboratory)",
+      "lat": 41.7148,
+      "lng": -87.9801,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Infrastructure",
+      "sample": false,
+      "date": "28 January 2025",
+      "location": "Lemont, Illinois, United States",
+      "scope": "United States (DOE open science programme)",
+      "description": "US Department of Energy exascale supercomputer deployed at Argonne National Laboratory, achieving exascale performance using 63,744 Intel Data Center GPU Max 1550 accelerators across 10,624 blades. Third US exascale system under the DOE Exascale Computing Project, released to the open science research community.",
+      "investment": "~US$500M; 63,744 Intel GPU Max 1550s; 60MW facility electrical capacity; 166 racks",
+      "domain": "Energy/Infrastructure",
+      "sources": 2,
+      "corroborating": 0,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.0",
+      "industryPrimary": "Cloud, Data Centres & Connectivity Infrastructure",
+      "environmentalNexusTags": [
+        {
+          "type": "ENT-1",
+          "name": "Resource Demand",
+          "mechanism": "Aurora's 60MW exascale computing facility creates documented demand on grid infrastructure (requiring dedicated 138kV transmission line construction with NEPA review), water resources (56.7 million gallons/year canal water), and land (tree-clearing for transmission infrastructure).",
+          "evidenceBasis": "Documented",
+          "sources": [
+            {
+              "citation": "DOE NEPA Categorical Exclusion — 138kV transmission line construction for Argonne",
+              "type": "primary",
+              "url": "https://www.energy.gov/sites/default/files/2019/01/f58/CX-019252.pdf",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429044406/https://www.energy.gov/sites/default/files/2019/01/f58/CX-019252.pdf"
+            },
+            {
+              "citation": "Argonne Site Sustainability Plan — HPC facilities energy and water use data",
+              "type": "primary",
+              "url": "https://www.anl.gov/sites/www/files/2020-06/Argonne_Site_Sustainability_Plan.pdf",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429044320/https://www.anl.gov/sites/www/files/2020-06/Argonne_Site_Sustainability_Plan.pdf"
+            }
+          ]
+        },
+        {
+          "type": "ENT-2",
+          "name": "Environmental Enablement",
+          "mechanism": "DOE Order 436.1 establishes binding PUE efficiency targets (1.2–1.4 for new data centres) and sustainable acquisition requirements as operative conditions governing Aurora's facility operations at Argonne National Laboratory.",
+          "evidenceBasis": "Documented",
+          "sources": [
+            {
+              "citation": "Argonne Sustainability Plan FY2017 — DOE Order 436.1 mandate and PUE targets",
+              "type": "primary",
+              "url": "https://www.anl.gov/sites/www/files/2018-02/anl_site_sustainability_plan_20170101.pdf",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429044331/https://www.anl.gov/sites/www/files/2018-02/anl_site_sustainability_plan_20170101.pdf"
+            },
+            {
+              "citation": "Argonne Sustainability Plan FY2018 — prime contract sustainability clauses",
+              "type": "primary",
+              "url": "https://www.anl.gov/sites/www/files/2018-02/Argonne_SiteSustainabilityPlan_FY2018_0.pdf",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429044342/https://www.anl.gov/sites/www/files/2018-02/Argonne_SiteSustainabilityPlan_FY2018_0.pdf"
+            }
+          ]
+        },
+        {
+          "type": "ENT-4",
+          "name": "Environmental Dependency",
+          "mechanism": "Argonne National Laboratory is located in the Des Plaines Basin (WRI Aqueduct: High water stress, 40–80%) and requires water-based cooling consuming 56.7 million gallons/year, while Northern Illinois faces documented climate risks to grid infrastructure from heatwaves and flooding.",
+          "evidenceBasis": "Assessed",
+          "sources": [
+            {
+              "citation": "WRI Aqueduct classification via CDP disclosure — Des Plaines Basin (High, 40–80%)",
+              "type": "primary",
+              "url": "https://www.bms.com/assets/bms/us/en-us/pdf/bms-cdp-questions-questionnaire.pdf",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429044354/https://www.bms.com/assets/bms/us/en-us/pdf/bms-cdp-questions-questionnaire.pdf"
+            },
+            {
+              "citation": "Argonne climate risk publication — grid infrastructure vulnerability",
+              "type": "primary",
+              "url": "https://publications.anl.gov/anlpubs/2022/12/180058.pdf",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429043735/https://publications.anl.gov/anlpubs/2022/12/180058.pdf"
+            },
+            {
+              "citation": "CMAP regional risk assessment — flooding and infrastructure impacts",
+              "type": "primary",
+              "url": "https://cmap.illinois.gov/wp-content/uploads/dlm_uploads/Risk-based-Vulnerability-Assessment.pdf",
+              "accessDate": "2026-04-30",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260430095557/https://cmap.illinois.gov/wp-content/uploads/dlm_uploads/Risk-based-Vulnerability-Assessment.pdf"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "146",
+      "name": "China MIIT/SAMR Intelligent Connected Vehicle Notice",
+      "lat": 39.9042,
+      "lng": 116.4074,
+      "bloc": "Eastern",
+      "tier": 3,
+      "type": "Policy",
+      "sample": false,
+      "date": "25 February 2025",
+      "location": "Beijing, China",
+      "scope": "People's Republic of China (Mainland)",
+      "description": "Joint MIIT and SAMR notice establishing mandatory product admission, recall, and over-the-air software update management requirements for intelligent connected vehicles. Requires enterprises to submit technical parameters and verification materials for autonomous driving and AI-equipped vehicle features with a compliance deadline of 1 June 2025.",
+      "investment": "Regulatory Framework (mandatory compliance; product admission denial for non-compliance)",
+      "domain": "Technology",
+      "sources": 1,
+      "corroborating": 2,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.0",
+      "industryPrimary": "Automotive & Manufacturing",
+      "environmentalNexusTags": []
+    },
+    {
+      "id": "147",
+      "name": "China AI Content Labelling Measures",
+      "lat": 39.9042,
+      "lng": 116.4074,
+      "bloc": "Eastern",
+      "tier": 3,
+      "type": "Policy",
+      "sample": false,
+      "date": "1 September 2025",
+      "location": "Beijing, China",
+      "scope": "People's Republic of China (Mainland)",
+      "description": "Mandatory AI content labelling regulation jointly issued by CAC, MIIT, MPS, and NRTA requiring explicit and implicit labelling of all AI-generated synthetic content across text, image, audio, and video modalities. Accompanied by mandatory national technical standard GB 45438-2025 specifying labelling implementation requirements.",
+      "investment": "Regulatory framework (penalties via CAC/MPS enforcement authority); companion mandatory national standard GB 45438-2025",
+      "domain": "Technology",
+      "sources": 1,
+      "corroborating": 3,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.0",
+      "industryPrimary": "AI Software & Platforms",
+      "environmentalNexusTags": []
+    },
+    {
+      "id": "148",
+      "name": "Italy National AI Law (Law 132/2025)",
+      "lat": 41.9028,
+      "lng": 12.4964,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Policy",
+      "sample": false,
+      "date": "10 October 2025",
+      "location": "Rome, Italy",
+      "scope": "Italy (EU AI Act national implementation)",
+      "description": "Italy's first comprehensive national AI legislation (Law 132/2025), the first EU member state standalone implementation of the EU AI Act. Twenty-eight articles across six sections establishing AI governance framework with criminal penalties of 1–5 years and AgID/ACN enforcement authorities.",
+      "investment": "Regulatory framework (criminal penalties 1–5 years; administrative penalties under AgID and ACN oversight)",
+      "domain": "Technology",
+      "sources": 1,
+      "corroborating": 2,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.0",
+      "industryPrimary": "AI Software & Platforms",
+      "environmentalNexusTags": []
+    },
+    {
+      "id": "149",
+      "name": "Google-Kairos Power SMR Agreement",
+      "lat": 35.9311,
+      "lng": -84.31,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Corporate",
+      "sample": false,
+      "date": "14 October 2024",
+      "location": "Oak Ridge, Tennessee, United States",
+      "scope": "United States (national SMR fleet; first deployment Tennessee via TVA)",
+      "description": "Master Plant Development Agreement between Google and Kairos Power for a fleet of advanced small modular reactors (KP-FHR), totalling 500MW by 2035 to supply Google AI data centres. First corporate multi-site SMR deployment agreement in the United States; first reactor via TVA by 2030.",
+      "investment": "500MW total fleet capacity (6–7 reactors); first deployment 50MW (Hermes 2, Oak Ridge) by 2030; investment figure not publicly disclosed",
+      "domain": "Energy/Infrastructure",
+      "sources": 1,
+      "corroborating": 2,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.0",
+      "industryPrimary": "Energy & Power Infrastructure",
+      "environmentalNexusTags": [
+        {
+          "type": "ENT-1",
+          "name": "Resource Demand",
+          "mechanism": "Master Plant Development Agreement specifies 500MW total nuclear power capacity by 2035 dedicated to Google AI data centre operations.",
+          "evidenceBasis": "Documented",
+          "sources": [
+            {
+              "citation": "Kairos Power press release — 500 MW clean electricity generation partnership with Google",
+              "type": "primary",
+              "url": "https://kairospower.com/external_updates/google-and-kairos-power-partner-to-deploy-500-mw-of-clean-electricity-generation/",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429014453/https://www.kairospower.com/updates/google-and-kairos-power-partner-to-deploy-500-mw-of-clean-electricity-generation"
+            }
+          ]
+        },
+        {
+          "type": "ENT-2",
+          "name": "Environmental Enablement",
+          "mechanism": "Master Plant Development Agreement allocates environmental attributes to Google under binding PPAs in support of Google's 24/7 carbon-free energy and net zero goals for AI data centre operations.",
+          "evidenceBasis": "Documented",
+          "sources": [
+            {
+              "citation": "Kairos Power press release — environmental attributes and 24/7 carbon-free commitments",
+              "type": "primary",
+              "url": "https://kairospower.com/external_updates/google-and-kairos-power-partner-to-deploy-500-mw-of-clean-electricity-generation/",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429014453/https://www.kairospower.com/updates/google-and-kairos-power-partner-to-deploy-500-mw-of-clean-electricity-generation"
+            }
+          ]
+        },
+        {
+          "type": "ENT-4",
+          "name": "Environmental Dependency",
+          "mechanism": "NRC Environmental Report for Hermes 2 documents site-specific water consumption requirements (service water, potable water, decay heat removal, power generation makeup) totalling ~117 gpm for reactor operations in East Tennessee.",
+          "evidenceBasis": "Documented",
+          "sources": [
+            {
+              "citation": "NRC Environmental Report for Hermes 2 — Section 2.4 water use (Hermes 2 only; not fleet-wide)",
+              "type": "primary",
+              "url": "https://www.nrc.gov/docs/ML2319/ML23195A125.pdf",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429045336/https://www.nrc.gov/docs/ML2319/ML23195A125.pdf"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "150",
+      "name": "Amazon–Anthropic Strategic Investment",
+      "lat": 37.7749,
+      "lng": -122.4194,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Corporate",
+      "sample": false,
+      "date": "27 March 2024",
+      "location": "San Francisco, California, USA",
+      "scope": "United States (global Claude distribution via AWS Bedrock)",
+      "description": "Amazon's US$4 billion strategic equity investment in Anthropic, completed 27 March 2024, commercially coupled with Amazon's designation as Anthropic's primary cloud provider for training and inference workloads and integration of Claude models into Amazon Bedrock as a managed cloud AI service.",
+      "investment": "US$4 billion total equity; first tranche Q3 2023; completed 27 March 2024",
+      "domain": "Technology",
+      "sources": 2,
+      "corroborating": 2,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.1",
+      "industryPrimary": "AI Software & Platforms",
+      "environmentalNexusTags": []
+    },
+    {
+      "id": "151",
+      "name": "Meta–Constellation Clinton PPA",
+      "lat": 40.1722,
+      "lng": -88.8339,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Corporate",
+      "sample": false,
+      "date": "3 June 2025",
+      "location": "Clinton, Illinois, United States",
+      "scope": "United States (PJM Interconnection region)",
+      "description": "Meta's 20-year PPA with Constellation Energy for 1,121 MW of nuclear output from the Clinton Clean Energy Center in Illinois, structured as a virtual PPA retiring clean-energy attributes aligned with Meta's distributed US data centre AI operations. Power delivery commences June 2027.",
+      "investment": "US$1B+ category commitment; 1,121 MW post-uprate; 20-year term; 30 MW uprate capacity through 2029; delivery from June 2027",
+      "domain": "Energy/Infrastructure",
+      "sources": 2,
+      "corroborating": 6,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.1",
+      "industryPrimary": "Energy & Power Infrastructure",
+      "environmentalNexusTags": [
+        {
+          "type": "ENT-1",
+          "name": "Resource Demand",
+          "mechanism": "Twenty-year PPA commits 1,121 MW of Clinton Clean Energy Center nuclear output to Meta AI infrastructure operations, with 30 MW of committed capacity uprates through 2029.",
+          "evidenceBasis": "Documented",
+          "sources": [
+            {
+              "citation": "Constellation Energy — Meta 20-year PPA announcement",
+              "type": "primary",
+              "url": "https://www.constellationenergy.com/news/2025/constellation-meta-sign-20-year-deal-for-clean-reliable-nuclear-energy-in-illinois.html",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429140156/https://www.constellationenergy.com/news/2025/constellation-meta-sign-20-year-deal-for-clean-reliable-nuclear-energy-in-illinois.html"
+            },
+            {
+              "citation": "NRC Clinton 2024 Annual Radiological Environmental Operating Report",
+              "type": "primary",
+              "url": "https://www.nrc.gov/docs/ML2512/ML25122A164.pdf",
+              "accessDate": "2026-04-29",
+              "captureStatus": "recovered",
+              "snapshotUrl": "http://web.archive.org/web/20251217013939/https://www.nrc.gov/docs/ML2512/ML25122A164.pdf"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "152",
+      "name": "ISO/IEC 5259 Data Quality for ML Standards Series",
+      "lat": 46.2276,
+      "lng": 6.1434,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Coordination",
+      "sample": false,
+      "date": "1 December 2024",
+      "location": "Geneva, Switzerland",
+      "scope": "Global (ISO 169 member nations; IEC 89 member nations)",
+      "description": "International multi-part standard establishing data quality requirements for machine learning, published through ISO/IEC JTC 1/SC 42. Parts 1, 2, and 4 published as full International Standards in 2024; Part 3 published separately with first third-party certification issued December 2025 against data quality management process requirements.",
+      "investment": "Multi-part International Standard (Parts 1, 2, 3, 4); SC 42 portfolio; first certification December 2025",
+      "domain": "Technology",
+      "sources": 3,
+      "corroborating": 4,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.1",
+      "industryPrimary": "AI Software & Platforms",
+      "environmentalNexusTags": []
+    },
+    {
+      "id": "153",
+      "name": "China Telecom Hunan Mid-South Intelligent Computing Centre",
+      "lat": 28.1133,
+      "lng": 112.9983,
+      "bloc": "Eastern",
+      "tier": 3,
+      "type": "Infrastructure",
+      "sample": false,
+      "date": "28 October 2023",
+      "location": "Changsha, Hunan Province, China",
+      "scope": "Mainland China (Mid-South regional compute provision)",
+      "description": "China Telecom's regionally designated intelligent computing facility in Changsha, Hunan, carrying the 智算中心 (intelligent computing centre) designation within China's national compute infrastructure taxonomy. Architecture dedicated to AI-workload hosting and training/inference services as a Mid-South regional node within the central-government East Data West Compute (东数西算) framework.",
+      "investment": "RMB 12 billion total investment; 33,000 racks planned; 450,000 servers; 5,000 PFLOPS intelligent computing capacity; 500PB storage; 300亩 site area",
+      "domain": "Energy/Infrastructure",
+      "sources": 3,
+      "corroborating": 1,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.2",
+      "industryPrimary": "Cloud, Data Centres & Connectivity Infrastructure",
+      "environmentalNexusTags": []
+    },
+    {
+      "id": "154",
+      "name": "ABCI 3.0 Supercomputer (AIST Kashiwa)",
+      "lat": 35.8957,
+      "lng": 139.9476,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Infrastructure",
+      "sample": false,
+      "date": "15 April 2025",
+      "location": "Kashiwa, Chiba Prefecture, Japan",
+      "scope": "Japan (national AI research resource)",
+      "description": "AIST's national AI supercomputer at the Kashiwa site in Chiba, Japan, delivering 6.22 exaflops of half-precision peak AI compute across 6,128 NVIDIA H200 GPUs. Operated as AI Bridging Cloud Infrastructure for Japanese academic and industrial AI research under METI's compute-sovereignty strategy.",
+      "investment": "6,128 NVIDIA H200 GPUs; 6.22 exaflops half-precision; 144 racks; 6 MW electrical / 5.2 MW cooling; PUE <1.15",
+      "domain": "Energy/Infrastructure",
+      "sources": 2,
+      "corroborating": 3,
+      "confidence": "B",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.2",
+      "industryPrimary": "Cloud, Data Centres & Connectivity Infrastructure",
+      "environmentalNexusTags": [
+        {
+          "type": "ENT-1",
+          "name": "Resource Demand",
+          "mechanism": "ABCI 3.0 commissions 6 MW electrical capacity and 5.2 MW cooling capacity across 144 racks operating 6,128 NVIDIA H200 GPUs, with measured PUE below 1.15 achieved through 32°C warm-water direct liquid cooling.",
+          "evidenceBasis": "Documented",
+          "sources": [
+            {
+              "citation": "Huang et al. — ABCI 3.0 architecture paper",
+              "type": "primary",
+              "url": "https://arxiv.org/html/2411.09134v1",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429052813/https://arxiv.org/html/2411.09134v1"
+            },
+            {
+              "citation": "AIST G-QuAT SC25 panel — ABCI 3.0 operational overview",
+              "type": "primary",
+              "url": "https://unit.aist.go.jp/g-quat/en/events/img/SC25/panels/04_ABCI3.pdf",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429112441/https://unit.aist.go.jp/g-quat/en/events/img/SC25/panels/04_ABCI3.pdf"
+            }
+          ]
+        },
+        {
+          "type": "ENT-4",
+          "name": "Environmental Dependency",
+          "mechanism": "Facility operational continuity at the Kashiwa site depends on Chiba Prefecture electrical transmission infrastructure with documented vulnerability to typhoon-induced tower collapse, evidenced by prolonged Chiba Prefecture blackouts following Typhoon Faxai (No. 15) in 2019; J-SHIS seismic hazard framework applies to site-specific assessment.",
+          "evidenceBasis": "Documented",
+          "sources": [
+            {
+              "citation": "World Bank — Strengthening Japan's Power System Resilience",
+              "type": "primary",
+              "url": "https://thedocs.worldbank.org/en/doc/eb847365035f52d6e3b2a8ef00aae974-0450022025/original/Strengthening-Japans-Power-System-Resilience.pdf",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429111452/https://thedocs.worldbank.org/en/doc/eb847365035f52d6e3b2a8ef00aae974-0450022025/original/Strengthening-Japans-Power-System-Resilience.pdf"
+            },
+            {
+              "citation": "J-SHIS — Japan seismic hazard portal",
+              "type": "corroborating",
+              "url": "https://www.j-shis.bosai.go.jp/en/shm",
+              "accessDate": "2026-04-29",
+              "captureStatus": "captured",
+              "snapshotUrl": "https://web.archive.org/web/20260429044615/https://www.j-shis.bosai.go.jp/en/shm"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "155",
+      "name": "China Mobile Harbin Intelligent Computing Centre",
+      "lat": 45.8038,
+      "lng": 126.535,
+      "bloc": "Eastern",
+      "tier": 3,
+      "type": "Infrastructure",
+      "sample": false,
+      "date": "30 August 2024",
+      "location": "Harbin, Heilongjiang Province, China",
+      "scope": "Mainland China (national intelligent computing programme node)",
+      "description": "China Mobile Heilongjiang Company activated an ultra-large-scale intelligent computing centre in Harbin, deploying 18,000 AI acceleration cards in a single cluster with 6.9 EFLOPS of intelligent computing power using entirely domestically produced hardware and networking equipment. Designated under SASAC's Strategic Emerging Industries Hundred Major Projects.",
+      "investment": "SASAC Strategic Emerging Industries Hundred Major Projects; 18,000 AI acceleration cards; 6.9 EFLOPS; GSE 1.0 lossless networking; part of China Mobile's first batch of 13 smart computing centre nodes",
+      "domain": "Energy/Infrastructure",
+      "sources": 1,
+      "corroborating": 3,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.2",
+      "industryPrimary": "Cloud, Data Centres & Connectivity Infrastructure",
+      "environmentalNexusTags": []
+    },
+    {
+      "id": "156",
+      "name": "METI Beyond 2nm Project — Rapidus IIM-1 Pilot Line",
+      "lat": 42.8167,
+      "lng": 141.65,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Infrastructure",
+      "sample": false,
+      "date": "April 2025",
+      "location": "Chitose City, Hokkaido, Japan",
+      "scope": "Japan (global advanced semiconductor supply chain)",
+      "description": "Rapidus Corporation activated the IIM-1 (Innovative Integration for Manufacturing) pilot line in Chitose, Hokkaido, beginning test production of 2-nanometre gate-all-around nanosheet logic semiconductors under the METI/NEDO Beyond 2nm Project. Over 200 pieces of leading-edge equipment installed including an ASML EUV lithography system, with process technology based on IBM's nanosheet transistor structure.",
+      "investment": "JPY 1.72 trillion (~US$12B) government subsidy from METI/NEDO; estimated JPY 5 trillion (~US$35B) total programme; ASML EUV system >US$300M",
+      "domain": "Energy/Infrastructure",
+      "sources": 2,
+      "corroborating": 2,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.1",
+      "industryPrimary": "Semiconductors & Equipment",
+      "environmentalNexusTags": []
+    },
+    {
+      "id": "157",
+      "name": "Project Rainier Cluster",
+      "lat": 41.6764,
+      "lng": -86.252,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Corporate",
+      "sample": false,
+      "date": "29 October 2025",
+      "location": "St. Joseph County, Indiana, United States",
+      "scope": "United States (multi-site deployment; primary campus in Indiana)",
+      "description": "Amazon Web Services activated Project Rainier, deploying approximately 500,000 Trainium2 custom ASICs designed by Annapurna Labs as an EC2 UltraCluster of UltraServers. Primary campus in St. Joseph County, Indiana with US$11 billion committed. Entirely non-GPU architecture dedicated exclusively to training and serving Anthropic's Claude AI models.",
+      "investment": "US$11B (AWS Indiana campus commitment); ~500,000 Trainium2 custom ASICs; 2.2 GW designed IT load at full buildout",
+      "domain": "Energy/Infrastructure",
+      "sources": 4,
+      "corroborating": 0,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.1",
+      "industryPrimary": "Cloud, Data Centres & Connectivity Infrastructure",
+      "environmentalNexusTags": [
+        {
+          "type": "ENT-1",
+          "name": "Resource Demand",
+          "mechanism": "The Rainier campus documents specific water consumption requirements for AI compute cooling at 0.15 L/kWh, with seasonal cooling water use April–September quantified in primary facility documentation.",
+          "evidenceBasis": "Documented",
+          "vector": "Water",
+          "sources": [
+            {
+              "citation": "About Amazon — AWS WUE and seasonal water profile",
+              "type": "PRIMARY",
+              "url": "https://www.aboutamazon.com/news/aws/aws-project-rainier-ai-trainium-chips-compute-cluster",
+              "captureStatus": "capture_failed",
+              "accessDate": "2026-05-04"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "158",
+      "name": "Aramco Digital–Groq Saudi Arabia AI Inference Centre (Dammam)",
+      "lat": 26.4207,
+      "lng": 50.0888,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Infrastructure",
+      "sample": false,
+      "date": "10 February 2025",
+      "location": "Dammam, Saudi Arabia",
+      "scope": "Saudi Arabia (regional AI inference hub for Middle East)",
+      "description": "Aramco Digital and Groq Inc. established a dedicated AI inference data centre deploying Groq's proprietary LPU accelerators — purpose-designed ASICs for inference workloads distinct from GPU-based compute. Inference-only facility integrated with Aramco Digital's nawat AI-as-a-Service marketplace, backed by Saudi Arabia's Vision 2030 programme.",
+      "investment": "US$1.5B expansion commitment from Saudi Arabia; 19,000 Groq LPUs; 51-day construction; GroqCloud inference service; nawat AIaaS marketplace",
+      "domain": "Energy/Infrastructure",
+      "sources": 2,
+      "corroborating": 3,
+      "confidence": "A",
+      "version": "1.0",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "industryPrimary": "Cloud, Data Centres & Connectivity Infrastructure",
+      "environmentalNexusTags": []
+    },
+    {
+      "id": "159",
+      "name": "BDx Indonesia AI Data Centre Campus (Jatiluhur)",
+      "lat": -6.53,
+      "lng": 107.37,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Infrastructure",
+      "sample": false,
+      "date": "31 July 2024",
+      "location": "Jatiluhur, Purwakarta Regency, West Java, Indonesia",
+      "scope": "Indonesia (national AI data centre infrastructure)",
+      "description": "BDx Indonesia, a joint venture of BDx Data Centers, Indosat Ooredoo Hutchison, and Lintasarta, completed Phase 1 of the CGK4 AI campus, described as Indonesia's first renewable-powered AI data centre park. Equipped with NVIDIA accelerated computing and liquid cooling.",
+      "investment": "500MW scalable campus; 70MW Phase 1 across 4,150 sqm; 120kW/rack density; liquid cooling; 75-day deployment",
+      "domain": "Energy/Infrastructure",
+      "sources": 1,
+      "corroborating": 3,
+      "confidence": "A",
+      "version": "1.0",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "industryPrimary": "Cloud, Data Centres & Connectivity Infrastructure",
+      "environmentalNexusTags": []
+    },
+    {
+      "id": "160",
+      "name": "Beijing Yizhuang AI Public Computing Platform",
+      "lat": 39.78,
+      "lng": 116.5,
+      "bloc": "Eastern",
+      "tier": 3,
+      "type": "Infrastructure",
+      "sample": false,
+      "date": "29 March 2024",
+      "location": "Yizhuang, Daxing District, Beijing, China",
+      "scope": "Beijing municipality (public AI compute utility)",
+      "description": "Beijing Yizhuang AI Public Computing Platform (北京亦庄人工智能公共算力平台), operated by the Smart City Research Institute Group under Beijing Yizhuang Investment Holding Co., Ltd., deployed petaflops-scale AI computing at the National IT Innovation Park (国家信创园). Voucher-based access model subsidises domestically controlled foundation models for Beijing-area enterprises.",
+      "investment": "3,000 petaflops at launch (March 2024); expanded to 5,000 petaflops (January 2025); 10,000 petaflops target; RMB 100M/year computing vouchers; RMB 100M/year model vouchers; CECloud system integration",
+      "domain": "Energy/Infrastructure",
+      "sources": 2,
+      "corroborating": 4,
+      "confidence": "A",
+      "version": "1.1",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "industryPrimary": "Cloud, Data Centres & Connectivity Infrastructure",
+      "environmentalNexusTags": []
+    },
+    {
+      "id": "161",
+      "name": "YTL-NVIDIA Malaysia AI Data Centre (Johor)",
+      "lat": 1.66,
+      "lng": 103.6,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Infrastructure",
+      "sample": false,
+      "date": "October 2025",
+      "location": "Kulai, Johor, Malaysia",
+      "scope": "Malaysia (national AI compute hub)",
+      "description": "YTL Power International commissioned an NVIDIA-powered AI data centre at the YTL Green Data Center Park, described as Malaysia's first NVIDIA-powered AI data centre. Deploys GB200 Grace Blackwell liquid-cooled NVL72 GPUs as sovereign AI compute infrastructure under bilateral technology partnership with NVIDIA.",
+      "investment": "RM10B (~US$2.38B); 50% data centre infrastructure, 50% AI solutions including ILMU; 500MW solar; 600MW grid backup; 1,640 acres",
+      "domain": "Energy/Infrastructure",
+      "sources": 1,
+      "corroborating": 3,
+      "confidence": "A",
+      "version": "1.0",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "industryPrimary": "Cloud, Data Centres & Connectivity Infrastructure",
+      "environmentalNexusTags": [
+        {
+          "type": "ENT-1",
+          "name": "Resource Demand",
+          "mechanism": "AI data centre campus documents 600MW national grid backup requirement for AI compute operations across 1,640-acre site, with total facility energy demand at hyperscale capacity (500MW dedicated solar generation supplementing grid supply).",
+          "evidenceBasis": "Documented",
+          "sources": [
+            {
+              "citation": "w.media (November 2025)",
+              "type": "corroborating",
+              "url": "https://w.media/ytl-power-completes-nvidia-powered-ai-data-centre-in-johor/",
+              "captureStatus": "captured",
+              "accessDate": "2026-05-08",
+              "snapshotUrl": "https://web.archive.org/web/20260508/https://w.media/ytl-power-completes-nvidia-powered-ai-data-centre-in-johor/"
+            },
+            {
+              "citation": "YTL Power International press release (October 2025)",
+              "type": "primary",
+              "url": "https://web.archive.org/web/20251209203012/https://www.ytlpowerinternational.com/press-releases/malaysia-accelerates-sovereign-ai-ambition-nvidia-and-ytl-brief-prime-minister-anwar-ibrahim-at-apec-summit/",
+              "captureStatus": "existing",
+              "accessDate": "2026-05-08",
+              "snapshotUrl": "https://web.archive.org/web/20251209203012/https://www.ytlpowerinternational.com/press-releases/malaysia-accelerates-sovereign-ai-ambition-nvidia-and-ytl-brief-prime-minister-anwar-ibrahim-at-apec-summit/"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "162",
+      "name": "Ningxia Zhongwei Intelligent Computing Base",
+      "lat": 37.51,
+      "lng": 105.19,
+      "bloc": "Eastern",
+      "tier": 3,
+      "type": "Infrastructure",
+      "sample": false,
+      "date": "End-2023",
+      "location": "Zhongwei, Ningxia Hui Autonomous Region, China",
+      "scope": "China national (东数西算 hub node — dual designation)",
+      "description": "National-scale AI computing base within China's East Data West Compute (东数西算) programme, designated as the country's first 万卡+ intelligent computing base and one of eight national hub nodes. Multi-operator deployment across China Telecom, China Mobile, and China Unicom.",
+      "investment": "56.5 billion yuan cumulative cluster investment across 26 operators (~US$7.8 billion); 39,700 PFLOPS and 93,000 AI accelerator cards (2024 figures); 2,050 MW planned capacity (中金数据 zero-carbon base project within the cluster)",
+      "domain": "Energy/Infrastructure",
+      "sources": 3,
+      "corroborating": 4,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.1",
+      "industryPrimary": "Cloud, Data Centres & Connectivity Infrastructure",
+      "environmentalNexusTags": [
+        {
+          "type": "ENT-1",
+          "name": "Resource Demand",
+          "mechanism": "Cluster documentation specifies 2,050 MW total power capacity with dedicated 330kV grid infrastructure under construction for intelligent computing operations.",
+          "evidenceBasis": "Documented",
+          "vector": "Energy",
+          "sources": [
+            {
+              "citation": "新华网宁夏 — 中金数据 zero-carbon base",
+              "type": "corroborating",
+              "url": "http://nx.news.cn/20250509/f07332e669434fca8ae2b7ba03ab417f/c.html"
+            },
+            {
+              "citation": "State Grid Ningxia 330kV substation EIA filing",
+              "type": "primary",
+              "url": "http://www.nx.sgcc.cn/html/main/col7/2026-04/23/20260423164701527992765_1.html"
+            }
+          ]
+        },
+        {
+          "type": "ENT-2",
+          "name": "Environmental Enablement",
+          "mechanism": "Municipal data authority enforces binding Power Usage Effectiveness (PUE) ≤1.2 and Water Usage Effectiveness (WUE) ≤0.8 limits on the Zhongwei data centre cluster through official administrative directives implementing GB 40879-2021.",
+          "evidenceBasis": "Documented",
+          "sources": [
+            {
+              "citation": "中卫市数据局 CPPCC response — binding PUE/WUE limits",
+              "type": "primary",
+              "url": "https://www.nxzw.gov.cn/zwgk/bmxxgkml/syjshdsjfzj/fdzdgknr_50309/jyta_50325/202509/t20250924_5035851.html"
+            }
+          ]
+        },
+        {
+          "type": "ENT-4",
+          "name": "Environmental Dependency",
+          "mechanism": "Zhongwei is located in an arid zone within the Yellow River basin where water allocation is under documented stress; data centre cooling systems depend on regional water infrastructure under constrained supply conditions.",
+          "evidenceBasis": "Documented",
+          "dependencyType": "Water stress",
+          "sources": [
+            {
+              "citation": "水利部黄河水利委员会 — drought documentation",
+              "type": "corroborating",
+              "url": "http://www.yrcc.gov.cn/xwdt/lylw/202505/t20250530_442511.html"
+            },
+            {
+              "citation": "沙坡头区水务局 — Yellow River water allocation constraints",
+              "type": "primary",
+              "url": "https://www.spt.gov.cn/xxgk/bmxxgkml/sptqswj/fdzdgknr_51443/bmxzwj_51469/202604/t20260410_5214358.html"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "163",
+      "name": "Huawei Cloud Gui'an Intelligent Computing Centre",
+      "lat": 26.42,
+      "lng": 106.47,
+      "bloc": "Eastern",
+      "tier": 3,
+      "type": "Corporate",
+      "sample": false,
+      "date": "October 2024",
+      "location": "Gui'an New District, Guizhou Province, China",
+      "scope": "China national (东数西算 Guizhou hub node)",
+      "description": "Huawei Cloud's globally largest intelligent computing centre, deploying over 110,000 domestically designed Ascend NPUs within the 东数西算 Guizhou hub node. Power Usage Effectiveness (PUE) of 1.12. Majority-domestic chip composition at the cluster level.",
+      "investment": "Over 110,000 Ascend NPUs; target capacity 150 exaFLOPS; located within Guian New District served by a 500kV substation providing 4,000 MW capacity to the district's 27+ data centres",
+      "domain": "Energy/Infrastructure",
+      "sources": 1,
+      "corroborating": 4,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.1",
+      "industryPrimary": "Cloud, Data Centres & Connectivity Infrastructure",
+      "environmentalNexusTags": [
+        {
+          "type": "ENT-1",
+          "name": "Resource Demand",
+          "mechanism": "Cluster-level power infrastructure includes a 500kV substation with 4,000 MW supply capacity serving the Gui'an data centre cluster, within which Huawei Cloud operates its intelligent computing centre.",
+          "evidenceBasis": "Documented",
+          "vector": "Energy",
+          "sources": [
+            {
+              "citation": "贵州日报 — 500kV substation 4,000 MW capacity",
+              "type": "corroborating",
+              "url": "https://www.ddcpc.cn/detail/d_guizhou/11515117136145.html"
+            }
+          ]
+        },
+        {
+          "type": "ENT-4",
+          "name": "Environmental Dependency",
+          "mechanism": "Gui'an New District is located within the upstream catchment area of major drinking water reservoirs serving Guiyang, creating documented environmental dependency where data centre operations must manage pollution risk to downstream water supplies.",
+          "evidenceBasis": "Documented",
+          "dependencyType": "Water source vulnerability",
+          "sources": [
+            {
+              "citation": "北极星环保网 — Gui'an upstream water source analysis",
+              "type": "corroborating",
+              "url": "https://huanbao.bjx.com.cn/news/20180129/877213.shtml"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "164",
+      "name": "Qingyang Intelligent Computing Cluster",
+      "lat": 35.73,
+      "lng": 107.64,
+      "bloc": "Eastern",
+      "tier": 3,
+      "type": "Infrastructure",
+      "sample": false,
+      "date": "20 December 2024",
+      "location": "Qingyang, Gansu Province, China",
+      "scope": "China national (东数西算 Gansu hub node)",
+      "description": "China's first domestically manufactured 万卡-scale AI inference cluster at time of implementation, deploying Enflame S60 inference accelerators within the 东数西算 Gansu hub node.",
+      "investment": "51,000 PFLOPS aggregate cluster capacity (6 computing centres); 31,000 standard racks (cluster total); expanding to 114,000 PFLOPS by end-2025. All capacity commercially contracted at 100% uptake rate; clients include Infinigence and Meituan.",
+      "domain": "Energy/Infrastructure",
+      "sources": 1,
+      "corroborating": 3,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.1",
+      "industryPrimary": "Cloud, Data Centres & Connectivity Infrastructure",
+      "environmentalNexusTags": [
+        {
+          "type": "ENT-1",
+          "name": "Resource Demand",
+          "mechanism": "Cluster-level power infrastructure provisioning supports AI computing operations across multiple data centre facilities within the Qingyang hub node.",
+          "evidenceBasis": "Assessed",
+          "vector": "Energy",
+          "sources": []
+        },
+        {
+          "type": "ENT-2",
+          "name": "Environmental Enablement",
+          "mechanism": "Municipal development commission project approval mandates Power Usage Effectiveness (PUE) ≤1.198 for the computing cluster, establishing binding energy efficiency requirements through regulatory approval conditions.",
+          "evidenceBasis": "Documented",
+          "sources": [
+            {
+              "citation": "庆阳市发改委 project approval with PUE mandate",
+              "type": "primary",
+              "url": "https://fgw.zgqingyang.gov.cn/zzzq/zzlm/fgdt__xwzx/gzdt/content_344421"
+            }
+          ]
+        },
+        {
+          "type": "ENT-4",
+          "name": "Environmental Dependency",
+          "mechanism": "Qingyang is classified as an extremely water-scarce region with per-capita water availability at one-eighth of the national average; data centre cooling operations depend on water infrastructure under extreme scarcity conditions.",
+          "evidenceBasis": "Documented",
+          "dependencyType": "Water stress",
+          "sources": [
+            {
+              "citation": "民族先锋报 — Qingyang extreme water scarcity classification",
+              "type": "corroborating",
+              "url": "http://szb1.mzxsb.com/mzxsb/20251015/html/content_20251015003003.htm"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "165",
+      "name": "UK AI Growth Zones",
+      "lat": 51.5074,
+      "lng": -0.1278,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Policy",
+      "sample": false,
+      "date": "13 January 2025",
+      "location": "London, United Kingdom",
+      "scope": "National — UK-wide (England, Wales, Scotland)",
+      "description": "UK government programme designating sites for AI data centre development under the AI Opportunities Action Plan. Qualifying zones require minimum 500MW power capacity, 100 acres, and water supply evidence. The Culham pilot zone features a 400kV JET-inherited grid connection at the UKAEA campus.",
+      "investment": "£2.5B government commitment; £100B private capital target; 6GW national capacity; 5 designated zones",
+      "domain": "Energy/Infrastructure",
+      "sources": 2,
+      "corroborating": 3,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.0",
+      "industryPrimary": "Cloud, Data Centres & Connectivity Infrastructure",
+      "environmentalNexusTags": [
+        {
+          "type": "ENT-1",
+          "name": "Resource Demand",
+          "mechanism": "DSIT qualifying criteria mandate 500MW minimum power capacity, water supply evidence for 500MW of AI infrastructure, and 100 acres of land per designated AI Growth Zone.",
+          "evidenceBasis": "Documented",
+          "sources": [
+            {
+              "citation": "GOV.UK Delivering AI Growth Zones Policy Paper",
+              "type": "primary",
+              "url": "https://www.gov.uk/government/publications/delivering-ai-growth-zones/delivering-ai-growth-zones"
+            }
+          ]
+        },
+        {
+          "type": "ENT-3",
+          "name": "Environmental Consequence",
+          "mechanism": "Culham AIGZ pilot zone generates waste heat with planned recovery infrastructure for 3,500 adjacent homes, sited in a Thames Water water-stressed region where data centre water demand intersects existing resource constraints.",
+          "evidenceBasis": "Documented",
+          "sources": [
+            {
+              "citation": "UK Find a Tender — Culham Campus Heat Network",
+              "type": "primary",
+              "url": "https://www.find-tender.service.gov.uk/procurement/ocds-h6vhtk-05945d"
+            }
+          ]
+        },
+        {
+          "type": "ENT-4",
+          "name": "Environmental Dependency",
+          "mechanism": "AI Growth Zone viability depends on existing grid infrastructure — Culham’s 400kV JET powerline and national grid connection capacity — with queue reform provisions acknowledging infrastructure dependency constraints.",
+          "evidenceBasis": "Documented",
+          "sources": [
+            {
+              "citation": "UKTN — Culham AIGZ CTO Interview",
+              "type": "primary",
+              "url": "https://www.uktech.news/ai/exciting-plans-ahead-for-culham-britains-first-ai-growth-zone-says-uk-atomic-energy-authority-cto-20250204"
+            }
+          ]
+        },
+        {
+          "type": "ENT-5",
+          "name": "Environmental Coordination",
+          "mechanism": "The AI Energy Council, chaired by Science and Energy Secretaries, institutionalises coordination between AI infrastructure development and energy policy governance, with the cross-government AIGZ Delivery Unit providing operational coordination.",
+          "evidenceBasis": "Documented",
+          "pathway": "A",
+          "sources": [
+            {
+              "citation": "GOV.UK — AI Growth Zones Launch Press Release",
+              "type": "primary",
+              "url": "https://www.gov.uk/government/news/government-fires-starting-gun-on-ai-growth-zones-to-turbocharge-plan-for-change"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "166",
+      "name": "Cambricon SiYuan 590",
+      "lat": 39.9042,
+      "lng": 116.4074,
+      "bloc": "Eastern",
+      "tier": 3,
+      "type": "Corporate",
+      "sample": false,
+      "date": "Q3 2024",
+      "location": "Beijing, China",
+      "scope": "Mainland China (domestic AI semiconductor sector)",
+      "description": "Cambricon Technologies commenced volume production of the SiYuan 590 in Q3 2024, a 7nm chiplet-architecture AI training and inference chip fabricated on SMIC's N+2 process. Achieving approximately 80% of NVIDIA A100 inference performance, the chip is deployed across government cloud platforms and carrier intelligent computing centres in China.",
+      "investment": "RMB 1.174B revenue (2024); 65.56% YoY growth; cloud segment 11× growth; 512 TOPS INT8 / 256 TFLOPS FP16; single customer 79.15% of revenue",
+      "domain": "Technology",
+      "sources": 2,
+      "corroborating": 2,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "aiDetail": "Option E (SSE annual report 688256.SH — Disclosure-Verified)",
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.1",
+      "industryPrimary": "Semiconductors & Equipment",
+      "environmentalNexusTags": []
+    },
+    {
+      "id": "167",
+      "name": "Biren Technology BR100/BR106 GPU Series",
+      "lat": 31.2304,
+      "lng": 121.4737,
+      "bloc": "Eastern",
+      "tier": 3,
+      "type": "Corporate",
+      "sample": false,
+      "date": "January 2023",
+      "location": "Shanghai, China",
+      "scope": "Mainland China (domestic AI semiconductor sector)",
+      "description": "Biren Technology's BR100 employs a 7nm chiplet design integrating 77 billion transistors; the BR106 is a simplified single-die variant. Following the October 2022 US export controls that halted TSMC production, the company transitioned to domestic fabrication. Both chips are supported by the full-stack BIRENSUPA™ software platform.",
+      "investment": "Revenue RMB 337M (2024) → RMB 1.035B (2025); 2,048 TOPS INT8 / 1,024 TFLOPS BF16; HKEX listing 2 January 2026",
+      "domain": "Technology",
+      "sources": 2,
+      "corroborating": 3,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "aiDetail": "Option E (HKEX prospectus 06082.HK — Disclosure-Verified)",
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.1",
+      "industryPrimary": "Semiconductors & Equipment",
+      "environmentalNexusTags": []
+    },
+    {
+      "id": "168",
+      "name": "China Telecom Shanghai Lingang Intelligent Computing Centre",
+      "lat": 30.89,
+      "lng": 121.93,
+      "bloc": "Eastern",
+      "tier": 3,
+      "type": "Infrastructure",
+      "sample": false,
+      "date": "22 March 2024",
+      "location": "Shanghai Lingang New Area, China",
+      "scope": "China (Shanghai Lingang New Area — 东数西算 eastern node)",
+      "description": "China Telecom launched a domesticated single-pool 万卡 (10,000-card) liquid-cooled intelligent computing cluster at Shanghai Lingang, deploying cold plate and immersion cooling architecture for trillion-parameter model training. The facility serves as an eastern computing node within the national 东数西算 (East Data West Computing) strategy.",
+      "investment": "10,000-card AI accelerator pool; PUE <1.25; Phase 3: ~40,000 racks across 300 mu (~200,000 sqm land area; ~400,000 sqm building area); 5A certified (May 2025)",
+      "domain": "Energy/Infrastructure",
+      "sources": 2,
+      "corroborating": 1,
+      "confidence": "A",
+      "version": "1.1",
+      "checkpoints": {
+        "ai": true,
+        "aiDetail": "OEP (Pathway C — Strong)",
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "industryPrimary": "Cloud, Data Centres & Connectivity Infrastructure",
+      "environmentalNexusTags": [],
+      "aiConnectionPathway": "oep"
+    },
+    {
+      "id": "169",
+      "name": "China Telecom BTH Intelligent Computing Centre (Wuqing)",
+      "lat": 39.38,
+      "lng": 117.04,
+      "bloc": "Eastern",
+      "tier": 3,
+      "type": "Infrastructure",
+      "sample": false,
+      "date": "20 March 2025",
+      "location": "Wuqing District, Tianjin, China",
+      "scope": "China (Wuqing, Tianjin — Beijing-Tianjin-Hebei region)",
+      "description": "China Telecom inaugurated the Beijing-Tianjin-Hebei Intelligent Computing Centre in Wuqing, Tianjin, designated as a SASAC AI+ demonstration base. The facility delivers domesticated liquid-cooled intelligent computing at 万卡 (10,000-card) scale, providing full-function pre-training services across the Beijing-Tianjin-Hebei corridor.",
+      "investment": "5,760 PFLOPS; 10,000-card single-cluster; one of four national operator 万卡 clusters (2 China Telecom, 2 China Mobile, as of September 2025)",
+      "domain": "Energy/Infrastructure",
+      "sources": 3,
+      "corroborating": 0,
+      "confidence": "A",
+      "version": "1.2",
+      "checkpoints": {
+        "ai": true,
+        "aiDetail": "OEP (Pathway C — Strong)",
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "industryPrimary": "Cloud, Data Centres & Connectivity Infrastructure",
+      "environmentalNexusTags": [
+        {
+          "type": "ENT-4",
+          "name": "Environmental Dependency",
+          "mechanism": "WRI Aqueduct classifies the Wuqing, Tianjin facility location as Extremely High baseline water stress; facility employs evaporative cooling systems requiring water consumption.",
+          "evidenceBasis": "Assessed",
+          "sources": [
+            {
+              "citation": "WRI Aqueduct Water Risk Atlas V4.0",
+              "type": "primary",
+              "url": "https://www.wri.org/aqueduct"
+            }
+          ]
+        }
+      ],
+      "aiConnectionPathway": "oep"
+    },
+    {
+      "id": "170",
+      "name": "China Unicom–Alibaba Cloud Xining Green Computing Centre",
+      "lat": 36.62,
+      "lng": 101.77,
+      "bloc": "Eastern",
+      "tier": 3,
+      "type": "Infrastructure",
+      "sample": false,
+      "date": "16 January 2025",
+      "location": "Xining, Qinghai, China",
+      "scope": "China (Xining, Qinghai — 东数西算 western computing node)",
+      "description": "China Unicom and Alibaba Cloud jointly launched the Sanjiangyuan Green Power Intelligent Computing Fusion Demonstration Park in Xining, Qinghai, combining domesticated multi-vendor AI computing at scale with 100% locally sourced green electricity and natural cooling from the highland climate.",
+      "investment": "~RMB 2B+ (~US$280M) total investment; 12,288 PFLOPS 万卡 heterogeneous intelligent computing cluster; 100% green electricity; zero-carbon microgrid; multi-vendor AI chips (T-Head, MetaX, Biren, Zhonghao Xinying)",
+      "domain": "Energy/Infrastructure",
+      "sources": 3,
+      "corroborating": 2,
+      "confidence": "A",
+      "version": "1.2",
+      "checkpoints": {
+        "ai": true,
+        "aiDetail": "OEP (Pathway C — Strong)",
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "industryPrimary": "Cloud, Data Centres & Connectivity Infrastructure",
+      "environmentalNexusTags": [],
+      "aiConnectionPathway": "oep"
+    },
+    {
+      "id": "171",
+      "name": "China Unicom Shanghai Lingang Intelligent Computing Centre",
+      "lat": 30.9,
+      "lng": 121.91,
+      "bloc": "Eastern",
+      "tier": 3,
+      "type": "Infrastructure",
+      "sample": false,
+      "date": "28 November 2024",
+      "location": "Shanghai Lingang New Area, China",
+      "scope": "China (Shanghai Lingang New Area)",
+      "description": "China Unicom opened its first fully domesticated 万卡 (10,000-card) intelligent computing centre at Shanghai Lingang, the first facility in the area to achieve ODCC 5A operational certification at time of assessment. The centre deploys Huawei, MetaX, and Hygon accelerators in a multi-architecture configuration with cold plate liquid cooling.",
+      "investment": "4,000 PFLOPS; 15,000 racks; 84-mu campus; PUE 1.2 (2025 operational measurement); 5A certified (November 2024)",
+      "domain": "Energy/Infrastructure",
+      "sources": 1,
+      "corroborating": 2,
+      "confidence": "A",
+      "version": "1.2",
+      "checkpoints": {
+        "ai": true,
+        "aiDetail": "OEP (Pathway C — Strong)",
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "industryPrimary": "Cloud, Data Centres & Connectivity Infrastructure",
+      "environmentalNexusTags": [
+        {
+          "type": "ENT-1",
+          "name": "Resource Demand",
+          "mechanism": "Facility-level power infrastructure supports AI computing operations at the Lingang hub node.",
+          "evidenceBasis": "Documented",
+          "sources": [
+            {
+              "citation": "CWW — facility specifications and power capacity",
+              "type": "primary",
+              "url": "http://cww.net.cn/article?id=602183"
+            }
+          ]
+        }
+      ],
+      "aiConnectionPathway": "oep"
+    },
+    {
+      "id": "172",
+      "name": "SoftBank AI Computing Platform (DGX SuperPOD)",
+      "lat": 34.55,
+      "lng": 135.48,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Corporate",
+      "sample": false,
+      "date": "22 July 2025",
+      "location": "Sakai, Osaka Prefecture, Japan",
+      "scope": "Japan — national AI compute infrastructure",
+      "description": "SoftBank Corp. deployed a DGX SuperPOD exceeding 4,000 NVIDIA Blackwell GPUs at its Sakai campus on 22 July 2025, the largest single deployment of this GPU architecture globally at time of implementation. The total platform exceeds 10,000 GPUs delivering 13.7 exaflops of AI compute under METI Economic Security Promotion Act certification.",
+      "investment": "Not publicly disclosed",
+      "domain": "Energy/Infrastructure",
+      "sources": 3,
+      "corroborating": 1,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.0",
+      "industryPrimary": "Cloud, Data Centres & Connectivity Infrastructure",
+      "environmentalNexusTags": [
+        {
+          "type": "ENT-1",
+          "name": "Resource Demand",
+          "mechanism": "SoftBank/Sharp MoU documents >150 MW Phase 1 and >400 MW full build dedicated power capacity for AI computing platform operations.",
+          "evidenceBasis": "Documented",
+          "sources": [
+            {
+              "citation": "SoftBank Corp. / Sharp Corp. MoU Press Release (7 June 2024)",
+              "type": "PRIMARY",
+              "url": "https://www.softbank.jp/en/corp/news/press/sbkk/2024/20240607_01/"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "173",
+      "name": "Meta AI Training Clusters",
+      "lat": 37.48,
+      "lng": -122.15,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Corporate",
+      "sample": false,
+      "date": "12 March 2024",
+      "location": "United States (facility undisclosed)",
+      "scope": "United States — corporate AI training infrastructure",
+      "description": "Meta Platforms built two data-centre-scale AI training clusters, each comprising 24,576 NVIDIA H100 Tensor Core GPUs on the Grand Teton open hardware platform, operational by March 2024 for Llama 3 training. The clusters employ dual network fabrics combining RoCE and NVIDIA Quantum-2 InfiniBand.",
+      "investment": "49,152 H100 GPUs across two clusters; compute roadmap: 350,000 H100 GPUs and ~600,000 H100-equivalents total (including other GPUs) by end of 2024",
+      "domain": "Energy/Infrastructure",
+      "sources": 2,
+      "corroborating": 2,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.1",
+      "industryPrimary": "Cloud, Data Centres & Connectivity Infrastructure",
+      "environmentalNexusTags": []
+    },
+    {
+      "id": "174",
+      "name": "Naver Gak Sejong Data Centre",
+      "lat": 36.5,
+      "lng": 127.0,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Corporate",
+      "sample": false,
+      "date": "8 November 2023",
+      "location": "Sejong City, South Korea",
+      "scope": "South Korea — national hyperscale AI/cloud data centre infrastructure",
+      "description": "Naver Corp. opened Gak Sejong (각 세종), its second hyperscale data centre, in Sejong City on 8 November 2023. Spanning 294,000 square metres with 270 MW substation capacity, the facility was the largest data centre operated by a single company in South Korea at time of implementation, anchoring Naver’s HyperCLOVA X sovereign AI platform.",
+      "investment": "~₩650B (~US$497M) Phase 1; ₩400B (US$270M) FSC expansion loan (April 2026); 270–275 MW; 600,000 server capacity; top 5 in Asia",
+      "domain": "Energy/Infrastructure",
+      "sources": 1,
+      "corroborating": 3,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "aiDetail": "Option E (Disclosure-Verified)",
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.0",
+      "industryPrimary": "Cloud, Data Centres & Connectivity Infrastructure",
+      "environmentalNexusTags": [
+        {
+          "type": "ENT-1",
+          "name": "Resource Demand",
+          "mechanism": "Gak Sejong data centre campus documents 270–275 MW dedicated power capacity with a 154 kV substation for AI and cloud computing operations.",
+          "evidenceBasis": "Documented",
+          "sources": [
+            {
+              "citation": "DCD — Naver Launches 270MW Data Centre Campus in Sejong",
+              "type": "CORROBORATING",
+              "url": "https://www.datacenterdynamics.com/en/news/naver-launches-270mw-data-center-campus-in-sejong-south-korea/"
+            },
+            {
+              "citation": "Korea Times — Operation Efficiency at Core of AI Infrastructure (October 2025)",
+              "type": "CORROBORATING",
+              "url": "https://www.koreatimes.co.kr/business/tech-science/20251028/operation-efficiency-at-core-of-ai-infrastructure-capability"
+            }
+          ]
+        },
+        {
+          "type": "ENT-4",
+          "name": "Environmental Dependency",
+          "mechanism": "NAMU III hybrid cooling system operational efficiency depends on Geum River natural wind for ~240 days per year of air cooling, with water-based cooling for the remaining period, creating documented dependency on local climate and water conditions.",
+          "evidenceBasis": "Documented",
+          "sources": [
+            {
+              "citation": "Naver Corp. — TCFD Climate Disclosure 2024",
+              "type": "PRIMARY",
+              "url": "https://www.navercorp.com/api/article/download/d5a77423-433f-4a5b-adc4-a15873c7c0df"
+            },
+            {
+              "citation": "Naver Corp. — TCFD Report 2022",
+              "type": "PRIMARY",
+              "url": "https://www.navercorp.com/api/article/download/c17482c3-8f86-41c6-aba4-469796415377"
+            },
+            {
+              "citation": "Korea Times — NAMU III Cooling and 240-Day Air Cooling (October 2025)",
+              "type": "CORROBORATING",
+              "url": "https://www.koreatimes.co.kr/business/tech-science/20251028/operation-efficiency-at-core-of-ai-infrastructure-capability"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "175",
+      "name": "EuroHPC AI Factories Network",
+      "lat": 50.8503,
+      "lng": 4.3517,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Coordination",
+      "sample": false,
+      "date": "9 July 2024",
+      "location": "Brussels, Belgium",
+      "scope": "EU (19 AI Factory sites across 15+ Member States)",
+      "description": "Council Regulation (EU) 2024/1732 expanded the EuroHPC Joint Undertaking mandate to establish and operate AI Factories across Europe. Nineteen sites were selected across three tranches (December 2024, March 2025, October 2025) with matched national and EU co-funding.",
+      "investment": "€10B total (Commission + Member State + Associated Country through EuroHPC JU, 2021–2027); EU contribution up to €800M from Digital Europe Programme",
+      "domain": "Energy/Infrastructure",
+      "industryPrimary": "Cloud, Data Centres & Connectivity Infrastructure",
+      "environmentalNexusTags": [],
+      "sources": 7,
+      "corroborating": 0,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.1"
+    },
+    {
+      "id": "176",
+      "name": "Enflame Technology S60",
+      "lat": 31.2304,
+      "lng": 121.4737,
+      "bloc": "Eastern",
+      "tier": 3,
+      "type": "Corporate",
+      "sample": false,
+      "date": "1 July 2024",
+      "location": "Shanghai, China",
+      "scope": "China (domestic AI chip design and production)",
+      "description": "Enflame Technology’s S60 cloud AI inference chip, the company’s third-generation proprietary architecture, is manufactured by TSMC. The chip is deployed across sovereign intelligent computing facilities and cloud computing centres in China for AI inference workloads.",
+      "investment": "RMB 6B (~US$830M) IPO target (filed January 2026, not yet completed); RMB 722M 2024 revenue; ~70,000 S60 units shipped",
+      "domain": "Technology",
+      "industryPrimary": "Semiconductors & Equipment",
+      "environmentalNexusTags": [],
+      "sources": 1,
+      "corroborating": 3,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.2"
+    },
+    {
+      "id": "177",
+      "name": "Sakura Internet Ishikari GPU Cloud (Koukaryoku)",
+      "lat": 43.1715,
+      "lng": 141.3147,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Corporate",
+      "sample": false,
+      "date": "31 January 2024",
+      "location": "Ishikari, Hokkaido, Japan",
+      "scope": "Japan (domestic GPU cloud computing infrastructure)",
+      "description": "Sakura Internet launched Koukaryoku PHY, a sovereign GPU cloud service, at Ishikari Data Centre in Hokkaido on 31 January 2024, deploying NVIDIA H100 infrastructure under a METI Economic Security Promotion Act subsidy of JPY 50.1B. The platform expanded in 2025 with NVIDIA H200 GPUs.",
+      "investment": "JPY 50.1B METI ESPA subsidy; 2,000 NVIDIA H100 GPUs (Phase 1, completed August 2024); ~1,000 NVIDIA H200 GPUs (Phase 2, 2025); expanding to ~10,800 total GPUs including B200 (through 2027); ~US$280M estimated facility investment",
+      "domain": "Energy/Infrastructure",
+      "industryPrimary": "Cloud, Data Centres & Connectivity Infrastructure",
+      "environmentalNexusTags": [],
+      "sources": 4,
+      "corroborating": 2,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.2"
+    },
+    {
+      "id": "178",
+      "name": "Microsoft Fairwater 2 Atlanta AI Superfactory",
+      "lat": 33.524,
+      "lng": -84.625,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Corporate",
+      "sample": false,
+      "date": "October 2025",
+      "location": "Fayette County, United States",
+      "scope": "United States (Fayette County, Georgia)",
+      "description": "Microsoft opened Fairwater 2 in Fayette County, Georgia, its second AI data centre purpose-built for Azure AI workloads including OpenAI operations. The facility forms part of a distributed superfactory architecture linked to Fairwater 1 Wisconsin via 120,000 miles of dedicated fibre, forgoing traditional UPS and generator systems.",
+      "investment": "GPU design capacity: hundreds of thousands of NVIDIA GB200/GB300; ~140kW per rack (~1,360kW per row)",
+      "domain": "Energy/Infrastructure",
+      "industryPrimary": "Cloud, Data Centres & Connectivity Infrastructure",
+      "environmentalNexusTags": [],
+      "sources": 2,
+      "corroborating": 2,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.0"
+    },
+    {
+      "id": "179",
+      "name": "CoreWeave Plano AI Supercomputer",
+      "lat": 33.014,
+      "lng": -96.765,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Corporate",
+      "sample": false,
+      "date": "September 2023",
+      "location": "Plano, United States",
+      "scope": "United States (Plano, Texas)",
+      "description": "CoreWeave opened its first Texas data centre in Plano, deploying NVIDIA H100 GPUs with Quantum-2 InfiniBand networking as a cloud-native AI supercomputer. The production cluster set a September 2023 MLPerf record, training the GPT-3 175B benchmark in under 11 minutes.",
+      "investment": "US$1.6B total investment; up to 30MW critical IT load; 450,000 sq ft on 23.8-acre campus; 3,500+ NVIDIA H100 GPUs",
+      "domain": "Energy/Infrastructure",
+      "industryPrimary": "Cloud, Data Centres & Connectivity Infrastructure",
+      "environmentalNexusTags": [],
+      "sources": 2,
+      "corroborating": 2,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.0"
+    },
+    {
+      "id": "180",
+      "name": "SK Telecom Gasan AI Data Centre (GPUaaS)",
+      "lat": 37.476,
+      "lng": 126.887,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Corporate",
+      "sample": false,
+      "date": "December 2024",
+      "location": "Seoul, South Korea",
+      "scope": "South Korea (Seoul, Gasan)",
+      "description": "SK Telecom deployed Lambda’s AI Cloud platform with NVIDIA H100 GPU clusters at its Gasan data centre in Seoul, establishing Lambda’s first Asia-Pacific region for GPU-as-a-Service. Launched in January 2025, the facility supports 44 kW per rack — nine times the Korean national average.",
+      "investment": "46 MW IT load across 69,300 sq m; rack density 44 kW (9× Korean national average); NVIDIA H100 GPUs",
+      "domain": "Energy/Infrastructure",
+      "industryPrimary": "Cloud, Data Centres & Connectivity Infrastructure",
+      "environmentalNexusTags": [],
+      "sources": 3,
+      "corroborating": 2,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.0"
+    },
+    {
+      "id": "181",
+      "name": "MetaX C500 GPU Series",
+      "lat": 31.2304,
+      "lng": 121.4737,
+      "bloc": "Eastern",
+      "tier": 3,
+      "type": "Corporate",
+      "sample": false,
+      "date": "February 2024",
+      "location": "Shanghai, China",
+      "scope": "Mainland China (domestic AI semiconductor sector)",
+      "description": "MetaX Integrated Circuits commenced volume production of the C500 series GPGPU in February 2024, a 7nm AI accelerator with a CUDA-compatible MXMACA software stack certified in the Red Hat Ecosystem Catalogue. The chip is deployed across AI public computing platforms and telecom intelligent computing centres in China.",
+      "investment": "STAR Market IPO raised RMB 4.197 billion (~US$596M) (December 2025); RMB 743M revenue (2024); C500 contributes 97.28% of main business revenue; cumulative sales >25,000 GPU units by March 2025",
+      "domain": "Technology",
+      "industryPrimary": "Semiconductors & Equipment",
+      "environmentalNexusTags": [],
+      "sources": 2,
+      "corroborating": 4,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "aiDetail": "Option E (STAR Market prospectus 688802.SH — Disclosure-Verified)",
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.1"
+    },
+    {
+      "id": "182",
+      "name": "Tesla Cortex AI Supercluster",
+      "lat": 30.2312,
+      "lng": -97.6139,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Corporate",
+      "sample": false,
+      "date": "October 2024",
+      "location": "Gigafactory Texas, Austin, United States",
+      "scope": "United States (Tesla proprietary AI training infrastructure)",
+      "description": "Tesla deployed Cortex, an AI training supercluster at Gigafactory Texas comprising approximately 50,000 NVIDIA H100 GPUs with Supermicro direct liquid cooling achieving an 89% reduction in cooling electricity versus air cooling. The cluster enabled Full Self-Driving Version 13 development with a 4.2× increase in training data throughput.",
+      "investment": "Cumulative AI-related capex ~US$5B (2024); ~130 MW pre-deployment power; ~50,000 NVIDIA H100 GPUs deployed",
+      "domain": "Energy/Infrastructure",
+      "industryPrimary": "Cloud, Data Centres & Connectivity Infrastructure",
+      "environmentalNexusTags": [
+        {
+          "type": "ENT-1",
+          "name": "Resource Demand",
+          "mechanism": "Tesla Cortex AI Supercluster at Gigafactory Texas has a documented pre-deployment design specification of approximately 130 MW for the initial approximately 50,000 H100 GPU deployment.",
+          "evidenceBasis": "Documented",
+          "sources": [
+            {
+              "citation": "Teslarati — Musk reveals power needs (June 2024)",
+              "type": "CORROBORATING",
+              "url": "https://www.teslarati.com/musk-tesla-supercomputing-130mw-power/"
+            },
+            {
+              "citation": "TechCrunch — Tesla’s Dojo, a timeline (September 2025)",
+              "type": "CORROBORATING",
+              "url": "https://techcrunch.com/2025/09/02/teslas-dojo-a-timeline/"
+            }
+          ]
+        },
+        {
+          "type": "ENT-4",
+          "name": "Environmental Dependency",
+          "mechanism": "Tesla Cortex is located at Gigafactory Texas in Travis County, within the Lower Colorado minor basin (Gulf Coast major basin). WRI Aqueduct 4.0 classifies baseline water stress at Medium-High (20–40%). Over 70% of Texas experienced moderate to severe drought in 2024.",
+          "evidenceBasis": "Documented",
+          "sources": [
+            {
+              "citation": "Tom’s Hardware — Supermicro CEO endorses liquid cooling (July 2024)",
+              "type": "CORROBORATING",
+              "url": "https://www.tomshardware.com/tech-industry/artificial-intelligence/elon-musks-liquid-cooled-gigafactory-data-centers-get-a-plug-from-supermicro-ceo-tesla-and-xais-new-supercomputers-will-have-350000-nvidia-gpus-both-will-be-online-within-months"
+            },
+            {
+              "citation": "Datacenters.com — Texas Water Crisis (July 2025)",
+              "type": "CORROBORATING",
+              "url": "https://www.datacenters.com/news/texas-water-crisis-the-impact-of-data-center-developments-on-a-fragile-resource"
+            }
+          ]
+        }
+      ],
+      "sources": 1,
+      "corroborating": 4,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true,
+        "aiDetail": "Option A (≥10% AI-designated capacity — ~50,000 H100 GPUs, 10× the 5,000+ threshold)"
+      },
+      "version": "1.1"
+    },
+    {
+      "id": "183",
+      "name": "Japan AI Promotion Act",
+      "lat": 35.6762,
+      "lng": 139.6503,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Policy",
+      "sample": false,
+      "date": "September 2025",
+      "location": "Tokyo, Japan",
+      "scope": "Japan — national scope, all AI systems and providers",
+      "description": "Japan enacted its first AI-specific statute on 28 May 2025, with full effect from September 2025. The Act establishes the AI Strategy Headquarters under the Prime Minister with a statutory mandate for the AI Basic Plan, adopting promotion-first governance through investigation and disclosure authority rather than monetary penalties.",
+      "investment": "No dedicated financial commitment specified. Institutional resource: AI Strategy Headquarters with statutory mandate and staffing from Cabinet Office, METI, and MIC.",
+      "domain": "Technology",
+      "industryPrimary": "AI Software & Platforms",
+      "environmentalNexusTags": [],
+      "sources": 1,
+      "corroborating": 4,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "aiDetail": "Dedicated AI Provisions",
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.0"
+    },
+    {
+      "id": "184",
+      "name": "China State Council AI+ Action Plan",
+      "lat": 39.9042,
+      "lng": 116.4074,
+      "bloc": "Eastern",
+      "tier": 3,
+      "type": "Policy",
+      "sample": false,
+      "date": "August 2025",
+      "location": "Beijing, China",
+      "scope": "China nationwide (six major action domains, all provincial governments and central ministries)",
+      "description": "The State Council issued binding directive 国发〔２０２５〕１１号 on 26 August 2025, mandating AI integration across six domains — science and technology, industrial development, consumption, livelihood, governance, and global cooperation — supported by eight foundational capability pillars.",
+      "investment": "No single financial figure specified. Smart terminal and AI agent penetration targets: >70% by 2027, >90% by 2030. Directive mandates resource mobilisation across all provincial governments and central ministries.",
+      "domain": "Technology",
+      "industryPrimary": "AI Software & Platforms",
+      "environmentalNexusTags": [],
+      "sources": 5,
+      "corroborating": 0,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "aiDetail": "Dedicated AI Provisions",
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.1"
+    },
+    {
+      "id": "185",
+      "name": "IRA Section 30D FEOC Final Rule",
+      "lat": 38.9072,
+      "lng": -77.0369,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Policy",
+      "sample": false,
+      "date": "06 May 2024",
+      "location": "United States",
+      "scope": "United States (with extraterritorial supply-chain implications for critical mineral and battery component sourcing)",
+      "description": "The IRA Section 30D Foreign Entity of Concern Final Rule (89 FR 37706), published 06 May 2024, conditions clean vehicle tax credit eligibility on battery component and critical mineral supply chain provenance under the Inflation Reduction Act. A concurrent DOE Interpretive Rule defines FEOC determination criteria.",
+      "investment": "N/A (regulatory instrument). Phased exclusion: battery components from 2024, critical minerals from 2025; Section 30D credit value US$7,500/US$3,750 per vehicle; qualifying models reduced from 43 to 19; covered nations: PRC, Russia, DPRK, Iran.",
+      "domain": "Trade",
+      "industryPrimary": "Trade & Logistics",
+      "environmentalNexusTags": [],
+      "sources": 2,
+      "corroborating": 3,
+      "confidence": "A",
+      "aiConnectionPathway": "option_g",
+      "checkpoints": {
+        "ai": true,
+        "aiDetail": "Option G (lithium, cobalt, graphite, REE — Supply-Chain-Verified)",
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.0"
+    },
+    {
+      "id": "187",
+      "name": "UNGA AI Scientific Panel and Global Dialogue (A/RES/79/325)",
+      "lat": 40.7489,
+      "lng": -73.968,
+      "bloc": "Western",
+      "tier": 3,
+      "type": "Coordination",
+      "sample": false,
+      "date": "26 August 2025",
+      "location": "New York, United States (UN General Assembly)",
+      "scope": "International (193 UN Member States; adopted by consensus without a vote)",
+      "description": "UNGA Resolution A/RES/79/325, adopted by consensus on 26 August 2025, establishes the Independent International Scientific Panel on Artificial Intelligence and the Global Dialogue on Artificial Intelligence Governance. The Scientific Panel is mandated to produce annual non-prescriptive assessment reports synthesising AI research. The resolution follows from the Global Digital Compact (A/RES/79/1) framework.",
+      "investment": "Consensus adoption by 193 Member States; 123 co-sponsors; 40-member Scientific Panel (3-year terms); both mechanisms launched at 80th General Assembly session September 2025; Dialogue convened annually alternating Geneva and New York.",
+      "domain": "Technology",
+      "industryPrimary": "AI Software & Platforms",
+      "environmentalNexusTags": [],
+      "sources": 2,
+      "corroborating": 4,
+      "confidence": "A",
+      "checkpoints": {
+        "ai": true,
+        "threshold": true,
+        "implemented": true,
+        "current": true
+      },
+      "version": "1.0"
+    }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -5838,8 +5838,9 @@
     .scp-dim-dot.gv { background: var(--scp-gov); }
     .scp-dim-st { font-weight: 500; }
     .scp-dim-met { color: #22C55E; }
-    .scp-dim-not { color: #475569; }
+    .scp-dim-not { color: var(--scp-part); }
     .scp-dim-constraint { font-size: 11px; color: #64748B; padding: 1px 0 4px 11px; font-style: italic; line-height: 1.5; }
+    .scp-dim-con-label { font-style: normal; font-weight: 500; color: #94A3B8; letter-spacing: 0.01em; }
     .scp-sev { font-size: 11px; color: #64748B; margin-top: 8px; padding-top: 8px; border-top: 1px solid rgba(255,255,255,0.04); line-height: 1.5; }
     .scp-sev strong { color: #94A3B8; font-weight: 500; }
     .scp-aik { margin-top: 8px; padding: 7px 8px; border-top: 1px solid rgba(255,255,255,0.04); }
@@ -11665,23 +11666,25 @@ function generateCCSection(eventId, showFullContent) {
     a.dims.forEach(function(d, i) {
       h += '<div class="scp-dim-row">';
       h += '<span class="scp-dim-name scp-tip-trigger" data-scp-tip="dim-' + i + '"><span class="scp-dim-dot ' + DC[i] + '"></span>' + DN[i] + '</span>';
-      h += '<span class="scp-dim-st ' + (d ? 'scp-dim-met' : 'scp-dim-not') + '">' + (d ? 'Met' : '—') + '</span>';
+      h += '<span class="scp-dim-st ' + (d ? 'scp-dim-met' : 'scp-dim-not') + '">' + (d ? 'Met' : 'Not Met') + '</span>';
       h += '</div>';
       if (d && a.con && a.con[i]) {
         h += '<div class="scp-dim-constraint">' + escH(a.con[i]) + '</div>';
+      } else if (!d && a.con && a.con[i]) {
+        h += '<div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> ' + escH(a.con[i]) + '</div>';
+      } else if (!d && a.hl && a.hl[i]) {
+        h += '<div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> ' + escH(a.hl[i]) + '</div>';
       }
-      /* Sources present in data -> show; absent -> lock (free-tier strip) */
-      if (d) {
-        if (a.src && a.src[i]) {
-          var s = a.src[i]; /* [g1, pub1, date1, fact1, url1, g2, pub2, date2, fact2, url2] */
-          h += '<div class="scp-src-trigger"><span class="scp-src-icon">ⓘ</span> Sources</div>';
-          h += '<div class="scp-src-block">';
-          h += srcEntry('Primary', s[0], s[1], s[2], s[3], s[4]);
-          h += srcEntry('Corroborating', s[5], s[6], s[7], s[8], s[9]);
-          h += '</div>';
-        } else {
-          h += '<div class="scp-src-lock" title="Supporter access required">' + WEO_ICON_LOCK + ' Sources (supporter access)</div>';
-        }
+      /* Sources present in data -> show; absent -> lock when content exists */
+      if (a.src && a.src[i]) {
+        var s = a.src[i]; /* [g1, pub1, date1, fact1, url1, g2, pub2, date2, fact2, url2] */
+        h += '<div class="scp-src-trigger"><span class="scp-src-icon">ⓘ</span> Sources</div>';
+        h += '<div class="scp-src-block">';
+        h += srcEntry('Primary', s[0], s[1], s[2], s[3], s[4]);
+        h += srcEntry('Corroborating', s[5], s[6], s[7], s[8], s[9]);
+        h += '</div>';
+      } else if (d || (!d && ((a.con && a.con[i]) || (a.hl && a.hl[i])))) {
+        h += '<div class="scp-src-lock" title="Supporter access required">' + WEO_ICON_LOCK + ' Sources (supporter access)</div>';
       }
     });
 
@@ -11723,6 +11726,7 @@ function generateCCSection(eventId, showFullContent) {
     return apiData.actors.map(function(actor) {
       var dims = DK.map(function(k) { return actor.dimensions[k] && actor.dimensions[k].met ? 1 : 0; });
       var con  = DK.map(function(k) { var dim = actor.dimensions[k] || {}; return dim.constraint || null; });
+      var hl   = DK.map(function(k) { var dim = actor.dimensions[k] || {}; return dim.constraint_headline || null; });
       var src  = DK.map(function(k) {
         var dim = actor.dimensions[k] || {};
         if (!dim.sources) return null;
@@ -11736,7 +11740,7 @@ function generateCCSection(eventId, showFullContent) {
         n: actor.name,
         s: actor.score || 0,
         d: actor.designation === 'Participant' ? 'Part' : (actor.designation || 'Part'),
-        dims: dims, con: con, svd: actor.severance_detail || null, src: src,
+        dims: dims, con: con, hl: hl, svd: actor.severance_detail || null, src: src,
         aik: actor.aik_profile || null,
         sample: actor.sample || false
       };

--- a/index.html
+++ b/index.html
@@ -5838,7 +5838,7 @@
     .scp-dim-dot.gv { background: var(--scp-gov); }
     .scp-dim-st { font-weight: 500; }
     .scp-dim-met { color: #22C55E; }
-    .scp-dim-not { color: var(--scp-part); }
+    .scp-dim-not { color: var(--weo-text-muted); }
     .scp-dim-constraint { font-size: 11px; color: #64748B; padding: 1px 0 4px 11px; font-style: italic; line-height: 1.5; }
     .scp-dim-con-label { font-style: normal; font-weight: 500; color: #94A3B8; letter-spacing: 0.01em; }
     .scp-sev { font-size: 11px; color: #64748B; margin-top: 8px; padding-top: 8px; border-top: 1px solid rgba(255,255,255,0.04); line-height: 1.5; }

--- a/index.html
+++ b/index.html
@@ -5838,7 +5838,7 @@
     .scp-dim-dot.gv { background: var(--scp-gov); }
     .scp-dim-st { font-weight: 500; }
     .scp-dim-met { color: #22C55E; }
-    .scp-dim-not { color: var(--weo-text-muted); }
+    .scp-dim-not { color: var(--scp-part); }
     .scp-dim-constraint { font-size: 11px; color: #64748B; padding: 1px 0 4px 11px; font-style: italic; line-height: 1.5; }
     .scp-dim-con-label { font-style: normal; font-weight: 500; color: #94A3B8; letter-spacing: 0.01em; }
     .scp-sev { font-size: 11px; color: #64748B; margin-top: 8px; padding-top: 8px; border-top: 1px solid rgba(255,255,255,0.04); line-height: 1.5; }


### PR DESCRIPTION
## Summary

- **E185 (IRA Section 30D FEOC Final Rule):** restored `Section` in name; trimmed description (87w→46w); populated investment with phased exclusion timeline, credit values, covered nations; rewrote tierRationale (119w→81w, removed description duplication); corrected all 5 pisa5 factor names to corpus schema (F1–F5 codes → full names); restored J-Tier A in F1 rationale; populated relatedEvents (E42 rare earth, E121 graphite)
- **E187 (UNGA AI Scientific Panel and Global Dialogue):** restored D2 name (4 undocumented changes by Entry Agent reversed); trimmed description (71w→51w, participation metrics moved to SCALE); populated investment (28w); rewrote tierRationale (3 verbatim sentences removed, T1 failure explained per E54 precedent); restored `Non-binding — Level 5 required` in keohane[2]; populated relatedEvents (E53, E54 — predecessor UNGA AI resolutions, bidirectional)
- **E53, E54 (bidirectional relatedEvents):** E187 appended to both
- **CC-53-96-4:** `primary_documentation` added; `enabling_relationship` trimmed (dedup — institutional context moved to primary_documentation); `verified_date` corrected to ISO format `2026-06-02`

## Static fallback

`data/events-free.json` updated to match KV. Canonical changes live in `weo-api/events-canonical.json` and `weo-api/connections-canonical.json` (not committed to GitHub per safety rules).

## Verification

35/35 canonical assertions passed before deployment. Live API verified: E185 name, description, investment; E187 name, investment. Premium fields (pisa5, tierRationale, keohane, evidence_detail, relatedEvents) verified via canonical file checks only — not exposed in free-tier public API.

## Test plan

- [ ] Review E185 on WEO interface — name shows "IRA Section 30D FEOC Final Rule"
- [ ] Review E187 on WEO interface — name shows "UNGA AI Scientific Panel and Global Dialogue (A/RES/79/325)"
- [ ] Confirm no regressions on surrounding events

🤖 Generated with [Claude Code](https://claude.com/claude-code)