### PR TITLE
feat(profiles): full-screen SCP panel rebuild + routing changes

### DIFF
--- a/events.html
+++ b/events.html
@@ -3409,7 +3409,7 @@
     const WEO_DB = {
       event_count: 134,
       cc_count: 107,
-      last_updated: "2026-06-02",
+      last_updated: "2026-06-03",
       db_version: "1.5.0"
     };
 

--- a/index.html
+++ b/index.html
@@ -5731,6 +5731,8 @@
       transition: all var(--duration-fast) var(--ease-out);
     }
     .scp-close:hover { background: #334155; color: #F1F5F9; }
+    .scp-fullscreen-link { font-size: 10px; color: #475569; text-decoration: none; margin-top: 5px; display: inline-block; transition: color 150ms; }
+    .scp-fullscreen-link:hover { color: #94A3B8; }
 
     /* Dimension pills */
     .scp-pills {
@@ -6064,7 +6066,7 @@
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M2 12h20M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
       Map
     </a>
-    <a href="#" id="navScpToggle" onclick="event.preventDefault();" class="nav-scp-link">
+    <a href="/profiles/" class="nav-scp-link">
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
       Actor Profiles
     </a>
@@ -6263,6 +6265,7 @@
       <div>
         <div class="scp-title">Sovereign Capability Profiles <span class="scp-tip-trigger" data-scp-tip="scp-overview" style="font-size:12px;opacity:0.5;cursor:pointer;">&#9432;</span></div>
         <div class="scp-subtitle">Actor Designation Framework — <span id="scpCount">14</span> actors assessed</div>
+        <a href="/profiles/" class="scp-fullscreen-link">View full screen →</a>
       </div>
       <button class="scp-close" id="scpClose" aria-label="Close">×</button>
     </div>

--- a/index.html
+++ b/index.html
@@ -5838,7 +5838,7 @@
     .scp-dim-dot.gv { background: var(--scp-gov); }
     .scp-dim-st { font-weight: 500; }
     .scp-dim-met { color: #22C55E; }
-    .scp-dim-not { color: var(--scp-part); }
+    .scp-dim-not { color: var(--weo-text-muted); }
     .scp-dim-constraint { font-size: 11px; color: #64748B; padding: 1px 0 4px 11px; font-style: italic; line-height: 1.5; }
     .scp-dim-con-label { font-style: normal; font-weight: 500; color: #94A3B8; letter-spacing: 0.01em; }
     .scp-sev { font-size: 11px; color: #64748B; margin-top: 8px; padding-top: 8px; border-top: 1px solid rgba(255,255,255,0.04); line-height: 1.5; }

--- a/index.html
+++ b/index.html
@@ -5840,6 +5840,11 @@
     .scp-dim-met { color: #22C55E; }
     .scp-dim-not { color: var(--scp-part); }
     .scp-dim-constraint { font-size: 11px; color: #64748B; padding: 1px 0 4px 11px; font-style: italic; line-height: 1.5; }
+    .scp-dim-qual-hl { font-size: 11px; color: #CBD5E1; padding: 1px 0 4px 11px; line-height: 1.5; }
+    .scp-qual-trigger { font-size: 10px; color: #475569; cursor: pointer; margin-left: 11px; padding: 2px 0; display: flex; align-items: center; gap: 4px; transition: color var(--duration-fast); }
+    .scp-qual-trigger:hover { color: #94A3B8; }
+    .scp-qual-block { display: none; margin: 4px 0 6px 11px; padding: 8px 12px; background: rgba(15,23,42,0.5); border-radius: var(--weo-radius-sm); border: 1px solid rgba(255,255,255,0.04); font-size: 10px; color: #94A3B8; line-height: 1.6; }
+    .scp-qual-block.show { display: block; }
     .scp-dim-con-label { font-style: normal; font-weight: 500; color: #94A3B8; letter-spacing: 0.01em; }
     .scp-sev { font-size: 11px; color: #64748B; margin-top: 8px; padding-top: 8px; border-top: 1px solid rgba(255,255,255,0.04); line-height: 1.5; }
     .scp-sev strong { color: #94A3B8; font-weight: 500; }
@@ -6400,7 +6405,7 @@
     const WEO_DB = {
       event_count: 130,
       cc_count: 107,
-      last_updated: "2026-06-02",
+      last_updated: "2026-06-03",
       db_version: "1.5.0"
     };
 
@@ -11639,6 +11644,15 @@ function generateCCSection(eventId, showFullContent) {
           if (block) block.classList.toggle('show');
           return;
         }
+        var qualTrig = e.target.closest('.scp-qual-trigger');
+        if (qualTrig) {
+          var qualBlock = qualTrig.nextElementSibling;
+          if (qualBlock && qualBlock.classList.contains('scp-qual-block')) {
+            qualBlock.classList.toggle('show');
+            qualTrig.querySelector('.scp-src-icon').textContent = qualBlock.classList.contains('show') ? '▾' : '▸';
+          }
+          return;
+        }
         var lockEl = e.target.closest('.scp-src-lock');
         if (lockEl) { if (typeof window.openAccessModal === 'function') window.openAccessModal(); }
       });
@@ -11668,12 +11682,19 @@ function generateCCSection(eventId, showFullContent) {
       h += '<span class="scp-dim-name scp-tip-trigger" data-scp-tip="dim-' + i + '"><span class="scp-dim-dot ' + DC[i] + '"></span>' + DN[i] + '</span>';
       h += '<span class="scp-dim-st ' + (d ? 'scp-dim-met' : 'scp-dim-not') + '">' + (d ? 'Met' : 'Not Met') + '</span>';
       h += '</div>';
+      if (d && a.qhl && a.qhl[i]) {
+        h += '<div class="scp-dim-qual-hl">' + escH(a.qhl[i]) + '</div>';
+      }
       if (d && a.con && a.con[i]) {
         h += '<div class="scp-dim-constraint">' + escH(a.con[i]) + '</div>';
       } else if (!d && a.con && a.con[i]) {
         h += '<div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> ' + escH(a.con[i]) + '</div>';
       } else if (!d && a.hl && a.hl[i]) {
         h += '<div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> ' + escH(a.hl[i]) + '</div>';
+      }
+      if (d && a.qual && a.qual[i]) {
+        h += '<div class="scp-qual-trigger"><span class="scp-src-icon">▸</span> Qualification</div>';
+        h += '<div class="scp-qual-block">' + escH(a.qual[i]) + '</div>';
       }
       /* Sources present in data -> show; absent -> lock when content exists */
       if (a.src && a.src[i]) {
@@ -11727,6 +11748,8 @@ function generateCCSection(eventId, showFullContent) {
       var dims = DK.map(function(k) { return actor.dimensions[k] && actor.dimensions[k].met ? 1 : 0; });
       var con  = DK.map(function(k) { var dim = actor.dimensions[k] || {}; return dim.constraint || null; });
       var hl   = DK.map(function(k) { var dim = actor.dimensions[k] || {}; return dim.constraint_headline || null; });
+      var qhl  = DK.map(function(k) { var dim = actor.dimensions[k] || {}; return dim.qualification_headline || null; });
+      var qual = DK.map(function(k) { var dim = actor.dimensions[k] || {}; return dim.qualification || null; });
       var src  = DK.map(function(k) {
         var dim = actor.dimensions[k] || {};
         if (!dim.sources) return null;
@@ -11740,7 +11763,7 @@ function generateCCSection(eventId, showFullContent) {
         n: actor.name,
         s: actor.score || 0,
         d: actor.designation === 'Participant' ? 'Part' : (actor.designation || 'Part'),
-        dims: dims, con: con, hl: hl, svd: actor.severance_detail || null, src: src,
+        dims: dims, con: con, hl: hl, qhl: qhl, qual: qual, svd: actor.severance_detail || null, src: src,
         aik: actor.aik_profile || null,
         sample: actor.sample || false
       };

--- a/index.html
+++ b/index.html
@@ -5838,7 +5838,7 @@
     .scp-dim-dot.gv { background: var(--scp-gov); }
     .scp-dim-st { font-weight: 500; }
     .scp-dim-met { color: #22C55E; }
-    .scp-dim-not { color: var(--weo-text-muted); }
+    .scp-dim-not { color: var(--scp-part); }
     .scp-dim-constraint { font-size: 11px; color: #64748B; padding: 1px 0 4px 11px; font-style: italic; line-height: 1.5; }
     .scp-dim-con-label { font-style: normal; font-weight: 500; color: #94A3B8; letter-spacing: 0.01em; }
     .scp-sev { font-size: 11px; color: #64748B; margin-top: 8px; padding-top: 8px; border-top: 1px solid rgba(255,255,255,0.04); line-height: 1.5; }

--- a/profiles/index.html
+++ b/profiles/index.html
@@ -1,0 +1,1801 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Sovereign Capability Profiles — AI Infrastructure Assessments | Warmth Engine Observatory</title>
+  <meta name="description" content="Nation-state AI infrastructure assessments across 14 actors. Chip design, fabrication, equipment, compute, frontier models, regulation, and sovereign investment dimensions evaluated with sourced evidence.">
+  <link rel="canonical" href="https://warmthengine.com/profiles/">
+  <meta property="og:title" content="Sovereign Capability Profiles — Warmth Engine Observatory">
+  <meta property="og:description" content="Which nations control the AI infrastructure stack? 14 actors assessed across 7 dimensions with sourced evidence.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://warmthengine.com/profiles/">
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "name": "WEO Sovereign Capability Profiles",
+  "description": "Nation-state AI infrastructure capability assessments across 7 dimensions for 14 actors",
+  "url": "https://warmthengine.com/profiles/",
+  "creator": {
+    "@type": "Organisation",
+    "name": "Warmth Engine Observatory",
+    "url": "https://warmthengine.com"
+  },
+  "dateModified": "2026-06-03",
+  "license": "https://warmthengine.com/research/methodology/manual/"
+}
+  </script>
+  <style>
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+  --bg-primary: #0F172A;
+  --bg-card: #1E293B;
+  --bg-deep: #0B1120;
+  --text-primary: #E2E8F0;
+  --text-secondary: #94A3B8;
+  --text-muted: #64748B;
+  --accent: #3B82F6;
+  --border: rgba(255,255,255,0.07);
+  --scp-hw: #60A5FA;
+  --scp-pl: #A78BFA;
+  --scp-gv: #2DD4BF;
+  --scp-paa: #F59E0B;
+  --scp-aik: #06B6D4;
+  --scp-acs: #A855F7;
+  --scp-part: #64748B;
+  --scp-met: #22C55E;
+  --r-sm: 4px;
+  --r-md: 6px;
+  --r-pill: 20px;
+}
+
+html { scroll-behavior: smooth; }
+
+body {
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+.page-wrap { max-width: 900px; margin: 0 auto; padding: 0 20px 60px; }
+
+/* ── Page header ── */
+.page-header {
+  padding: 48px 0 36px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 40px;
+}
+.page-header h1 {
+  font-size: 28px; font-weight: 700; color: var(--text-primary);
+  letter-spacing: -0.02em; margin-bottom: 6px;
+}
+.page-subtitle { font-size: 15px; color: var(--text-secondary); margin-bottom: 18px; }
+.page-framework {
+  font-size: 13px; color: var(--text-secondary); line-height: 1.7;
+  max-width: 720px; margin-bottom: 20px;
+}
+.page-meta {
+  display: flex; gap: 20px; flex-wrap: wrap;
+  font-size: 12px; color: var(--text-muted); margin-bottom: 24px;
+}
+
+/* ── Dimension legend ── */
+.legend-heading {
+  font-size: 11px; font-weight: 700; color: var(--text-muted);
+  letter-spacing: 0.08em; text-transform: uppercase; margin-bottom: 10px;
+}
+.dim-legend {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 6px;
+}
+.legend-item {
+  display: flex; align-items: flex-start; gap: 7px;
+  font-size: 12px; line-height: 1.45; padding: 6px 8px;
+  background: rgba(30,41,59,0.5); border-radius: var(--r-sm);
+  border: 1px solid var(--border);
+}
+.legend-dot { width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0; margin-top: 3px; }
+.legend-key {
+  font-family: 'SF Mono','Fira Code',monospace; font-size: 10px;
+  color: var(--text-muted); flex-shrink: 0; min-width: 20px;
+}
+.legend-name { font-weight: 500; color: var(--text-secondary); flex-shrink: 0; min-width: 100px; }
+.legend-desc { color: var(--text-muted); font-size: 11px; }
+
+/* ── Designation groups ── */
+.desig-section { margin-bottom: 48px; }
+.desig-heading { display: flex; align-items: center; gap: 12px; margin-bottom: 18px; }
+.desig-heading h2 { font-size: 14px; font-weight: 700; letter-spacing: 0.01em; white-space: nowrap; }
+.desig-line { flex: 1; height: 1px; background: var(--border); }
+.desig-paa .desig-heading h2 { color: var(--scp-paa); }
+.desig-aik .desig-heading h2 { color: var(--scp-aik); }
+.desig-acs .desig-heading h2 { color: var(--scp-acs); }
+.desig-participant .desig-heading h2 { color: var(--scp-part); }
+
+/* ── Actor cards ── */
+.actor-card {
+  background: var(--bg-card); border: 1px solid var(--border);
+  border-radius: var(--r-md); margin-bottom: 14px; overflow: hidden;
+}
+.actor-header {
+  padding: 14px 20px 12px; border-bottom: 1px solid var(--border);
+}
+.actor-title-row {
+  display: flex; align-items: center; justify-content: space-between;
+  flex-wrap: wrap; gap: 8px; margin-bottom: 10px;
+}
+.actor-name {
+  font-size: 17px; font-weight: 700; color: var(--text-primary);
+  display: flex; align-items: center; gap: 8px;
+}
+.actor-meta { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+.actor-score {
+  font-family: 'SF Mono','Fira Code',monospace; font-size: 13px;
+  font-weight: 700; color: var(--text-secondary);
+  background: rgba(255,255,255,0.05); padding: 2px 8px;
+  border-radius: var(--r-sm); border: 1px solid var(--border);
+}
+.actor-badge {
+  font-size: 11px; font-weight: 700; letter-spacing: 0.04em;
+  padding: 3px 10px; border-radius: var(--r-pill); border: 1px solid;
+}
+.badge-paa   { background: rgba(245,158,11,0.15); color: #F59E0B;   border-color: rgba(245,158,11,0.35); }
+.badge-aik   { background: rgba(6,182,212,0.12);  color: #22D3EE;   border-color: rgba(6,182,212,0.3); }
+.badge-acs   { background: rgba(168,85,247,0.12); color: #C084FC;   border-color: rgba(168,85,247,0.3); }
+.badge-participant { background: rgba(100,116,139,0.12); color: #64748B; border-color: rgba(100,116,139,0.25); }
+.sample-badge {
+  font-size: 10px; font-weight: 600;
+  background: rgba(255,215,0,0.1); color: #FFD700;
+  border: 1px solid rgba(255,215,0,0.25); padding: 1px 6px;
+  border-radius: 3px; letter-spacing: 0.03em;
+}
+
+/* ── Dimension bar ── */
+.dim-bar { display: flex; gap: 4px; align-items: center; }
+.dim-bar-dot {
+  width: 10px; height: 10px; border-radius: 50%; border: 1.5px solid;
+  flex-shrink: 0;
+}
+.dim-bar-dot.hw.met  { background: var(--scp-hw);  border-color: var(--scp-hw); }
+.dim-bar-dot.pl.met  { background: var(--scp-pl);  border-color: var(--scp-pl); }
+.dim-bar-dot.gv.met  { background: var(--scp-gv);  border-color: var(--scp-gv); }
+.dim-bar-dot.hw.nmet { background: transparent; border-color: rgba(96,165,250,0.3); }
+.dim-bar-dot.pl.nmet { background: transparent; border-color: rgba(167,139,250,0.3); }
+.dim-bar-dot.gv.nmet { background: transparent; border-color: rgba(45,212,191,0.3); }
+
+/* ── Actor body ── */
+.actor-body { padding: 0 20px 14px; }
+
+/* ── Dimensions list ── */
+.dimensions-list { list-style: none; }
+
+.dim-item { border-bottom: 1px solid rgba(255,255,255,0.04); padding: 9px 0; }
+.dim-item:last-of-type { border-bottom: none; }
+
+.dim-header {
+  display: flex; align-items: center; gap: 7px;
+  font-size: 13px; flex-wrap: wrap;
+}
+.dim-dot { width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }
+.dim-dot.hw     { background: rgba(96,165,250,0.3); }
+.dim-dot.pl     { background: rgba(167,139,250,0.3); }
+.dim-dot.gv     { background: rgba(45,212,191,0.3); }
+.dim-dot.hw.met { background: var(--scp-hw); }
+.dim-dot.pl.met { background: var(--scp-pl); }
+.dim-dot.gv.met { background: var(--scp-gv); }
+.dim-key {
+  font-family: 'SF Mono','Fira Code',monospace; font-size: 10px;
+  color: var(--text-muted); flex-shrink: 0; min-width: 20px;
+}
+.dim-name  { color: var(--text-secondary); flex: 1; }
+.dim-status { font-size: 11px; font-weight: 700; flex-shrink: 0; }
+.dim-met   { color: var(--scp-met); }
+.dim-nmet  { color: var(--text-muted); }
+
+.dim-qual-hl {
+  font-size: 12px; color: #CBD5E1; line-height: 1.55;
+  padding: 4px 0 2px 13px;
+}
+.dim-constraint {
+  font-size: 12px; color: var(--text-muted); line-height: 1.55;
+  padding: 4px 0 2px 13px; font-style: italic;
+}
+.constraint-label { font-style: normal; font-weight: 700; color: var(--text-secondary); }
+
+.dim-details-dd { padding: 2px 0 2px 13px; }
+details.dim-details summary {
+  font-size: 11px; color: var(--text-muted); cursor: pointer;
+  padding: 3px 0; display: inline-flex; align-items: center; gap: 5px;
+  list-style: none; -webkit-appearance: none; transition: color 0.15s;
+}
+details.dim-details summary::-webkit-details-marker { display: none; }
+details.dim-details summary::before { content: '▸'; font-size: 9px; }
+details.dim-details[open] summary::before { content: '▾'; }
+details.dim-details summary:hover { color: var(--text-secondary); }
+
+.dim-qual-block {
+  margin-top: 6px; padding: 10px 12px;
+  background: rgba(15,23,42,0.6); border-radius: var(--r-sm);
+  border: 1px solid var(--border);
+  font-size: 12px; color: var(--text-secondary); line-height: 1.65;
+}
+
+/* ── Sources ── */
+.src-block {
+  margin-top: 6px; padding: 10px 12px;
+  background: rgba(15,23,42,0.6); border-radius: var(--r-sm);
+  border: 1px solid var(--border);
+}
+.src-entry {
+  padding: 8px 0; border-bottom: 1px solid rgba(255,255,255,0.04);
+}
+.src-entry:last-child { border-bottom: none; padding-bottom: 0; }
+.src-meta {
+  display: flex; flex-wrap: wrap; align-items: center; gap: 8px; margin-bottom: 5px;
+}
+.src-type  { font-size: 10px; font-weight: 700; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.05em; }
+.src-grade { font-size: 10px; font-weight: 700; padding: 1px 7px; border-radius: 3px; }
+.src-pub   { font-size: 11px; color: var(--text-secondary); }
+.src-date  { font-size: 10px; color: var(--text-muted); }
+.src-fact  { font-size: 11px; color: var(--text-secondary); line-height: 1.55; margin-bottom: 5px; }
+.src-link  { font-size: 11px; color: var(--accent); }
+
+/* ── AIK chokepoint ── */
+.aik-profile {
+  margin-top: 12px; padding: 10px 12px;
+  background: rgba(6,182,212,0.06); border: 1px solid rgba(6,182,212,0.15);
+  border-radius: var(--r-sm);
+}
+.aik-label  {
+  font-size: 10px; font-weight: 700; color: #94A3B8;
+  letter-spacing: 0.07em; text-transform: uppercase; margin-bottom: 4px;
+}
+.aik-nature   { font-size: 13px; color: #CBD5E1; font-weight: 500; line-height: 1.45; }
+.aik-entities { font-size: 11px; color: var(--text-muted); font-style: italic; line-height: 1.55; margin-top: 3px; }
+
+/* ── Severance ── */
+.actor-severance {
+  font-size: 12px; color: var(--text-muted); margin-top: 12px;
+  padding-top: 10px; border-top: 1px solid rgba(255,255,255,0.04);
+  line-height: 1.55;
+}
+.sev-label  { font-weight: 700; color: var(--text-secondary); }
+.sev-pass   { color: var(--scp-met); font-weight: 700; }
+.sev-fail   { color: #F87171; font-weight: 700; }
+
+/* ── Dimension watch ── */
+.watch-section {
+  margin-top: 48px; padding-top: 32px; border-top: 1px solid var(--border);
+}
+.watch-section h2 {
+  font-size: 17px; font-weight: 700; color: var(--text-primary); margin-bottom: 8px;
+}
+.watch-desc { font-size: 13px; color: var(--text-muted); margin-bottom: 16px; }
+.table-wrap { overflow-x: auto; -webkit-overflow-scrolling: touch; }
+.watch-table { width: 100%; border-collapse: collapse; font-size: 12px; }
+.watch-table th {
+  text-align: left; font-size: 10px; font-weight: 700;
+  color: var(--text-muted); text-transform: uppercase;
+  letter-spacing: 0.06em; padding: 8px 12px;
+  border-bottom: 1px solid var(--border); white-space: nowrap;
+}
+.watch-table td {
+  padding: 10px 12px; border-bottom: 1px solid rgba(255,255,255,0.03);
+  vertical-align: top; color: var(--text-secondary); line-height: 1.5;
+}
+.watch-table tr:last-child td { border-bottom: none; }
+.watch-table tr:hover td { background: rgba(255,255,255,0.01); }
+.dim-ref {
+  font-family: 'SF Mono','Fira Code',monospace; font-size: 10px;
+  color: var(--text-muted);
+}
+.w-met  { color: var(--scp-met); font-weight: 700; }
+.w-nmet { color: var(--text-muted); }
+
+/* ── Footer ── */
+.page-footer {
+  margin-top: 56px; padding-top: 24px; border-top: 1px solid var(--border);
+  font-size: 12px; color: var(--text-muted); line-height: 1.8;
+}
+.footer-cta {
+  font-size: 13px; color: var(--text-secondary); margin-bottom: 14px;
+  padding: 10px 14px;
+  background: rgba(59,130,246,0.05); border: 1px solid rgba(59,130,246,0.15);
+  border-radius: var(--r-sm);
+}
+.footer-links { display: flex; flex-wrap: wrap; gap: 16px; margin-bottom: 12px; }
+.footer-links a { color: var(--accent); }
+.footer-copy { font-size: 11px; color: var(--text-muted); }
+
+/* ── Responsive ── */
+@media (max-width: 600px) {
+  .page-header h1 { font-size: 22px; }
+  .actor-title-row { flex-direction: column; align-items: flex-start; }
+  .dim-legend { grid-template-columns: 1fr; }
+  .page-meta { flex-direction: column; gap: 4px; }
+  .actor-name { font-size: 15px; }
+}
+@media (max-width: 375px) {
+  .page-wrap { padding: 0 12px 40px; }
+  .page-header { padding: 32px 0 24px; }
+}
+
+  </style>
+</head>
+<body>
+  <div class="page-wrap">
+    <header class="page-header">
+      <h1>Sovereign Capability Profiles</h1>
+      <p class="page-subtitle">Actor Designation Framework — 14 actors assessed</p>
+      <p class="page-framework">The Sovereign Capability Profile (SCP) framework assesses nation-state control of the AI infrastructure stack across seven dimensions: chip design, advanced fabrication, critical equipment, AI compute, frontier models, AI regulation, and sovereign investment. Actors are designated as Principal AI Actors (PAA), AI Infrastructure Keystones (AIK), Advanced Capability States (ACS), or Participants through a three-gate framework evaluating dimensional breadth, severance resilience, and platform sustainability.</p>
+      <div class="page-meta">
+        <span>Assessment date: 2026-05-06</span>
+        <span>Methodology: V1.4</span>
+        <span>Register: SCP-REG-009</span>
+      </div>
+      <p class="legend-heading">Dimensions</p>
+      <div class="dim-legend">
+<div class="legend-item">
+  <span class="legend-dot" style="background:var(--scp-hw);"></span>
+  <span class="legend-key">D1</span>
+  <span class="legend-name">AI Chip Design</span>
+  <span class="legend-desc">Designs and commercially sells training-class AI accelerators under domestic IP control.</span>
+</div>
+<div class="legend-item">
+  <span class="legend-dot" style="background:var(--scp-hw);"></span>
+  <span class="legend-key">D2</span>
+  <span class="legend-name">Advanced Fabrication</span>
+  <span class="legend-desc">Operates production-capable semiconductor fabrication at process nodes of 7nm or below.</span>
+</div>
+<div class="legend-item">
+  <span class="legend-dot" style="background:var(--scp-hw);"></span>
+  <span class="legend-key">D3</span>
+  <span class="legend-name">Critical Equipment</span>
+  <span class="legend-desc">Hosts entities that design and manufacture globally essential semiconductor production equipment or sole-sourced subsystems for advanced fabrication.</span>
+</div>
+<div class="legend-item">
+  <span class="legend-dot" style="background:var(--scp-pl);"></span>
+  <span class="legend-key">D4</span>
+  <span class="legend-name">AI Compute</span>
+  <span class="legend-desc">Hosts hyperscale cloud providers operating AI training infrastructure sufficient to train current-generation frontier models, with compute physically on the actor&#x27;s territory.</span>
+</div>
+<div class="legend-item">
+  <span class="legend-dot" style="background:var(--scp-pl);"></span>
+  <span class="legend-key">D5</span>
+  <span class="legend-name">Frontier Models</span>
+  <span class="legend-desc">Hosts organisations developing state-of-the-art foundation models competitive with the current global frontier across multiple capability domains.</span>
+</div>
+<div class="legend-item">
+  <span class="legend-dot" style="background:var(--scp-gv);"></span>
+  <span class="legend-key">D6</span>
+  <span class="legend-name">AI Regulation</span>
+  <span class="legend-desc">Enforces AI-relevant compliance frameworks with binding obligations for entities outside its own jurisdiction.</span>
+</div>
+<div class="legend-item">
+  <span class="legend-dot" style="background:var(--scp-gv);"></span>
+  <span class="legend-key">D7</span>
+  <span class="legend-name">Sovereign Investment</span>
+  <span class="legend-desc">Operates a national programme directing significant public capital toward AI compute, semiconductor fabrication, or AI-specific physical infrastructure at nationally transformative scale.</span>
+</div>
+</div>
+    </header>
+
+    <main>
+<section class="desig-section desig-paa">
+  <div class="desig-heading">
+    <h2>Principal AI Actors (2)</h2>
+    <div class="desig-line"></div>
+  </div>
+  <article id="us" class="actor-card">
+  <header class="actor-header">
+    <div class="actor-title-row">
+      <h3 class="actor-name"><span class="sample-badge">Sample</span> United States</h3>
+      <div class="actor-meta">
+        <span class="actor-score">7/7</span>
+        <span class="actor-badge badge-paa">PAA</span>
+      </div>
+    </div>
+    <div class="dim-bar"><span class="dim-bar-dot hw met" title="D1"></span><span class="dim-bar-dot hw met" title="D2"></span><span class="dim-bar-dot hw met" title="D3"></span><span class="dim-bar-dot pl met" title="D4"></span><span class="dim-bar-dot pl met" title="D5"></span><span class="dim-bar-dot gv met" title="D6"></span><span class="dim-bar-dot gv met" title="D7"></span></div>
+  </header>
+  <div class="actor-body">
+    <dl class="dimensions-list">
+<div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot hw met"></span>
+  <span class="dim-key">D1</span>
+  <span class="dim-name">AI Chip Design</span>
+  <span class="dim-status dim-met">Met</span>
+</dt>
+<dd class="dim-qual-hl">Three independent training-class accelerator programmes — NVIDIA Blackwell Ultra, AMD Instinct, Trainium — under US IP control</dd>
+<dd class="dim-details-dd">
+  <details class="dim-details">
+    <summary>Qualification</summary>
+    <div class="dim-qual-block">NVIDIA Data Centre compute revenue reached US$43.0 billion (Q3 FY2026, up 56%) with Blackwell Ultra as leading architecture. Amazon deployed 1.4 million Trainium chips; combined custom silicon revenue exceeds US$10 billion annually. AMD ships the Instinct MI series. No other jurisdiction hosts more than one competitive programme.</div>
+  </details>
+</dd>
+<dd class="dim-details-dd">
+  <details class="dim-details">
+    <summary>Sources</summary>
+    <div class="src-block"><div class="src-entry">
+  <div class="src-meta">
+    <span class="src-type">Primary</span>
+    <span class="src-grade" style="background:rgba(59,130,246,0.15);color:#3B82F6;border:1px solid rgba(59,130,246,0.35);">Grade 2</span>
+    <span class="src-pub">NVIDIA (SEC 10-Q Q3 FY2026)</span>
+    <span class="src-date">2025-Q3</span>
+  </div>
+  <p class="src-fact">Data Centre compute revenue $43.0 billion, up 56%. Blackwell Ultra leading architecture across all customer categories.</p>
+  <a href="https://investor.nvidia.com/files/doc_financials/2026/q3/13e6981b-95ed-4aac-a602-ebc5865d0590.pdf" class="src-link" target="_blank" rel="noopener noreferrer">View source →</a>
+</div><div class="src-entry">
+  <div class="src-meta">
+    <span class="src-type">Corroborating</span>
+    <span class="src-grade" style="background:rgba(59,130,246,0.15);color:#3B82F6;border:1px solid rgba(59,130,246,0.35);">Grade 2</span>
+    <span class="src-pub">Amazon (SEC 8-K FY2025 Q4)</span>
+    <span class="src-date">2025-Q4</span>
+  </div>
+  <p class="src-fact">Trainium fully subscribed with 1.4 million chips landed across all generations. Combined custom silicon annual revenue run rate over US$10 billion (Trainium, Graviton, Nitro).</p>
+  <a href="https://www.sec.gov/Archives/edgar/data/0001018724/000101872426000002/amzn-20251231xex991.htm" class="src-link" target="_blank" rel="noopener noreferrer">View source →</a>
+</div></div>
+  </details>
+</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot hw met"></span>
+  <span class="dim-key">D2</span>
+  <span class="dim-name">Advanced Fabrication</span>
+  <span class="dim-status dim-met">Met</span>
+</dt>
+<dd class="dim-qual-hl">Intel Fab 52 manufactures Intel 18A wafers and TSMC Arizona is in volume production, both operating on US territory</dd>
+<dd class="dim-details-dd">
+  <details class="dim-details">
+    <summary>Qualification</summary>
+    <div class="dim-qual-block">Intel&#x27;s Fab 52 is fully operational producing Intel 18A wafers — the most advanced logic process manufactured in the United States at time of assessment. TSMC&#x27;s Arizona facility entered volume production in late 2024. Both sites operate on US soil under territorial jurisdiction regardless of corporate parent.</div>
+  </details>
+</dd>
+<dd class="dim-details-dd">
+  <details class="dim-details">
+    <summary>Sources</summary>
+    <div class="src-block"><div class="src-entry">
+  <div class="src-meta">
+    <span class="src-type">Primary</span>
+    <span class="src-grade" style="background:rgba(59,130,246,0.15);color:#3B82F6;border:1px solid rgba(59,130,246,0.35);">Grade 2</span>
+    <span class="src-pub">Intel (SEC 8-K Q3 FY2025)</span>
+    <span class="src-date">2025-Q3</span>
+  </div>
+  <p class="src-fact">Fab 52 fully operational, manufacturing Intel 18A wafers — most advanced logic wafers produced in the United States at time of assessment.</p>
+  <a href="https://www.sec.gov/Archives/edgar/data/0000050863/000005086325000169/q325earningsrelease.htm" class="src-link" target="_blank" rel="noopener noreferrer">View source →</a>
+</div><div class="src-entry">
+  <div class="src-meta">
+    <span class="src-type">Corroborating</span>
+    <span class="src-grade" style="background:rgba(59,130,246,0.15);color:#3B82F6;border:1px solid rgba(59,130,246,0.35);">Grade 2</span>
+    <span class="src-pub">TSMC</span>
+    <span class="src-date">2025-03</span>
+  </div>
+  <p class="src-fact">TSMC Arizona site in volume production since late 2024.</p>
+  <a href="https://pr.tsmc.com/english/news/3210" class="src-link" target="_blank" rel="noopener noreferrer">View source →</a>
+</div></div>
+  </details>
+</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot hw met"></span>
+  <span class="dim-key">D3</span>
+  <span class="dim-name">Critical Equipment</span>
+  <span class="dim-status dim-met">Met</span>
+</dt>
+<dd class="dim-qual-hl">KLA holds 73.8% of the global metrology and inspection market, described as indispensable to advanced process control</dd>
+<dd class="dim-details-dd">
+  <details class="dim-details">
+    <summary>Qualification</summary>
+    <div class="dim-qual-block">KLA increased its metrology and inspection market share from 72.6% in 2024 to 73.8% in 2025. Applied Materials and Lam Research hold dominant positions in deposition and etch respectively. No advanced fabrication facility at any node operates without US-designed process control equipment.</div>
+  </details>
+</dd>
+<dd class="dim-details-dd">
+  <details class="dim-details">
+    <summary>Sources</summary>
+    <div class="src-block"><div class="src-entry">
+  <div class="src-meta">
+    <span class="src-type">Primary</span>
+    <span class="src-grade" style="background:rgba(100,116,139,0.15);color:#94A3B8;border:1px solid rgba(100,116,139,0.3);">Grade 3</span>
+    <span class="src-pub">247 Wall St citing SEMI</span>
+    <span class="src-date">2026-05</span>
+  </div>
+  <p class="src-fact">KLA increased metrology and inspection share from 72.6% in 2024 to 73.8% in 2025.</p>
+  <a href="https://247wallst.com/technology-3/2026/05/04/kla-is-gaining-share-as-ai-chip-complexity-drives-up-yield-costs/" class="src-link" target="_blank" rel="noopener noreferrer">View source →</a>
+</div><div class="src-entry">
+  <div class="src-meta">
+    <span class="src-type">Corroborating</span>
+    <span class="src-grade" style="background:rgba(59,130,246,0.15);color:#3B82F6;border:1px solid rgba(59,130,246,0.35);">Grade 2</span>
+    <span class="src-pub">KLA 2026 Investor Day</span>
+    <span class="src-date">2026-03</span>
+  </div>
+  <p class="src-fact">CEO: KLA is indispensable to advanced process control regardless of fab operator.</p>
+  <a href="https://ir.kla.com/news-events/press-releases/detail/512/kla-hosts-investor-day-announces-7-billion-share" class="src-link" target="_blank" rel="noopener noreferrer">View source →</a>
+</div></div>
+  </details>
+</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot pl met"></span>
+  <span class="dim-key">D4</span>
+  <span class="dim-name">AI Compute</span>
+  <span class="dim-status dim-met">Met</span>
+</dt>
+<dd class="dim-qual-hl">xAI Colossus comprises 100,000 GPUs expanded to 555,000 at 2 GW; multiple US hyperscalers train frontier models on US territory</dd>
+<dd class="dim-details-dd">
+  <details class="dim-details">
+    <summary>Qualification</summary>
+    <div class="dim-qual-block">xAI&#x27;s Colossus cluster operates 100,000 NVIDIA Hopper GPUs, built in 122 days, and expanded to 555,000 GPUs at 2 GW capacity. Anthropic, xAI, Google, and OpenAI all occupy the top tier on Arena Elo rankings. US territory hosts the largest concentration of frontier-class AI training infrastructure globally at time of assessment.</div>
+  </details>
+</dd>
+<dd class="dim-details-dd">
+  <details class="dim-details">
+    <summary>Sources</summary>
+    <div class="src-block"><div class="src-entry">
+  <div class="src-meta">
+    <span class="src-type">Primary</span>
+    <span class="src-grade" style="background:rgba(59,130,246,0.15);color:#3B82F6;border:1px solid rgba(59,130,246,0.35);">Grade 2</span>
+    <span class="src-pub">NVIDIA Newsroom (Colossus/Spectrum-X)</span>
+    <span class="src-date">2026-01</span>
+  </div>
+  <p class="src-fact">xAI Colossus: 100,000 NVIDIA Hopper GPUs, built in 122 days. Expanded to 555,000 GPUs at 2 GW.</p>
+  <a href="https://nvidianews.nvidia.com/news/spectrum-x-ethernet-networking-xai-colossus" class="src-link" target="_blank" rel="noopener noreferrer">View source →</a>
+</div><div class="src-entry">
+  <div class="src-meta">
+    <span class="src-type">Corroborating</span>
+    <span class="src-grade" style="background:rgba(100,116,139,0.15);color:#94A3B8;border:1px solid rgba(100,116,139,0.3);">Grade 3</span>
+    <span class="src-pub">Stanford HAI AI Index 2026</span>
+    <span class="src-date">2026</span>
+  </div>
+  <p class="src-fact">Anthropic, xAI, Google, OpenAI all occupy the top tier on Arena Elo.</p>
+  <a href="https://hai.stanford.edu/ai-index/2026-ai-index-report/technical-performance" class="src-link" target="_blank" rel="noopener noreferrer">View source →</a>
+</div></div>
+  </details>
+</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot pl met"></span>
+  <span class="dim-key">D5</span>
+  <span class="dim-name">Frontier Models</span>
+  <span class="dim-status dim-met">Met</span>
+</dt>
+<dd class="dim-qual-hl">Anthropic, OpenAI, Google, and xAI all occupy the top benchmark tier; no other jurisdiction hosts four frontier labs</dd>
+<dd class="dim-details-dd">
+  <details class="dim-details">
+    <summary>Qualification</summary>
+    <div class="dim-qual-block">Stanford HAI&#x27;s 2026 AI Index confirms Anthropic, xAI, Google, and OpenAI in the top Arena Elo tier. Frontier models gained 30 percentage points on Humanity&#x27;s Last Exam in a single year. Multiple US-headquartered organisations hold frontier positions across reasoning, coding, and knowledge benchmarks.</div>
+  </details>
+</dd>
+<dd class="dim-details-dd">
+  <details class="dim-details">
+    <summary>Sources</summary>
+    <div class="src-block"><div class="src-entry">
+  <div class="src-meta">
+    <span class="src-type">Primary</span>
+    <span class="src-grade" style="background:rgba(100,116,139,0.15);color:#94A3B8;border:1px solid rgba(100,116,139,0.3);">Grade 3</span>
+    <span class="src-pub">Stanford HAI AI Index 2026</span>
+    <span class="src-date">2026</span>
+  </div>
+  <p class="src-fact">Frontier models gained 30 percentage points in a single year on Humanity&#x27;s Last Exam.</p>
+  <a href="https://hai.stanford.edu/ai-index/2026-ai-index-report/technical-performance" class="src-link" target="_blank" rel="noopener noreferrer">View source →</a>
+</div><div class="src-entry">
+  <div class="src-meta">
+    <span class="src-type">Corroborating</span>
+    <span class="src-grade" style="background:rgba(100,116,139,0.15);color:#94A3B8;border:1px solid rgba(100,116,139,0.3);">Grade 3</span>
+    <span class="src-pub">Artificial Analysis / LMArena</span>
+    <span class="src-date">2026-05</span>
+  </div>
+  <p class="src-fact">Multiple US-headquartered models (Anthropic, OpenAI, Google, xAI) at global frontier across reasoning, coding, and knowledge benchmarks.</p>
+  <a href="https://artificialanalysis.ai" class="src-link" target="_blank" rel="noopener noreferrer">View source →</a>
+</div></div>
+  </details>
+</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot gv met"></span>
+  <span class="dim-key">D6</span>
+  <span class="dim-name">AI Regulation</span>
+  <span class="dim-status dim-met">Met</span>
+</dt>
+<dd class="dim-qual-hl">Export controls enforced extraterritorially — Operation Gatekeeper prosecuted US$160 million GPU smuggling conspiracy</dd>
+<dd class="dim-details-dd">
+  <details class="dim-details">
+    <summary>Qualification</summary>
+    <div class="dim-qual-block">The Department of Justice prosecuted conspiracy to export at least US$160 million in controlled GPUs destined for China. Operation Gatekeeper seized over US$50 million in NVIDIA H100 and H200 GPUs and obtained guilty pleas, demonstrating active extraterritorial enforcement of AI-relevant export control instruments.</div>
+  </details>
+</dd>
+<dd class="dim-details-dd">
+  <details class="dim-details">
+    <summary>Sources</summary>
+    <div class="src-block"><div class="src-entry">
+  <div class="src-meta">
+    <span class="src-type">Primary</span>
+    <span class="src-grade" style="background:rgba(245,158,11,0.15);color:#F59E0B;border:1px solid rgba(245,158,11,0.35);">Grade 1</span>
+    <span class="src-pub">US Department of Justice</span>
+    <span class="src-date">2025-11</span>
+  </div>
+  <p class="src-fact">Prosecution for conspiracy to violate export controls by illegally exporting advanced GPUs to the PRC.</p>
+  <a href="https://www.justice.gov/opa/pr/us-citizens-and-chinese-nationals-arrested-exporting-artificial-intelligence-technology" class="src-link" target="_blank" rel="noopener noreferrer">View source →</a>
+</div><div class="src-entry">
+  <div class="src-meta">
+    <span class="src-type">Corroborating</span>
+    <span class="src-grade" style="background:rgba(245,158,11,0.15);color:#F59E0B;border:1px solid rgba(245,158,11,0.35);">Grade 1</span>
+    <span class="src-pub">US Department of Justice (Operation Gatekeeper)</span>
+    <span class="src-date">2025-12</span>
+  </div>
+  <p class="src-fact">Conspiracy to export at least US$160 million in export-controlled NVIDIA H100 and H200 GPUs. Over US$50 million seized. Guilty pleas obtained.</p>
+  <a href="https://www.justice.gov/opa/pr/us-authorities-shut-down-major-china-linked-ai-tech-smuggling-network" class="src-link" target="_blank" rel="noopener noreferrer">View source →</a>
+</div></div>
+  </details>
+</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot gv met"></span>
+  <span class="dim-key">D7</span>
+  <span class="dim-name">Sovereign Investment</span>
+  <span class="dim-status dim-met">Met</span>
+</dt>
+<dd class="dim-qual-hl">CHIPS for America awarded over US$33 billion in fabrication incentives; Intel alone received US$5.7 billion</dd>
+<dd class="dim-details-dd">
+  <details class="dim-details">
+    <summary>Qualification</summary>
+    <div class="dim-qual-block">The CHIPS for America programme awarded over US$33 billion of the US$36 billion in proposed incentives, directed at semiconductor fabrication on US territory. Intel received US$5.695 billion in CHIPS incentives and issued equity instruments. The programme is the largest single sovereign investment in domestic semiconductor manufacturing at time of assessment.</div>
+  </details>
+</dd>
+<dd class="dim-details-dd">
+  <details class="dim-details">
+    <summary>Sources</summary>
+    <div class="src-block"><div class="src-entry">
+  <div class="src-meta">
+    <span class="src-type">Primary</span>
+    <span class="src-grade" style="background:rgba(245,158,11,0.15);color:#F59E0B;border:1px solid rgba(245,158,11,0.35);">Grade 1</span>
+    <span class="src-pub">US Department of Commerce (CHIPS for America)</span>
+    <span class="src-date">2025-01</span>
+  </div>
+  <p class="src-fact">CHIPS for America awarded over $33 billion of the over $36 billion in proposed incentives funding.</p>
+  <a href="https://www.commerce.gov/news/press-releases/2025/01/us-department-commerce-announces-chips-incentives-awards-corning" class="src-link" target="_blank" rel="noopener noreferrer">View source →</a>
+</div><div class="src-entry">
+  <div class="src-meta">
+    <span class="src-type">Corroborating</span>
+    <span class="src-grade" style="background:rgba(59,130,246,0.15);color:#3B82F6;border:1px solid rgba(59,130,246,0.35);">Grade 2</span>
+    <span class="src-pub">Intel (SEC 8-K)</span>
+    <span class="src-date">2025-08-27</span>
+  </div>
+  <p class="src-fact">Intel received $5.695 billion in CHIPS incentives; issued 274.6M shares of common stock and a warrant.</p>
+  <a href="https://www.sec.gov/Archives/edgar/data/0000050863/000005086325000135/intc-20250827.htm" class="src-link" target="_blank" rel="noopener noreferrer">View source →</a>
+</div></div>
+  </details>
+</dd>
+</div>
+    </dl>
+    
+    <div class="actor-severance"><span class="sev-label">Severance:</span> <span class="sev-pass">PASS</span> — All 7 dimensions sustainable under severance. Full-stack ecosystem anchor.</div>
+  </div>
+</article><article id="cn" class="actor-card">
+  <header class="actor-header">
+    <div class="actor-title-row">
+      <h3 class="actor-name">China</h3>
+      <div class="actor-meta">
+        <span class="actor-score">6/7</span>
+        <span class="actor-badge badge-paa">PAA</span>
+      </div>
+    </div>
+    <div class="dim-bar"><span class="dim-bar-dot hw met" title="D1"></span><span class="dim-bar-dot hw met" title="D2"></span><span class="dim-bar-dot hw nmet" title="D3"></span><span class="dim-bar-dot pl met" title="D4"></span><span class="dim-bar-dot pl met" title="D5"></span><span class="dim-bar-dot gv met" title="D6"></span><span class="dim-bar-dot gv met" title="D7"></span></div>
+  </header>
+  <div class="actor-body">
+    <dl class="dimensions-list">
+<div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot hw met"></span>
+  <span class="dim-key">D1</span>
+  <span class="dim-name">AI Chip Design</span>
+  <span class="dim-status dim-met">Met</span>
+</dt>
+<dd class="dim-qual-hl">Huawei&#x27;s Ascend 910B/910C uses the domestically designed DaVinci architecture with confirmed commercial hyperscale deployment</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot hw met"></span>
+  <span class="dim-key">D2</span>
+  <span class="dim-name">Advanced Fabrication</span>
+  <span class="dim-status dim-met">Met</span>
+</dt>
+<dd class="dim-qual-hl">SMIC produces 7nm-class wafers using multi-patterning DUV lithography; DUV-only fabrication with no EUV access</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot hw"></span>
+  <span class="dim-key">D3</span>
+  <span class="dim-name">Critical Equipment</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> No Chinese tool globally non-substitutable at ≤7nm; all functions replaceable by US/Japan/Netherlands alternatives</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot pl met"></span>
+  <span class="dim-key">D4</span>
+  <span class="dim-name">AI Compute</span>
+  <span class="dim-status dim-met">Met</span>
+</dt>
+<dd class="dim-qual-hl">Frontier training on Chinese territory via Ascend clusters and pre-restriction NVIDIA H800; Ascend performance gap persists</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot pl met"></span>
+  <span class="dim-key">D5</span>
+  <span class="dim-name">Frontier Models</span>
+  <span class="dim-status dim-met">Met</span>
+</dt>
+<dd class="dim-qual-hl">Alibaba and DeepSeek place in the top Arena Elo tier alongside US frontier labs across multiple capability domains</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot gv met"></span>
+  <span class="dim-key">D6</span>
+  <span class="dim-name">AI Regulation</span>
+  <span class="dim-status dim-met">Met</span>
+</dt>
+<dd class="dim-qual-hl">Article 49 extends jurisdiction to transfers outside China; REE extraterritorial controls exercised then suspended</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot gv met"></span>
+  <span class="dim-key">D7</span>
+  <span class="dim-name">Sovereign Investment</span>
+  <span class="dim-status dim-met">Met</span>
+</dt>
+<dd class="dim-qual-hl">Big Fund III raised RMB 344 billion (US$47.5 billion) from 19 state-backed investors for semiconductor development</dd>
+</div>
+    </dl>
+    
+    <div class="actor-severance"><span class="sev-label">Severance:</span> <span class="sev-pass">PASS</span></div>
+  </div>
+</article>
+</section>
+<section class="desig-section desig-aik">
+  <div class="desig-heading">
+    <h2>AI Infrastructure Keystones (3)</h2>
+    <div class="desig-line"></div>
+  </div>
+  <article id="jp" class="actor-card">
+  <header class="actor-header">
+    <div class="actor-title-row">
+      <h3 class="actor-name">Japan</h3>
+      <div class="actor-meta">
+        <span class="actor-score">4/7</span>
+        <span class="actor-badge badge-aik">AIK</span>
+      </div>
+    </div>
+    <div class="dim-bar"><span class="dim-bar-dot hw nmet" title="D1"></span><span class="dim-bar-dot hw nmet" title="D2"></span><span class="dim-bar-dot hw met" title="D3"></span><span class="dim-bar-dot pl met" title="D4"></span><span class="dim-bar-dot pl nmet" title="D5"></span><span class="dim-bar-dot gv met" title="D6"></span><span class="dim-bar-dot gv met" title="D7"></span></div>
+  </header>
+  <div class="actor-body">
+    <dl class="dimensions-list">
+<div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot hw"></span>
+  <span class="dim-key">D1</span>
+  <span class="dim-name">AI Chip Design</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Only domestic training accelerator (PFN MN-Core 2) deployed in low thousands; Japan&#x27;s own flagship HPC selects NVIDIA for AI workloads</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot hw"></span>
+  <span class="dim-key">D2</span>
+  <span class="dim-name">Advanced Fabrication</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Zero ≤7nm fabs in volume manufacturing; Rapidus 2nm in pilot only, mass production targeted H2 FY2027</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot hw met"></span>
+  <span class="dim-key">D3</span>
+  <span class="dim-name">Critical Equipment</span>
+  <span class="dim-status dim-met">Met</span>
+</dt>
+<dd class="dim-qual-hl">TEL holds ~100% EUV coater/developer share and Lasertec sole-sources actinic mask inspection; US-dependency exposure documented</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot pl met"></span>
+  <span class="dim-key">D4</span>
+  <span class="dim-name">AI Compute</span>
+  <span class="dim-status dim-met">Met</span>
+</dt>
+<dd class="dim-qual-hl">SoftBank cluster delivers 13.7 ExaFLOPS on Japanese territory; domestically scaled but GPU procurement dependent on US ecosystem</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot pl"></span>
+  <span class="dim-key">D5</span>
+  <span class="dim-name">Frontier Models</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> No Japanese-developed model places in the global top tier on any canonical discriminating benchmark</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot gv met"></span>
+  <span class="dim-key">D6</span>
+  <span class="dim-name">AI Regulation</span>
+  <span class="dim-status dim-met">Met</span>
+</dt>
+<dd class="dim-qual-hl">FEFTA controls 23 types of advanced semiconductor manufacturing equipment; catch-all controls strengthened October 2025</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot gv met"></span>
+  <span class="dim-key">D7</span>
+  <span class="dim-name">Sovereign Investment</span>
+  <span class="dim-status dim-met">Met</span>
+</dt>
+<dd class="dim-qual-hl">AI budgeted support nearly quadrupled to approximately ¥1.23 trillion; Rapidus received ¥2.35 trillion in total state backing</dd>
+</div>
+    </dl>
+    <div class="aik-profile">
+  <div class="aik-label">Chokepoint Profile</div>
+  <div class="aik-nature">Front-end process tools and materials</div>
+  <div class="aik-entities">TEL coater/developer (~90–100% EUV), Lasertec actinic mask inspection (100%), SCREEN single-wafer cleans, Shin-Etsu/JSR/TOK/SUMCO materials</div>
+</div>
+    <div class="actor-severance"><span class="sev-label">Severance:</span> <span class="sev-pass">PASS</span></div>
+  </div>
+</article><article id="kr" class="actor-card">
+  <header class="actor-header">
+    <div class="actor-title-row">
+      <h3 class="actor-name">South Korea</h3>
+      <div class="actor-meta">
+        <span class="actor-score">4/7</span>
+        <span class="actor-badge badge-aik">AIK</span>
+      </div>
+    </div>
+    <div class="dim-bar"><span class="dim-bar-dot hw nmet" title="D1"></span><span class="dim-bar-dot hw met" title="D2"></span><span class="dim-bar-dot hw met" title="D3"></span><span class="dim-bar-dot pl nmet" title="D4"></span><span class="dim-bar-dot pl nmet" title="D5"></span><span class="dim-bar-dot gv met" title="D6"></span><span class="dim-bar-dot gv met" title="D7"></span></div>
+  </header>
+  <div class="actor-body">
+    <dl class="dimensions-list">
+<div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot hw"></span>
+  <span class="dim-key">D1</span>
+  <span class="dim-name">AI Chip Design</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> All shipping Korean-designed accelerators are inference-only; training compute runs on imported NVIDIA silicon</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot hw met"></span>
+  <span class="dim-key">D2</span>
+  <span class="dim-name">Advanced Fabrication</span>
+  <span class="dim-status dim-met">Met</span>
+</dt>
+<dd class="dim-qual-hl">Samsung Foundry produces at 3nm and commenced 2nm GAA mass production; fabrication dependent on imported ASML EUV equipment</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot hw met"></span>
+  <span class="dim-key">D3</span>
+  <span class="dim-name">Critical Equipment</span>
+  <span class="dim-status dim-met">Met</span>
+</dt>
+<dd class="dim-qual-hl">HPSP is sole-source for high-pressure annealing and Hanmi holds 71.2% TC bonder share; FDPR and BIS exposure documented</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot pl"></span>
+  <span class="dim-key">D4</span>
+  <span class="dim-name">AI Compute</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Largest coherent Korean-owned training cluster is ~4,000 GPUs; major facilities are US-hyperscaler-anchored</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot pl"></span>
+  <span class="dim-key">D5</span>
+  <span class="dim-name">Frontier Models</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Best Korean models score ~25-30 points below frontier flagships on aggregated capability leaderboards</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot gv met"></span>
+  <span class="dim-key">D6</span>
+  <span class="dim-name">AI Regulation</span>
+  <span class="dim-status dim-met">Met</span>
+</dt>
+<dd class="dim-qual-hl">AI Basic Act (Law 20676) Article 4(1) applies to acts conducted abroad affecting the Korean domestic market or users</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot gv met"></span>
+  <span class="dim-key">D7</span>
+  <span class="dim-name">Sovereign Investment</span>
+  <span class="dim-status dim-met">Met</span>
+</dt>
+<dd class="dim-qual-hl">KRW 10.1 trillion allocated in the 2026 AI budget; AI Growth Fund expanded to over KRW 150 trillion</dd>
+</div>
+    </dl>
+    <div class="aik-profile">
+  <div class="aik-label">Chokepoint Profile</div>
+  <div class="aik-nature">Memory packaging, fabrication, and sovereign equipment monopolies</div>
+  <div class="aik-entities">HPSP sole-source high-pressure annealing, Hanmi 71.2% TC bonder share, Samsung Foundry 2nm GAA HVM</div>
+</div>
+    <div class="actor-severance"><span class="sev-label">Severance:</span> <span class="sev-pass">PASS</span></div>
+  </div>
+</article><article id="nl" class="actor-card">
+  <header class="actor-header">
+    <div class="actor-title-row">
+      <h3 class="actor-name">Netherlands</h3>
+      <div class="actor-meta">
+        <span class="actor-score">3/7</span>
+        <span class="actor-badge badge-aik">AIK</span>
+      </div>
+    </div>
+    <div class="dim-bar"><span class="dim-bar-dot hw nmet" title="D1"></span><span class="dim-bar-dot hw nmet" title="D2"></span><span class="dim-bar-dot hw met" title="D3"></span><span class="dim-bar-dot pl nmet" title="D4"></span><span class="dim-bar-dot pl nmet" title="D5"></span><span class="dim-bar-dot gv met" title="D6"></span><span class="dim-bar-dot gv met" title="D7"></span></div>
+  </header>
+  <div class="actor-body">
+    <dl class="dimensions-list">
+<div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot hw"></span>
+  <span class="dim-key">D1</span>
+  <span class="dim-name">AI Chip Design</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Dutch chip designers (NXP, Axelera) produce inference/edge silicon only; no training-class accelerator exists</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot hw"></span>
+  <span class="dim-key">D2</span>
+  <span class="dim-name">Advanced Fabrication</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> No ≤7nm fab on Dutch territory; NXP Nijmegen operates at 200mm (~140nm), slated for closure</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot hw met"></span>
+  <span class="dim-key">D3</span>
+  <span class="dim-name">Critical Equipment</span>
+  <span class="dim-status dim-met">Met</span>
+</dt>
+<dd class="dim-qual-hl">ASML holds 100% EUV monopoly and Besi leads hybrid bonding from Dutch territory; Cymer and multiple US leverage vectors documented</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot pl"></span>
+  <span class="dim-key">D4</span>
+  <span class="dim-name">AI Compute</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Nebius Group N.V. Dutch-domiciled; zero qualifying compute on Dutch territory (all operational in Finland)</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot pl"></span>
+  <span class="dim-key">D5</span>
+  <span class="dim-name">Frontier Models</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> GPT-NL targets Dutch-language sovereignty at ~1/100th frontier budget; no Dutch model ranks on global benchmarks</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot gv met"></span>
+  <span class="dim-key">D6</span>
+  <span class="dim-name">AI Regulation</span>
+  <span class="dim-status dim-met">Met</span>
+</dt>
+<dd class="dim-qual-hl">Strategic Goods Decree expanded semiconductor equipment export controls with national authorisation requirements</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot gv met"></span>
+  <span class="dim-key">D7</span>
+  <span class="dim-name">Sovereign Investment</span>
+  <span class="dim-status dim-met">Met</span>
+</dt>
+<dd class="dim-qual-hl">Project Beethoven committed €2.51 billion to the Brainport Eindhoven chip ecosystem; AI Factory received €200 million</dd>
+</div>
+    </dl>
+    <div class="aik-profile">
+  <div class="aik-label">Chokepoint Profile</div>
+  <div class="aik-nature">Core lithography integration and advanced packaging</div>
+  <div class="aik-entities">ASML 100% EUV monopoly, ASM International (ALD/epi), Besi (hybrid bonding)</div>
+</div>
+    <div class="actor-severance"><span class="sev-label">Severance:</span> <span class="sev-pass">PASS</span></div>
+  </div>
+</article>
+</section>
+<section class="desig-section desig-acs">
+  <div class="desig-heading">
+    <h2>Advanced Capability States (2)</h2>
+    <div class="desig-line"></div>
+  </div>
+  <article id="eu" class="actor-card">
+  <header class="actor-header">
+    <div class="actor-title-row">
+      <h3 class="actor-name">European Union</h3>
+      <div class="actor-meta">
+        <span class="actor-score">4/7</span>
+        <span class="actor-badge badge-acs">ACS</span>
+      </div>
+    </div>
+    <div class="dim-bar"><span class="dim-bar-dot hw nmet" title="D1"></span><span class="dim-bar-dot hw met" title="D2"></span><span class="dim-bar-dot hw met" title="D3"></span><span class="dim-bar-dot pl nmet" title="D4"></span><span class="dim-bar-dot pl nmet" title="D5"></span><span class="dim-bar-dot gv met" title="D6"></span><span class="dim-bar-dot gv met" title="D7"></span></div>
+  </header>
+  <div class="actor-body">
+    <dl class="dimensions-list">
+<div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot hw"></span>
+  <span class="dim-key">D1</span>
+  <span class="dim-name">AI Chip Design</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> No EU entity designs a datacenter training accelerator; closest candidate (SiPearl Rhea1) is an HPC CPU for inference</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot hw met"></span>
+  <span class="dim-key">D2</span>
+  <span class="dim-name">Advanced Fabrication</span>
+  <span class="dim-status dim-met">Met</span>
+</dt>
+<dd class="dim-qual-hl">Intel Fab 34 in Ireland is the first European facility using EUV in volume production; the facility is US-owned</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot hw met"></span>
+  <span class="dim-key">D3</span>
+  <span class="dim-name">Critical Equipment</span>
+  <span class="dim-status dim-met">Met</span>
+</dt>
+<dd class="dim-qual-hl">ASML shipped 44 EUV systems as sole global supplier; Zeiss holds 100% EUV optics share — Cymer light source under US jurisdiction</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot pl"></span>
+  <span class="dim-key">D4</span>
+  <span class="dim-name">AI Compute</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Largest EU-controlled coherent training cluster is ~1,016 H100s; frontier training requires 50,000-200,000+</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot pl"></span>
+  <span class="dim-key">D5</span>
+  <span class="dim-name">Frontier Models</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Mistral&#x27;s best model scores 39/100 on composite intelligence index; frontier models score 57-61</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot gv met"></span>
+  <span class="dim-key">D6</span>
+  <span class="dim-name">AI Regulation</span>
+  <span class="dim-status dim-met">Met</span>
+</dt>
+<dd class="dim-qual-hl">EU AI Act Article 2(1)(c) applies to providers placing AI systems on the EU market regardless of establishment location</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot gv met"></span>
+  <span class="dim-key">D7</span>
+  <span class="dim-name">Sovereign Investment</span>
+  <span class="dim-status dim-met">Met</span>
+</dt>
+<dd class="dim-qual-hl">EuroHPC mandate expanded with AI Gigafactories programme; JUPITER operational at exascale, LUMI at pre-exascale</dd>
+</div>
+    </dl>
+    
+    <div class="actor-severance"><span class="sev-label">Severance:</span> <span class="sev-fail">FAIL</span></div>
+  </div>
+</article><article id="tw" class="actor-card">
+  <header class="actor-header">
+    <div class="actor-title-row">
+      <h3 class="actor-name">Taiwan</h3>
+      <div class="actor-meta">
+        <span class="actor-score">3/7</span>
+        <span class="actor-badge badge-acs">ACS</span>
+      </div>
+    </div>
+    <div class="dim-bar"><span class="dim-bar-dot hw nmet" title="D1"></span><span class="dim-bar-dot hw met" title="D2"></span><span class="dim-bar-dot hw met" title="D3"></span><span class="dim-bar-dot pl nmet" title="D4"></span><span class="dim-bar-dot pl nmet" title="D5"></span><span class="dim-bar-dot gv nmet" title="D6"></span><span class="dim-bar-dot gv met" title="D7"></span></div>
+  </header>
+  <div class="actor-body">
+    <dl class="dimensions-list">
+<div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot hw"></span>
+  <span class="dim-key">D1</span>
+  <span class="dim-name">AI Chip Design</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Taiwan&#x27;s ASIC design firms execute foreign clients&#x27; architectures; core accelerator IP remains abroad</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot hw met"></span>
+  <span class="dim-key">D2</span>
+  <span class="dim-name">Advanced Fabrication</span>
+  <span class="dim-status dim-met">Met</span>
+</dt>
+<dd class="dim-qual-hl">TSMC operates 3nm volume production at Fab 18 with N2 GAA on roadmap; fabrication dependent on US-origin equipment and EDA tools</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot hw met"></span>
+  <span class="dim-key">D3</span>
+  <span class="dim-name">Critical Equipment</span>
+  <span class="dim-status dim-met">Met</span>
+</dt>
+<dd class="dim-qual-hl">Gudeng Precision holds approximately 80% of the global EUV photomask pod market and is sole supplier to TSMC</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot pl"></span>
+  <span class="dim-key">D4</span>
+  <span class="dim-name">AI Compute</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Aggregate national compute (~114 PFLOPS) is roughly two orders of magnitude below frontier-training scale</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot pl"></span>
+  <span class="dim-key">D5</span>
+  <span class="dim-name">Frontier Models</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> All domestic models are foreign-base fine-tunes; none rank on any global benchmark leaderboard</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot gv"></span>
+  <span class="dim-key">D6</span>
+  <span class="dim-name">AI Regulation</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Export controls bind domestic exporters only; AI Basic Act is soft law with no extraterritorial reach</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot gv met"></span>
+  <span class="dim-key">D7</span>
+  <span class="dim-name">Sovereign Investment</span>
+  <span class="dim-status dim-met">Met</span>
+</dt>
+<dd class="dim-qual-hl">NT$30–31.1 billion first-year AI strategy allocation under NSTC; FY2026 budget at legislative risk, compute procures NVIDIA GPUs</dd>
+</div>
+    </dl>
+    
+    <div class="actor-severance"><span class="sev-label">Severance:</span> <span class="sev-fail">FAIL</span></div>
+  </div>
+</article>
+</section>
+<section class="desig-section desig-participant">
+  <div class="desig-heading">
+    <h2>Participants (7)</h2>
+    <div class="desig-line"></div>
+  </div>
+  <article id="fr" class="actor-card">
+  <header class="actor-header">
+    <div class="actor-title-row">
+      <h3 class="actor-name">France</h3>
+      <div class="actor-meta">
+        <span class="actor-score">2/7</span>
+        <span class="actor-badge badge-participant">Participant</span>
+      </div>
+    </div>
+    <div class="dim-bar"><span class="dim-bar-dot hw nmet" title="D1"></span><span class="dim-bar-dot hw nmet" title="D2"></span><span class="dim-bar-dot hw nmet" title="D3"></span><span class="dim-bar-dot pl nmet" title="D4"></span><span class="dim-bar-dot pl nmet" title="D5"></span><span class="dim-bar-dot gv met" title="D6"></span><span class="dim-bar-dot gv met" title="D7"></span></div>
+  </header>
+  <div class="actor-body">
+    <dl class="dimensions-list">
+<div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot hw"></span>
+  <span class="dim-key">D1</span>
+  <span class="dim-name">AI Chip Design</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> All French AI chip designs use licensed ARM architecture; no sovereign training-class accelerator exists</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot hw"></span>
+  <span class="dim-key">D2</span>
+  <span class="dim-name">Advanced Fabrication</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Most advanced French volume node is 18nm FD-SOI; no FinFET or GAA fab exists at any node</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot hw"></span>
+  <span class="dim-key">D3</span>
+  <span class="dim-name">Critical Equipment</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Soitec&#x27;s SOI substrates serve 22-90nm nodes, not ≤7nm FinFET/GAA process flows</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot pl"></span>
+  <span class="dim-key">D4</span>
+  <span class="dim-name">AI Compute</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Largest sovereign cluster (Mistral Compute, ~13,800 GB300s) is commissioning, not operational</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot pl"></span>
+  <span class="dim-key">D5</span>
+  <span class="dim-name">Frontier Models</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Mistral scores ~35% below frontier on aggregate intelligence indices across key benchmarks</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot gv met"></span>
+  <span class="dim-key">D6</span>
+  <span class="dim-name">AI Regulation</span>
+  <span class="dim-status dim-met">Met</span>
+</dt>
+<dd class="dim-qual-hl">Exercises EU AI Act authority with demonstrated extraterritorial enforcement — CNIL fined Clearview AI €20 million</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot gv met"></span>
+  <span class="dim-key">D7</span>
+  <span class="dim-name">Sovereign Investment</span>
+  <span class="dim-status dim-met">Met</span>
+</dt>
+<dd class="dim-qual-hl">France 2030 provides a €54 billion investment envelope; national AI strategy spending totals €2.4 billion across two phases</dd>
+</div>
+    </dl>
+    
+    
+  </div>
+</article><article id="de" class="actor-card">
+  <header class="actor-header">
+    <div class="actor-title-row">
+      <h3 class="actor-name">Germany</h3>
+      <div class="actor-meta">
+        <span class="actor-score">2/7</span>
+        <span class="actor-badge badge-participant">Participant</span>
+      </div>
+    </div>
+    <div class="dim-bar"><span class="dim-bar-dot hw nmet" title="D1"></span><span class="dim-bar-dot hw nmet" title="D2"></span><span class="dim-bar-dot hw met" title="D3"></span><span class="dim-bar-dot pl nmet" title="D4"></span><span class="dim-bar-dot pl nmet" title="D5"></span><span class="dim-bar-dot gv met" title="D6"></span><span class="dim-bar-dot gv nmet" title="D7"></span></div>
+  </header>
+  <div class="actor-body">
+    <dl class="dimensions-list">
+<div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot hw"></span>
+  <span class="dim-key">D1</span>
+  <span class="dim-name">AI Chip Design</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> No German entity designs or markets a datacenter AI training accelerator; full NVIDIA dependency for all sovereign compute</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot hw"></span>
+  <span class="dim-key">D2</span>
+  <span class="dim-name">Advanced Fabrication</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> No fab on German territory produces at ≤7nm; Intel Magdeburg cancelled, ESMC Dresden targets ≥12nm only</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot hw met"></span>
+  <span class="dim-key">D3</span>
+  <span class="dim-name">Critical Equipment</span>
+  <span class="dim-status dim-met">Met</span>
+</dt>
+<dd class="dim-qual-hl">Zeiss holds 100% EUV optics share and TRUMPF sole-sources EUV drive lasers; leverage operates through ASML, not independently</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot pl"></span>
+  <span class="dim-key">D4</span>
+  <span class="dim-name">AI Compute</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Largest German-controlled AI cluster (~10,000 GPUs / 0.5 ExaFLOPS) is ~1/10th frontier training scale</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot pl"></span>
+  <span class="dim-key">D5</span>
+  <span class="dim-name">Frontier Models</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> No German-controlled entity produces a top-tier foundation model; Aleph Alpha absorbed by Canadian Cohere (90/10 split)</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot gv met"></span>
+  <span class="dim-key">D6</span>
+  <span class="dim-name">AI Regulation</span>
+  <span class="dim-status dim-met">Met</span>
+</dt>
+<dd class="dim-qual-hl">21st AWV amendment added AI systems and semiconductor technology to the national export control list in July 2024</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot gv"></span>
+  <span class="dim-key">D7</span>
+  <span class="dim-name">Sovereign Investment</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> JUPITER is genuine (~€250M national share) but not &#x27;at scale&#x27;; collapsed Intel subsidy and foreign-controlled ESMC subsidy cannot be credited</dd>
+</div>
+    </dl>
+    
+    
+  </div>
+</article><article id="gb" class="actor-card">
+  <header class="actor-header">
+    <div class="actor-title-row">
+      <h3 class="actor-name">United Kingdom</h3>
+      <div class="actor-meta">
+        <span class="actor-score">1/7</span>
+        <span class="actor-badge badge-participant">Participant</span>
+      </div>
+    </div>
+    <div class="dim-bar"><span class="dim-bar-dot hw nmet" title="D1"></span><span class="dim-bar-dot hw nmet" title="D2"></span><span class="dim-bar-dot hw nmet" title="D3"></span><span class="dim-bar-dot pl nmet" title="D4"></span><span class="dim-bar-dot pl nmet" title="D5"></span><span class="dim-bar-dot gv nmet" title="D6"></span><span class="dim-bar-dot gv met" title="D7"></span></div>
+  </header>
+  <div class="actor-body">
+    <dl class="dimensions-list">
+<div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot hw"></span>
+  <span class="dim-key">D1</span>
+  <span class="dim-name">AI Chip Design</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Sole UK AI accelerator designer (Graphcore) acquired by SoftBank July 2024; no IP-transfer restrictions imposed</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot hw"></span>
+  <span class="dim-key">D2</span>
+  <span class="dim-name">Advanced Fabrication</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> No UK fab operates at or below 7nm; domestic capacity limited to mature and compound semiconductor nodes</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot hw"></span>
+  <span class="dim-key">D3</span>
+  <span class="dim-name">Critical Equipment</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> UK equipment firms serve advanced fabs but none is sole-sourced for ≤7nm lithographic fabrication</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot pl"></span>
+  <span class="dim-key">D4</span>
+  <span class="dim-name">AI Compute</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> No UK-HQ provider operates frontier-training-class compute on UK soil at assessment date; Nscale flagship facility scheduled Q4 2026-Q1 2027</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot pl"></span>
+  <span class="dim-key">D5</span>
+  <span class="dim-name">Frontier Models</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> DeepMind IP owned by Alphabet (US); no independent UK lab ranks top-tier across broad reasoning benchmarks</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot gv"></span>
+  <span class="dim-key">D6</span>
+  <span class="dim-name">AI Regulation</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> No AI-specific binding framework enacted; AISI evaluations voluntary; anticipated UK AI bill did not materialise</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot gv met"></span>
+  <span class="dim-key">D7</span>
+  <span class="dim-name">Sovereign Investment</span>
+  <span class="dim-status dim-met">Met</span>
+</dt>
+<dd class="dim-qual-hl">UK Compute Roadmap commits up to £2 billion for public AI compute infrastructure, confirmed by Parliament</dd>
+</div>
+    </dl>
+    
+    
+  </div>
+</article><article id="in" class="actor-card">
+  <header class="actor-header">
+    <div class="actor-title-row">
+      <h3 class="actor-name">India</h3>
+      <div class="actor-meta">
+        <span class="actor-score">1/7</span>
+        <span class="actor-badge badge-participant">Participant</span>
+      </div>
+    </div>
+    <div class="dim-bar"><span class="dim-bar-dot hw nmet" title="D1"></span><span class="dim-bar-dot hw nmet" title="D2"></span><span class="dim-bar-dot hw nmet" title="D3"></span><span class="dim-bar-dot pl nmet" title="D4"></span><span class="dim-bar-dot pl nmet" title="D5"></span><span class="dim-bar-dot gv nmet" title="D6"></span><span class="dim-bar-dot gv met" title="D7"></span></div>
+  </header>
+  <div class="actor-body">
+    <dl class="dimensions-list">
+<div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot hw"></span>
+  <span class="dim-key">D1</span>
+  <span class="dim-name">AI Chip Design</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> No commercially marketed datacenter AI training accelerator with domestically controlled core microarchitectural IP</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot hw"></span>
+  <span class="dim-key">D2</span>
+  <span class="dim-name">Advanced Fabrication</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> No ≤7nm wafer fab on Indian territory; most advanced approved project (Tata Dholera) targets 28nm-110nm</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot hw"></span>
+  <span class="dim-key">D3</span>
+  <span class="dim-name">Critical Equipment</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> No Indian sole-source position in the ≤7nm semiconductor equipment supply chain</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot pl"></span>
+  <span class="dim-key">D4</span>
+  <span class="dim-name">AI Compute</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Largest sovereign compute allocation (4,096 H100s, IndiaAI Mission) empirically exercised; produced sub-frontier result</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot pl"></span>
+  <span class="dim-key">D5</span>
+  <span class="dim-name">Frontier Models</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Sole candidate (Sarvam-105B) trails absolute May 2026 frontier; independent evaluation limited</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot gv"></span>
+  <span class="dim-key">D6</span>
+  <span class="dim-name">AI Regulation</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> No AI-specific statute in force; DPDPA core obligations delayed to May 2027; IT Rules 2026 limited to content moderation</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot gv met"></span>
+  <span class="dim-key">D7</span>
+  <span class="dim-name">Sovereign Investment</span>
+  <span class="dim-status dim-met">Met</span>
+</dt>
+<dd class="dim-qual-hl">IndiaAI Mission budgets Rs 10,372 crore across seven pillars with a 10,000 GPU target; compute runs on US ecosystem infrastructure</dd>
+</div>
+    </dl>
+    
+    
+  </div>
+</article><article id="il" class="actor-card">
+  <header class="actor-header">
+    <div class="actor-title-row">
+      <h3 class="actor-name">Israel</h3>
+      <div class="actor-meta">
+        <span class="actor-score">1/7</span>
+        <span class="actor-badge badge-participant">Participant</span>
+      </div>
+    </div>
+    <div class="dim-bar"><span class="dim-bar-dot hw nmet" title="D1"></span><span class="dim-bar-dot hw nmet" title="D2"></span><span class="dim-bar-dot hw met" title="D3"></span><span class="dim-bar-dot pl nmet" title="D4"></span><span class="dim-bar-dot pl nmet" title="D5"></span><span class="dim-bar-dot gv nmet" title="D6"></span><span class="dim-bar-dot gv nmet" title="D7"></span></div>
+  </header>
+  <div class="actor-body">
+    <dl class="dimensions-list">
+<div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot hw"></span>
+  <span class="dim-key">D1</span>
+  <span class="dim-name">AI Chip Design</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Habana Labs/Gaudi IP wholly owned by Intel US; no independent Israeli training-class accelerator programme remains</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot hw"></span>
+  <span class="dim-key">D2</span>
+  <span class="dim-name">Advanced Fabrication</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Fab 28 runs Intel 7 (10nm-class DUV, no EUV); Fab 38 frozen since mid-2024 with no restart date</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot hw met"></span>
+  <span class="dim-key">D3</span>
+  <span class="dim-name">Critical Equipment</span>
+  <span class="dim-status dim-met">Met</span>
+</dt>
+<dd class="dim-qual-hl">Nova holds sole-source metrology and Camtek is tool of reference for HBM4; limited to inspection, US-parented entities excluded</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot pl"></span>
+  <span class="dim-key">D4</span>
+  <span class="dim-name">AI Compute</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Largest Israeli-controlled GPU clusters are an order of magnitude below frontier training scale</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot pl"></span>
+  <span class="dim-key">D5</span>
+  <span class="dim-name">Frontier Models</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> AI21 Jamba scores 40-50 percentage points behind frontier benchmarks; company has pivoted away from scale competition</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot gv"></span>
+  <span class="dim-key">D6</span>
+  <span class="dim-name">AI Regulation</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> No enacted AI-specific law with extraterritorial reach; existing controls are privacy-based or dual-use export</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot gv"></span>
+  <span class="dim-key">D7</span>
+  <span class="dim-name">Sovereign Investment</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> ~$140M deployed AI-specific capital over six years; two orders of magnitude below $1B-$10B+ peer programmes</dd>
+</div>
+    </dl>
+    
+    
+  </div>
+</article><article id="ru" class="actor-card">
+  <header class="actor-header">
+    <div class="actor-title-row">
+      <h3 class="actor-name">Russia</h3>
+      <div class="actor-meta">
+        <span class="actor-score">0/7</span>
+        <span class="actor-badge badge-participant">Participant</span>
+      </div>
+    </div>
+    <div class="dim-bar"><span class="dim-bar-dot hw nmet" title="D1"></span><span class="dim-bar-dot hw nmet" title="D2"></span><span class="dim-bar-dot hw nmet" title="D3"></span><span class="dim-bar-dot pl nmet" title="D4"></span><span class="dim-bar-dot pl nmet" title="D5"></span><span class="dim-bar-dot gv nmet" title="D6"></span><span class="dim-bar-dot gv nmet" title="D7"></span></div>
+  </header>
+  <div class="actor-body">
+    <dl class="dimensions-list">
+<div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot hw"></span>
+  <span class="dim-key">D1</span>
+  <span class="dim-name">AI Chip Design</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> No domestically designed training-class accelerator in production; ARM/MIPS licenses revoked, foundry access severed</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot hw"></span>
+  <span class="dim-key">D2</span>
+  <span class="dim-name">Advanced Fabrication</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Most advanced operational node is 90nm at Mikron; state roadmap targets 28nm no earlier than 2028-2030</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot hw"></span>
+  <span class="dim-key">D3</span>
+  <span class="dim-name">Critical Equipment</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Best domestic lithography tool operates at 350nm on 200mm wafers; no global supply role</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot pl"></span>
+  <span class="dim-key">D4</span>
+  <span class="dim-name">AI Compute</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Total national AI compute 0.073 exaflops; largest cluster ~1,600 A100 nodes</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot pl"></span>
+  <span class="dim-key">D5</span>
+  <span class="dim-name">Frontier Models</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Flagship LLMs trail frontier by 34-55% on key benchmarks; two of three built on Chinese Qwen base weights</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot gv"></span>
+  <span class="dim-key">D6</span>
+  <span class="dim-name">AI Regulation</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> No enacted AI-specific extraterritorial framework; enforcement model produces market exit, not foreign compliance</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot gv"></span>
+  <span class="dim-key">D7</span>
+  <span class="dim-name">Sovereign Investment</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Executed federal AI spending ~$80-90M/year; announced budgets systematically revised downward 5-20×</dd>
+</div>
+    </dl>
+    
+    
+  </div>
+</article><article id="ca" class="actor-card">
+  <header class="actor-header">
+    <div class="actor-title-row">
+      <h3 class="actor-name">Canada</h3>
+      <div class="actor-meta">
+        <span class="actor-score">0/7</span>
+        <span class="actor-badge badge-participant">Participant</span>
+      </div>
+    </div>
+    <div class="dim-bar"><span class="dim-bar-dot hw nmet" title="D1"></span><span class="dim-bar-dot hw nmet" title="D2"></span><span class="dim-bar-dot hw nmet" title="D3"></span><span class="dim-bar-dot pl nmet" title="D4"></span><span class="dim-bar-dot pl nmet" title="D5"></span><span class="dim-bar-dot gv nmet" title="D6"></span><span class="dim-bar-dot gv nmet" title="D7"></span></div>
+  </header>
+  <div class="actor-body">
+    <dl class="dimensions-list">
+<div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot hw"></span>
+  <span class="dim-key">D1</span>
+  <span class="dim-name">AI Chip Design</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Tenstorrent redomiciled to Delaware 2023; no Canadian-controlled accelerator in volume production</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot hw"></span>
+  <span class="dim-key">D2</span>
+  <span class="dim-name">Advanced Fabrication</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Zero front-end logic fabs at ≤7nm on Canadian territory; ecosystem is packaging and specialty nodes</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot hw"></span>
+  <span class="dim-key">D3</span>
+  <span class="dim-name">Critical Equipment</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> US-parented entity (Teledyne Technologies); pellicle manufacturing credits to parent jurisdiction</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot pl"></span>
+  <span class="dim-key">D4</span>
+  <span class="dim-name">AI Compute</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> No Canadian-HQ entity operates GPU clusters at frontier-training scale; all hyperscalers US-controlled</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot pl"></span>
+  <span class="dim-key">D5</span>
+  <span class="dim-name">Frontier Models</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Cohere ranks decisively second-tier on flagship cross-domain benchmarks (GPQA, Arena, SWE-bench)</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot gv"></span>
+  <span class="dim-key">D6</span>
+  <span class="dim-name">AI Regulation</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> AIDA died on the order paper January 2025; ECL export controls bind Canadian exporters only, no extraterritorial reach</dd>
+</div><div class="dim-item">
+<dt class="dim-header">
+  <span class="dim-dot gv"></span>
+  <span class="dim-key">D7</span>
+  <span class="dim-name">Sovereign Investment</span>
+  <span class="dim-status dim-nmet">Not Met</span>
+</dt>
+<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> ~CAD $2.9B over five years (~0.02% GDP/yr); flagship SCIP supercomputer not yet operational</dd>
+</div>
+    </dl>
+    
+    
+  </div>
+</article>
+</section>
+
+      <section class="watch-section">
+  <h2>Dimension Watch</h2>
+  <p class="watch-desc">Dimensions under active monitoring for potential status change at next assessment.</p>
+  <div class="table-wrap">
+    <table class="watch-table">
+      <thead>
+        <tr>
+          <th>Actor</th>
+          <th>Dimension</th>
+          <th>Current</th>
+          <th>Expected Change</th>
+          <th>Trigger</th>
+          <th>Timeline</th>
+        </tr>
+      </thead>
+      <tbody>
+<tr>
+  <td><a href="#gb">United Kingdom</a></td>
+  <td><span class="dim-ref">D4</span> AI Compute</td>
+  <td class="w-nmet">NOT MET</td>
+  <td>Probable MET</td>
+  <td>Nscale Loughton 23,040-GPU cluster operational</td>
+  <td>Q1 2027</td>
+</tr>
+<tr>
+  <td><a href="#fr">France</a></td>
+  <td><span class="dim-ref">D4</span> AI Compute</td>
+  <td class="w-nmet">NOT MET</td>
+  <td>Possible MET</td>
+  <td>Mistral Compute sustained frontier-class training runs</td>
+  <td>Q3/Q4 2026</td>
+</tr>
+<tr>
+  <td><a href="#fr">France</a></td>
+  <td><span class="dim-ref">D5</span> Frontier Models</td>
+  <td class="w-nmet">NOT MET</td>
+  <td>Possible MET</td>
+  <td>Mistral release closing approximately 35% frontier gap</td>
+  <td>Unknown</td>
+</tr>
+<tr>
+  <td><a href="#kr">South Korea</a></td>
+  <td><span class="dim-ref">D4</span> AI Compute</td>
+  <td class="w-nmet">NOT MET</td>
+  <td>Possible MET</td>
+  <td>Sovereign compute exceeding 50,000 GPUs</td>
+  <td>2027–2028</td>
+</tr>
+<tr>
+  <td><a href="#in">India</a></td>
+  <td><span class="dim-ref">D4</span> AI Compute</td>
+  <td class="w-nmet">NOT MET</td>
+  <td>Possible MET</td>
+  <td>Sovereign compute consolidation exceeding 50,000 GPUs</td>
+  <td>2027–2028</td>
+</tr>
+<tr>
+  <td><a href="#in">India</a></td>
+  <td><span class="dim-ref">D5</span> Frontier Models</td>
+  <td class="w-nmet">NOT MET</td>
+  <td>Possible MET</td>
+  <td>Independent verification of Sarvam-105B benchmark claims</td>
+  <td>Near-term</td>
+</tr>
+<tr>
+  <td><a href="#tw">Taiwan</a></td>
+  <td><span class="dim-ref">D7</span> Sovereign Investment</td>
+  <td class="w-met">MET</td>
+  <td>At risk</td>
+  <td>FY2026 budget blocked by opposition in Legislative Yuan</td>
+  <td>Ongoing</td>
+</tr>
+<tr>
+  <td><a href="#de">Germany</a></td>
+  <td><span class="dim-ref">D7</span> Sovereign Investment</td>
+  <td class="w-nmet">NOT MET</td>
+  <td>Possible MET</td>
+  <td>STACKIT and sovereign AI programme scaling</td>
+  <td>End-2027+</td>
+</tr>
+<tr>
+  <td><a href="#il">Israel</a></td>
+  <td><span class="dim-ref">D7</span> Sovereign Investment</td>
+  <td class="w-nmet">NOT MET</td>
+  <td>Possible MET</td>
+  <td>Nagel Committee NIS 25 billion legislatively appropriated</td>
+  <td>Unknown</td>
+</tr>
+<tr>
+  <td><a href="#ca">Canada</a></td>
+  <td><span class="dim-ref">D5</span> Frontier Models</td>
+  <td class="w-nmet">NOT MET</td>
+  <td>Possible shift</td>
+  <td>Cohere–Aleph Alpha merger closes and combined capability assessed</td>
+  <td>Late 2026</td>
+</tr>
+<tr>
+  <td><a href="#ca">Canada</a></td>
+  <td><span class="dim-ref">D7</span> Sovereign Investment</td>
+  <td class="w-nmet">NOT MET</td>
+  <td>Possible MET</td>
+  <td>SCIP operational and Budget 2026 scales commitment</td>
+  <td>2027–2028</td>
+</tr>
+
+      </tbody>
+    </table>
+  </div>
+</section>
+    </main>
+
+    <footer class="page-footer">
+      <p class="footer-cta">Full analysis and sources for all actors available with supporter access.</p>
+      <div class="footer-links">
+        <a href="/?scp=open">Explore the interactive Sovereign Capability Profiles →</a>
+        <a href="/research/methodology/manual/">Methodology Manual →</a>
+      </div>
+      <p class="footer-copy">SCP Register v1.0 · Assessment: May 2026 · Methodology V1.4 · © 2026 Warmth Engine</p>
+    </footer>
+  </div>
+</body>
+</html>

--- a/profiles/index.html
+++ b/profiles/index.html
@@ -1,8 +1,12 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en-GB">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="weo-version" content="1.3.0">
+  <link rel="icon" type="image/png" sizes="48x48" href="/favicon_48x48.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon_32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon_16x16.png">
   <title>Sovereign Capability Profiles — AI Infrastructure Assessments | Warmth Engine Observatory</title>
   <meta name="description" content="Nation-state AI infrastructure assessments across 14 actors. Chip design, fabrication, equipment, compute, frontier models, regulation, and sovereign investment dimensions evaluated with sourced evidence.">
   <link rel="canonical" href="https://warmthengine.com/profiles/">
@@ -10,6 +14,10 @@
   <meta property="og:description" content="Which nations control the AI infrastructure stack? 14 actors assessed across 7 dimensions with sourced evidence.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://warmthengine.com/profiles/">
+  <meta property="og:image" content="https://www.warmthengine.com/og-image.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Geist:wght@100..900&family=Geist+Mono:wght@100..900&display=swap" rel="stylesheet">
   <script type="application/ld+json">
 {
   "@context": "https://schema.org",
@@ -31,38 +39,75 @@
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
 :root {
-  --bg-primary: #0F172A;
-  --bg-card: #1E293B;
-  --bg-deep: #0B1120;
-  --text-primary: #E2E8F0;
-  --text-secondary: #94A3B8;
-  --text-muted: #64748B;
-  --accent: #3B82F6;
-  --border: rgba(255,255,255,0.07);
-  --scp-hw: #60A5FA;
-  --scp-pl: #A78BFA;
-  --scp-gv: #2DD4BF;
-  --scp-paa: #F59E0B;
-  --scp-aik: #06B6D4;
-  --scp-acs: #A855F7;
+  /* WEO design tokens — aligned with index.html / 404.html */
+  --weo-surface-base:    #0F172A;
+  --weo-surface-raised:  #1E293B;
+  --weo-text-primary:    #E2E8F0;
+  --weo-text-secondary:  rgba(226, 232, 240, 0.7);
+  --weo-text-muted:      #94A3B8;
+  --weo-accent-hover:    #60A5FA;
+  --weo-border-primary:  #334155;
+  --weo-radius-sm:       4px;
+  --weo-radius-md:       8px;
+  --weo-radius-lg:       12px;
+
+  /* SCP palette */
+  --scp-hw:   #60A5FA;
+  --scp-pl:   #A78BFA;
+  --scp-gv:   #2DD4BF;
+  --scp-paa:  #F59E0B;
+  --scp-aik:  #06B6D4;
+  --scp-acs:  #A855F7;
   --scp-part: #64748B;
-  --scp-met: #22C55E;
-  --r-sm: 4px;
-  --r-md: 6px;
+  --scp-met:  #22C55E;
+
+  /* local shorthand */
   --r-pill: 20px;
 }
 
 html { scroll-behavior: smooth; }
 
+/* ── Focus & motion ── */
+*:focus { outline: none; }
+*:focus-visible { outline: 2px solid var(--weo-accent-hover); outline-offset: 2px; }
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
 body {
-  background: var(--bg-primary);
-  color: var(--text-primary);
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+  background: var(--weo-surface-base);
+  color: var(--weo-text-primary);
+  font-family: 'Geist', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   line-height: 1.6;
   -webkit-font-smoothing: antialiased;
 }
 
-a { color: var(--accent); text-decoration: none; }
+/* ── Geist dark-mode weight compensation ──
+   Variable font weights adjusted for light-on-dark halation.
+   Standard 400 body → 380, standard 600 heading → 580, standard 500 data → 480. */
+body               { font-weight: 380; }
+.page-header h1    { font-weight: 580; }
+.actor-name        { font-weight: 580; }
+.desig-heading h2  { font-weight: 580; }
+.watch-section h2  { font-weight: 580; }
+.dim-status        { font-weight: 580; }
+.constraint-label  { font-weight: 580; }
+.sev-label         { font-weight: 580; }
+.aik-label         { font-weight: 580; }
+.actor-badge       { font-weight: 580; }
+.src-type          { font-weight: 580; }
+.src-grade         { font-weight: 580; }
+.actor-score       { font-weight: 480; }
+.dim-key           { font-weight: 480; }
+.dim-ref           { font-weight: 480; }
+.legend-key        { font-weight: 480; }
+
+a { color: var(--weo-accent-hover); text-decoration: none; }
 a:hover { text-decoration: underline; }
 
 .page-wrap { max-width: 900px; margin: 0 auto; padding: 0 20px 60px; }
@@ -70,26 +115,26 @@ a:hover { text-decoration: underline; }
 /* ── Page header ── */
 .page-header {
   padding: 48px 0 36px;
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--weo-border-primary);
   margin-bottom: 40px;
 }
 .page-header h1 {
-  font-size: 28px; font-weight: 700; color: var(--text-primary);
+  font-size: 28px; color: var(--weo-text-primary);
   letter-spacing: -0.02em; margin-bottom: 6px;
 }
-.page-subtitle { font-size: 15px; color: var(--text-secondary); margin-bottom: 18px; }
+.page-subtitle { font-size: 15px; color: var(--weo-text-secondary); margin-bottom: 18px; }
 .page-framework {
-  font-size: 13px; color: var(--text-secondary); line-height: 1.7;
+  font-size: 13px; color: var(--weo-text-secondary); line-height: 1.7;
   max-width: 720px; margin-bottom: 20px;
 }
 .page-meta {
   display: flex; gap: 20px; flex-wrap: wrap;
-  font-size: 12px; color: var(--text-muted); margin-bottom: 24px;
+  font-size: 12px; color: #64748B; margin-bottom: 24px;
 }
 
 /* ── Dimension legend ── */
 .legend-heading {
-  font-size: 11px; font-weight: 700; color: var(--text-muted);
+  font-size: 11px; color: var(--weo-text-muted);
   letter-spacing: 0.08em; text-transform: uppercase; margin-bottom: 10px;
 }
 .dim-legend {
@@ -98,62 +143,69 @@ a:hover { text-decoration: underline; }
   gap: 6px;
 }
 .legend-item {
-  display: flex; align-items: flex-start; gap: 7px;
-  font-size: 12px; line-height: 1.45; padding: 6px 8px;
-  background: rgba(30,41,59,0.5); border-radius: var(--r-sm);
-  border: 1px solid var(--border);
+  display: flex; align-items: center; gap: 7px;
+  font-size: 12px; padding: 6px 8px;
+  background: rgba(30,41,59,0.5); border-radius: var(--weo-radius-sm);
+  border: 1px solid var(--weo-border-primary);
+  min-width: 0;
 }
-.legend-dot { width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0; margin-top: 3px; }
+.legend-dot { width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0; }
 .legend-key {
-  font-family: 'SF Mono','Fira Code',monospace; font-size: 10px;
-  color: var(--text-muted); flex-shrink: 0; min-width: 20px;
+  font-family: 'Geist Mono', 'Fira Code', 'Consolas', monospace; font-size: 10px;
+  color: #64748B; flex-shrink: 0; min-width: 20px;
 }
-.legend-name { font-weight: 500; color: var(--text-secondary); flex-shrink: 0; min-width: 100px; }
-.legend-desc { color: var(--text-muted); font-size: 11px; }
+.legend-name { color: var(--weo-text-muted); flex-shrink: 0; min-width: 100px; }
+.legend-desc {
+  color: #64748B; font-size: 11px;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
 
 /* ── Designation groups ── */
 .desig-section { margin-bottom: 48px; }
 .desig-heading { display: flex; align-items: center; gap: 12px; margin-bottom: 18px; }
-.desig-heading h2 { font-size: 14px; font-weight: 700; letter-spacing: 0.01em; white-space: nowrap; }
-.desig-line { flex: 1; height: 1px; background: var(--border); }
-.desig-paa .desig-heading h2 { color: var(--scp-paa); }
-.desig-aik .desig-heading h2 { color: var(--scp-aik); }
-.desig-acs .desig-heading h2 { color: var(--scp-acs); }
+.desig-heading h2 { font-size: 14px; letter-spacing: 0.01em; white-space: nowrap; }
+.desig-line { flex: 1; height: 1px; background: var(--weo-border-primary); }
+.desig-paa .desig-heading h2         { color: var(--scp-paa); }
+.desig-aik .desig-heading h2         { color: var(--scp-aik); }
+.desig-acs .desig-heading h2         { color: var(--scp-acs); }
 .desig-participant .desig-heading h2 { color: var(--scp-part); }
 
 /* ── Actor cards ── */
 .actor-card {
-  background: var(--bg-card); border: 1px solid var(--border);
-  border-radius: var(--r-md); margin-bottom: 14px; overflow: hidden;
+  background: var(--weo-surface-raised);
+  border: 1px solid var(--weo-border-primary);
+  border-radius: var(--weo-radius-md);
+  box-shadow: 0 1px 3px rgba(0,0,0,0.2), 0 0 0 1px rgba(255,255,255,0.03);
+  margin-bottom: 14px; overflow: hidden;
 }
 .actor-header {
-  padding: 14px 20px 12px; border-bottom: 1px solid var(--border);
+  padding: 14px 20px 12px; border-bottom: 1px solid var(--weo-border-primary);
 }
 .actor-title-row {
   display: flex; align-items: center; justify-content: space-between;
   flex-wrap: wrap; gap: 8px; margin-bottom: 10px;
 }
 .actor-name {
-  font-size: 17px; font-weight: 700; color: var(--text-primary);
+  font-size: 17px; color: var(--weo-text-primary);
   display: flex; align-items: center; gap: 8px;
 }
 .actor-meta { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
 .actor-score {
-  font-family: 'SF Mono','Fira Code',monospace; font-size: 13px;
-  font-weight: 700; color: var(--text-secondary);
+  font-family: 'Geist Mono', 'Fira Code', 'Consolas', monospace; font-size: 13px;
+  color: var(--weo-text-muted);
   background: rgba(255,255,255,0.05); padding: 2px 8px;
-  border-radius: var(--r-sm); border: 1px solid var(--border);
+  border-radius: var(--weo-radius-sm); border: 1px solid var(--weo-border-primary);
 }
 .actor-badge {
-  font-size: 11px; font-weight: 700; letter-spacing: 0.04em;
+  font-size: 11px; letter-spacing: 0.04em;
   padding: 3px 10px; border-radius: var(--r-pill); border: 1px solid;
 }
-.badge-paa   { background: rgba(245,158,11,0.15); color: #F59E0B;   border-color: rgba(245,158,11,0.35); }
-.badge-aik   { background: rgba(6,182,212,0.12);  color: #22D3EE;   border-color: rgba(6,182,212,0.3); }
-.badge-acs   { background: rgba(168,85,247,0.12); color: #C084FC;   border-color: rgba(168,85,247,0.3); }
+.badge-paa         { background: rgba(245,158,11,0.15); color: #F59E0B;  border-color: rgba(245,158,11,0.35); }
+.badge-aik         { background: rgba(6,182,212,0.12);  color: #22D3EE;  border-color: rgba(6,182,212,0.3); }
+.badge-acs         { background: rgba(168,85,247,0.12); color: #C084FC;  border-color: rgba(168,85,247,0.3); }
 .badge-participant { background: rgba(100,116,139,0.12); color: #64748B; border-color: rgba(100,116,139,0.25); }
 .sample-badge {
-  font-size: 10px; font-weight: 600;
+  font-size: 10px;
   background: rgba(255,215,0,0.1); color: #FFD700;
   border: 1px solid rgba(255,215,0,0.25); padding: 1px 6px;
   border-radius: 3px; letter-spacing: 0.03em;
@@ -165,9 +217,9 @@ a:hover { text-decoration: underline; }
   width: 10px; height: 10px; border-radius: 50%; border: 1.5px solid;
   flex-shrink: 0;
 }
-.dim-bar-dot.hw.met  { background: var(--scp-hw);  border-color: var(--scp-hw); }
-.dim-bar-dot.pl.met  { background: var(--scp-pl);  border-color: var(--scp-pl); }
-.dim-bar-dot.gv.met  { background: var(--scp-gv);  border-color: var(--scp-gv); }
+.dim-bar-dot.hw.met  { background: var(--scp-hw); border-color: var(--scp-hw); }
+.dim-bar-dot.pl.met  { background: var(--scp-pl); border-color: var(--scp-pl); }
+.dim-bar-dot.gv.met  { background: var(--scp-gv); border-color: var(--scp-gv); }
 .dim-bar-dot.hw.nmet { background: transparent; border-color: rgba(96,165,250,0.3); }
 .dim-bar-dot.pl.nmet { background: transparent; border-color: rgba(167,139,250,0.3); }
 .dim-bar-dot.gv.nmet { background: transparent; border-color: rgba(45,212,191,0.3); }
@@ -193,47 +245,47 @@ a:hover { text-decoration: underline; }
 .dim-dot.pl.met { background: var(--scp-pl); }
 .dim-dot.gv.met { background: var(--scp-gv); }
 .dim-key {
-  font-family: 'SF Mono','Fira Code',monospace; font-size: 10px;
-  color: var(--text-muted); flex-shrink: 0; min-width: 20px;
+  font-family: 'Geist Mono', 'Fira Code', 'Consolas', monospace; font-size: 10px;
+  color: #64748B; flex-shrink: 0; min-width: 20px;
 }
-.dim-name  { color: var(--text-secondary); flex: 1; }
-.dim-status { font-size: 11px; font-weight: 700; flex-shrink: 0; }
+.dim-name  { color: var(--weo-text-muted); flex: 1; }
+.dim-status { font-size: 11px; flex-shrink: 0; }
 .dim-met   { color: var(--scp-met); }
-.dim-nmet  { color: var(--text-muted); }
+.dim-nmet  { color: #64748B; }
 
 .dim-qual-hl {
-  font-size: 12px; color: #CBD5E1; line-height: 1.55;
+  font-size: 12px; color: var(--weo-text-secondary); line-height: 1.55;
   padding: 4px 0 2px 13px;
 }
 .dim-constraint {
-  font-size: 12px; color: var(--text-muted); line-height: 1.55;
+  font-size: 12px; color: #64748B; line-height: 1.55;
   padding: 4px 0 2px 13px; font-style: italic;
 }
-.constraint-label { font-style: normal; font-weight: 700; color: var(--text-secondary); }
+.constraint-label { font-style: normal; color: var(--weo-text-secondary); }
 
 .dim-details-dd { padding: 2px 0 2px 13px; }
 details.dim-details summary {
-  font-size: 11px; color: var(--text-muted); cursor: pointer;
+  font-size: 11px; color: #64748B; cursor: pointer;
   padding: 3px 0; display: inline-flex; align-items: center; gap: 5px;
   list-style: none; -webkit-appearance: none; transition: color 0.15s;
 }
 details.dim-details summary::-webkit-details-marker { display: none; }
 details.dim-details summary::before { content: '▸'; font-size: 9px; }
 details.dim-details[open] summary::before { content: '▾'; }
-details.dim-details summary:hover { color: var(--text-secondary); }
+details.dim-details summary:hover { color: var(--weo-text-muted); }
 
 .dim-qual-block {
   margin-top: 6px; padding: 10px 12px;
-  background: rgba(15,23,42,0.6); border-radius: var(--r-sm);
-  border: 1px solid var(--border);
-  font-size: 12px; color: var(--text-secondary); line-height: 1.65;
+  background: rgba(15,23,42,0.6); border-radius: var(--weo-radius-sm);
+  border: 1px solid var(--weo-border-primary);
+  font-size: 12px; color: var(--weo-text-secondary); line-height: 1.65;
 }
 
 /* ── Sources ── */
 .src-block {
   margin-top: 6px; padding: 10px 12px;
-  background: rgba(15,23,42,0.6); border-radius: var(--r-sm);
-  border: 1px solid var(--border);
+  background: rgba(15,23,42,0.6); border-radius: var(--weo-radius-sm);
+  border: 1px solid var(--weo-border-primary);
 }
 .src-entry {
   padding: 8px 0; border-bottom: 1px solid rgba(255,255,255,0.04);
@@ -242,79 +294,83 @@ details.dim-details summary:hover { color: var(--text-secondary); }
 .src-meta {
   display: flex; flex-wrap: wrap; align-items: center; gap: 8px; margin-bottom: 5px;
 }
-.src-type  { font-size: 10px; font-weight: 700; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.05em; }
-.src-grade { font-size: 10px; font-weight: 700; padding: 1px 7px; border-radius: 3px; }
-.src-pub   { font-size: 11px; color: var(--text-secondary); }
-.src-date  { font-size: 10px; color: var(--text-muted); }
-.src-fact  { font-size: 11px; color: var(--text-secondary); line-height: 1.55; margin-bottom: 5px; }
-.src-link  { font-size: 11px; color: var(--accent); }
+.src-type  { font-size: 10px; color: var(--weo-text-muted); text-transform: uppercase; letter-spacing: 0.05em; }
+.src-grade { font-size: 10px; padding: 1px 7px; border-radius: 3px; }
+.src-pub   { font-size: 11px; color: var(--weo-text-muted); }
+.src-date  { font-size: 10px; color: #64748B; }
+.src-fact  { font-size: 11px; color: var(--weo-text-secondary); line-height: 1.55; margin-bottom: 5px; }
+.src-link  { font-size: 11px; color: var(--weo-accent-hover); }
 
 /* ── AIK chokepoint ── */
 .aik-profile {
   margin-top: 12px; padding: 10px 12px;
   background: rgba(6,182,212,0.06); border: 1px solid rgba(6,182,212,0.15);
-  border-radius: var(--r-sm);
+  border-radius: var(--weo-radius-sm);
 }
 .aik-label  {
-  font-size: 10px; font-weight: 700; color: #94A3B8;
+  font-size: 10px; color: var(--weo-text-muted);
   letter-spacing: 0.07em; text-transform: uppercase; margin-bottom: 4px;
 }
-.aik-nature   { font-size: 13px; color: #CBD5E1; font-weight: 500; line-height: 1.45; }
-.aik-entities { font-size: 11px; color: var(--text-muted); font-style: italic; line-height: 1.55; margin-top: 3px; }
+.aik-nature   { font-size: 13px; color: var(--weo-text-secondary); line-height: 1.45; }
+.aik-entities { font-size: 11px; color: #64748B; font-style: italic; line-height: 1.55; margin-top: 3px; }
 
 /* ── Severance ── */
 .actor-severance {
-  font-size: 12px; color: var(--text-muted); margin-top: 12px;
+  font-size: 12px; color: #64748B; margin-top: 12px;
   padding-top: 10px; border-top: 1px solid rgba(255,255,255,0.04);
   line-height: 1.55;
 }
-.sev-label  { font-weight: 700; color: var(--text-secondary); }
-.sev-pass   { color: var(--scp-met); font-weight: 700; }
-.sev-fail   { color: #F87171; font-weight: 700; }
+.sev-label  { color: var(--weo-text-secondary); }
+.sev-pass   { color: var(--scp-met); }
+.sev-fail   { color: #F87171; }
 
 /* ── Dimension watch ── */
 .watch-section {
-  margin-top: 48px; padding-top: 32px; border-top: 1px solid var(--border);
+  margin-top: 48px; padding-top: 32px; border-top: 1px solid var(--weo-border-primary);
 }
 .watch-section h2 {
-  font-size: 17px; font-weight: 700; color: var(--text-primary); margin-bottom: 8px;
+  font-size: 17px; color: var(--weo-text-primary); margin-bottom: 8px;
 }
-.watch-desc { font-size: 13px; color: var(--text-muted); margin-bottom: 16px; }
+.watch-desc { font-size: 13px; color: #64748B; margin-bottom: 16px; }
 .table-wrap { overflow-x: auto; -webkit-overflow-scrolling: touch; }
 .watch-table { width: 100%; border-collapse: collapse; font-size: 12px; }
 .watch-table th {
-  text-align: left; font-size: 10px; font-weight: 700;
-  color: var(--text-muted); text-transform: uppercase;
+  text-align: left; font-size: 10px;
+  color: var(--weo-text-muted); text-transform: uppercase;
   letter-spacing: 0.06em; padding: 8px 12px;
-  border-bottom: 1px solid var(--border); white-space: nowrap;
+  border-bottom: 1px solid var(--weo-border-primary); white-space: nowrap;
 }
 .watch-table td {
   padding: 10px 12px; border-bottom: 1px solid rgba(255,255,255,0.03);
-  vertical-align: top; color: var(--text-secondary); line-height: 1.5;
+  vertical-align: top; color: var(--weo-text-secondary); line-height: 1.5;
 }
 .watch-table tr:last-child td { border-bottom: none; }
 .watch-table tr:hover td { background: rgba(255,255,255,0.01); }
 .dim-ref {
-  font-family: 'SF Mono','Fira Code',monospace; font-size: 10px;
-  color: var(--text-muted);
+  font-family: 'Geist Mono', 'Fira Code', 'Consolas', monospace; font-size: 10px;
+  color: var(--weo-text-muted);
 }
-.w-met  { color: var(--scp-met); font-weight: 700; }
-.w-nmet { color: var(--text-muted); }
+.w-met  { color: var(--scp-met); }
+.w-nmet { color: #64748B; }
 
 /* ── Footer ── */
 .page-footer {
-  margin-top: 56px; padding-top: 24px; border-top: 1px solid var(--border);
-  font-size: 12px; color: var(--text-muted); line-height: 1.8;
+  margin-top: 56px; padding-top: 24px; border-top: 1px solid var(--weo-border-primary);
+  font-size: 12px; color: #64748B; line-height: 1.8;
 }
 .footer-cta {
-  font-size: 13px; color: var(--text-secondary); margin-bottom: 14px;
+  font-size: 13px; color: var(--weo-text-secondary); margin-bottom: 14px;
   padding: 10px 14px;
-  background: rgba(59,130,246,0.05); border: 1px solid rgba(59,130,246,0.15);
-  border-radius: var(--r-sm);
+  background: rgba(96,165,250,0.05); border: 1px solid rgba(96,165,250,0.15);
+  border-radius: var(--weo-radius-sm);
 }
 .footer-links { display: flex; flex-wrap: wrap; gap: 16px; margin-bottom: 12px; }
-.footer-links a { color: var(--accent); }
-.footer-copy { font-size: 11px; color: var(--text-muted); }
+.footer-links a { color: var(--weo-accent-hover); }
+.footer-mono {
+  font-family: 'Geist Mono', 'Fira Code', 'Consolas', monospace;
+  font-size: 11px; color: var(--weo-text-muted); opacity: 0.5;
+  letter-spacing: 0.04em;
+}
 
 /* ── Responsive ── */
 @media (max-width: 600px) {
@@ -345,43 +401,43 @@ details.dim-details summary:hover { color: var(--text-secondary); }
       <p class="legend-heading">Dimensions</p>
       <div class="dim-legend">
 <div class="legend-item">
-  <span class="legend-dot" style="background:var(--scp-hw);"></span>
+  <span class="legend-dot" style="background:var(--scp-hw);flex-shrink:0;"></span>
   <span class="legend-key">D1</span>
   <span class="legend-name">AI Chip Design</span>
   <span class="legend-desc">Designs and commercially sells training-class AI accelerators under domestic IP control.</span>
 </div>
 <div class="legend-item">
-  <span class="legend-dot" style="background:var(--scp-hw);"></span>
+  <span class="legend-dot" style="background:var(--scp-hw);flex-shrink:0;"></span>
   <span class="legend-key">D2</span>
   <span class="legend-name">Advanced Fabrication</span>
   <span class="legend-desc">Operates production-capable semiconductor fabrication at process nodes of 7nm or below.</span>
 </div>
 <div class="legend-item">
-  <span class="legend-dot" style="background:var(--scp-hw);"></span>
+  <span class="legend-dot" style="background:var(--scp-hw);flex-shrink:0;"></span>
   <span class="legend-key">D3</span>
   <span class="legend-name">Critical Equipment</span>
   <span class="legend-desc">Hosts entities that design and manufacture globally essential semiconductor production equipment or sole-sourced subsystems for advanced fabrication.</span>
 </div>
 <div class="legend-item">
-  <span class="legend-dot" style="background:var(--scp-pl);"></span>
+  <span class="legend-dot" style="background:var(--scp-pl);flex-shrink:0;"></span>
   <span class="legend-key">D4</span>
   <span class="legend-name">AI Compute</span>
   <span class="legend-desc">Hosts hyperscale cloud providers operating AI training infrastructure sufficient to train current-generation frontier models, with compute physically on the actor&#x27;s territory.</span>
 </div>
 <div class="legend-item">
-  <span class="legend-dot" style="background:var(--scp-pl);"></span>
+  <span class="legend-dot" style="background:var(--scp-pl);flex-shrink:0;"></span>
   <span class="legend-key">D5</span>
   <span class="legend-name">Frontier Models</span>
   <span class="legend-desc">Hosts organisations developing state-of-the-art foundation models competitive with the current global frontier across multiple capability domains.</span>
 </div>
 <div class="legend-item">
-  <span class="legend-dot" style="background:var(--scp-gv);"></span>
+  <span class="legend-dot" style="background:var(--scp-gv);flex-shrink:0;"></span>
   <span class="legend-key">D6</span>
   <span class="legend-name">AI Regulation</span>
   <span class="legend-desc">Enforces AI-relevant compliance frameworks with binding obligations for entities outside its own jurisdiction.</span>
 </div>
 <div class="legend-item">
-  <span class="legend-dot" style="background:var(--scp-gv);"></span>
+  <span class="legend-dot" style="background:var(--scp-gv);flex-shrink:0;"></span>
   <span class="legend-key">D7</span>
   <span class="legend-name">Sovereign Investment</span>
   <span class="legend-desc">Operates a national programme directing significant public capital toward AI compute, semiconductor fabrication, or AI-specific physical infrastructure at nationally transformative scale.</span>
@@ -1794,8 +1850,17 @@ details.dim-details summary:hover { color: var(--text-secondary); }
         <a href="/?scp=open">Explore the interactive Sovereign Capability Profiles →</a>
         <a href="/research/methodology/manual/">Methodology Manual →</a>
       </div>
-      <p class="footer-copy">SCP Register v1.0 · Assessment: May 2026 · Methodology V1.4 · © 2026 Warmth Engine</p>
+      <p class="footer-mono">SCP Register v1.0 · Assessment: May 2026 · Methodology V1.4 · WEO v1.3.0</p>
+      <p class="footer-mono" style="margin-top:4px;opacity:0.5;">© 2026 Warmth Engine Observatory</p>
     </footer>
   </div>
+<script data-goatcounter="https://warmthengine.goatcounter.com/count"
+        async src="//gc.zgo.at/count.js"></script>
+<script>
+(function(){
+  var v = document.querySelector('meta[name="weo-version"]');
+  if (v) console.log('WEO v' + v.getAttribute('content'));
+})();
+</script>
 </body>
 </html>

--- a/profiles/index.html
+++ b/profiles/index.html
@@ -4,9 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="weo-version" content="1.3.0">
-  <link rel="icon" type="image/png" sizes="48x48" href="/favicon_48x48.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon_32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon_16x16.png">
   <title>Sovereign Capability Profiles — AI Infrastructure Assessments | Warmth Engine Observatory</title>
   <meta name="description" content="Nation-state AI infrastructure assessments across 14 actors. Chip design, fabrication, equipment, compute, frontier models, regulation, and sovereign investment dimensions evaluated with sourced evidence.">
   <link rel="canonical" href="https://warmthengine.com/profiles/">
@@ -15,1852 +12,395 @@
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://warmthengine.com/profiles/">
   <meta property="og:image" content="https://www.warmthengine.com/og-image.png">
+  <link rel="icon" type="image/png" sizes="48x48" href="/favicon_48x48.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon_32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon_16x16.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Geist:wght@100..900&family=Geist+Mono:wght@100..900&display=swap" rel="stylesheet">
   <script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "Dataset",
-  "name": "WEO Sovereign Capability Profiles",
-  "description": "Nation-state AI infrastructure capability assessments across 7 dimensions for 14 actors",
-  "url": "https://warmthengine.com/profiles/",
-  "creator": {
-    "@type": "Organisation",
-    "name": "Warmth Engine Observatory",
-    "url": "https://warmthengine.com"
-  },
-  "dateModified": "2026-06-03",
-  "license": "https://warmthengine.com/research/methodology/manual/"
-}
+  {
+    "@context": "https://schema.org",
+    "@type": "Dataset",
+    "name": "WEO Sovereign Capability Profiles",
+    "description": "Nation-state AI infrastructure capability assessments across 7 dimensions for 14 actors",
+    "url": "https://warmthengine.com/profiles/",
+    "creator": { "@type": "Organization", "name": "Warmth Engine Observatory", "url": "https://warmthengine.com" },
+    "dateModified": "2026-06-04",
+    "license": "https://warmthengine.com/research/methodology/manual/"
+  }
   </script>
   <style>
+    /* ── Reset ── */
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    *:focus { outline: none; }
+    *:focus-visible { outline: 2px solid #60a5fa; outline-offset: 2px; }
 
-*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    /* ── Tokens — exact match to index.html ── */
+    :root {
+      --scp-hw: #60A5FA; --scp-plat: #A78BFA; --scp-gov: #2DD4BF;
+      --scp-paa: #F59E0B; --scp-aik: #06B6D4; --scp-acs: #A855F7; --scp-part: #64748B;
+      --weo-radius-sm: 4px; --weo-radius-md: 8px; --weo-radius-lg: 12px;
+      --duration-fast: 150ms; --duration-normal: 250ms;
+      --ease-out: cubic-bezier(0.33, 1, 0.68, 1);
+    }
 
-:root {
-  /* WEO design tokens — aligned with index.html / 404.html */
-  --weo-surface-base:    #0F172A;
-  --weo-surface-raised:  #1E293B;
-  --weo-text-primary:    #E2E8F0;
-  --weo-text-secondary:  rgba(226, 232, 240, 0.7);
-  --weo-text-muted:      #94A3B8;
-  --weo-accent-hover:    #60A5FA;
-  --weo-border-primary:  #334155;
-  --weo-radius-sm:       4px;
-  --weo-radius-md:       8px;
-  --weo-radius-lg:       12px;
+    html { scroll-behavior: smooth; }
 
-  /* SCP palette */
-  --scp-hw:   #60A5FA;
-  --scp-pl:   #A78BFA;
-  --scp-gv:   #2DD4BF;
-  --scp-paa:  #F59E0B;
-  --scp-aik:  #06B6D4;
-  --scp-acs:  #A855F7;
-  --scp-part: #64748B;
-  --scp-met:  #22C55E;
+    body {
+      font-family: 'Geist', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      font-weight: 380;
+      background: #0F172A;
+      color: #E2E8F0;
+      min-height: 100vh;
+      -webkit-font-smoothing: antialiased;
+    }
 
-  /* local shorthand */
-  --r-pill: 20px;
-}
+    /* ── Page frame ── */
+    .page-nav {
+      display: flex; justify-content: space-between; align-items: center;
+      padding: 12px 32px;
+      border-bottom: 1px solid rgba(51,65,85,0.5);
+      font-size: 12px; font-weight: 480;
+      background: #1E293B;
+      position: sticky; top: 0; z-index: 100;
+    }
+    .page-nav a { color: #94A3B8; text-decoration: none; transition: color var(--duration-fast); }
+    .page-nav a:hover { color: #E2E8F0; }
+    .nav-brand { color: #CBD5E1; font-weight: 580; display: flex; align-items: center; gap: 6px; }
+    .nav-brand span { font-size: 13px; }
+    .nav-links { display: flex; gap: 16px; }
 
-html { scroll-behavior: smooth; }
+    .page-wrap {
+      max-width: 800px;
+      margin: 0 auto;
+      padding: 32px 24px 60px;
+    }
 
-/* ── Focus & motion ── */
-*:focus { outline: none; }
-*:focus-visible { outline: 2px solid var(--weo-accent-hover); outline-offset: 2px; }
+    /* ── Header ── */
+    .scp-page-title { font-size: 22px; font-weight: 580; color: #F1F5F9; letter-spacing: 0.01em; }
+    .scp-page-subtitle { font-size: 13px; color: #94A3B8; margin-top: 4px; font-weight: 380; }
+    .scp-page-meta {
+      font-family: 'Geist Mono', 'Fira Code', monospace;
+      font-size: 11px; font-weight: 480; color: #64748B;
+      margin-top: 10px; letter-spacing: 0.02em;
+    }
+    .scp-page-header {
+      padding-bottom: 20px;
+      border-bottom: 1px solid rgba(51,65,85,0.5);
+      margin-bottom: 4px;
+    }
 
-@media (prefers-reduced-motion: reduce) {
-  *, *::before, *::after {
-    animation-duration: 0.01ms !important;
-    animation-iteration-count: 1 !important;
-    transition-duration: 0.01ms !important;
-  }
-}
+    /* ── Dimension pills — exact match ── */
+    .scp-pills {
+      display: flex; gap: 5px; padding: 14px 0;
+      border-bottom: 1px solid rgba(51,65,85,0.5);
+      flex-wrap: wrap;
+    }
+    .scp-pill {
+      font-size: 12px; font-weight: 480; padding: 4px 11px; border-radius: 12px;
+      border: 1px solid transparent; cursor: pointer;
+      transition: all var(--duration-fast); user-select: none; white-space: nowrap;
+      display: inline-flex; align-items: center; gap: 5px;
+    }
+    .scp-pill .scp-pill-dot { width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }
+    .scp-pill.hw { color: #7DB8F5; background: rgba(96,165,250,0.06); border-color: rgba(96,165,250,0.15); }
+    .scp-pill.hw .scp-pill-dot { background: var(--scp-hw); }
+    .scp-pill.pl { color: #B9A4F8; background: rgba(167,139,250,0.06); border-color: rgba(167,139,250,0.15); }
+    .scp-pill.pl .scp-pill-dot { background: var(--scp-plat); }
+    .scp-pill.gv { color: #5EDBC9; background: rgba(45,212,191,0.06); border-color: rgba(45,212,191,0.15); }
+    .scp-pill.gv .scp-pill-dot { background: var(--scp-gov); }
+    .scp-pill:hover.hw { background: rgba(96,165,250,0.12); border-color: rgba(96,165,250,0.3); }
+    .scp-pill:hover.pl { background: rgba(167,139,250,0.12); border-color: rgba(167,139,250,0.3); }
+    .scp-pill:hover.gv { background: rgba(45,212,191,0.12); border-color: rgba(45,212,191,0.3); }
+    .scp-pill.active.hw { background: rgba(96,165,250,0.2); border-color: rgba(96,165,250,0.5); color: #93C5FD; }
+    .scp-pill.active.pl { background: rgba(167,139,250,0.2); border-color: rgba(167,139,250,0.5); color: #C4B5FD; }
+    .scp-pill.active.gv { background: rgba(45,212,191,0.2); border-color: rgba(45,212,191,0.5); color: #5EEAD4; }
+    .scp-pill-ct { font-family: 'Geist Mono','Fira Code',monospace; font-size: 10px; opacity: 0.5; font-weight: 480; }
 
-body {
-  background: var(--weo-surface-base);
-  color: var(--weo-text-primary);
-  font-family: 'Geist', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  line-height: 1.6;
-  -webkit-font-smoothing: antialiased;
-}
+    /* ── Body ── */
+    .scp-body { padding-top: 4px; }
 
-/* ── Geist dark-mode weight compensation ──
-   Variable font weights adjusted for light-on-dark halation.
-   Standard 400 body → 380, standard 600 heading → 580, standard 500 data → 480. */
-body               { font-weight: 380; }
-.page-header h1    { font-weight: 580; }
-.actor-name        { font-weight: 580; }
-.desig-heading h2  { font-weight: 580; }
-.watch-section h2  { font-weight: 580; }
-.dim-status        { font-weight: 580; }
-.constraint-label  { font-weight: 580; }
-.sev-label         { font-weight: 580; }
-.aik-label         { font-weight: 580; }
-.actor-badge       { font-weight: 580; }
-.src-type          { font-weight: 580; }
-.src-grade         { font-weight: 580; }
-.actor-score       { font-weight: 480; }
-.dim-key           { font-weight: 480; }
-.dim-ref           { font-weight: 480; }
-.legend-key        { font-weight: 480; }
+    /* ── Group headers — exact match ── */
+    .scp-grp {
+      font-size: 11px; font-weight: 580; color: #64748B;
+      text-transform: uppercase; letter-spacing: 0.06em;
+      padding: 16px 0 6px;
+      display: flex; align-items: center; gap: 8px;
+    }
+    .scp-grp-line { flex: 1; height: 1px; background: #334155; }
 
-a { color: var(--weo-accent-hover); text-decoration: none; }
-a:hover { text-decoration: underline; }
+    .scp-paa-fold { margin: 6px 0 0; border-bottom: 2px solid rgba(245,158,11,0.3); padding-bottom: 6px; }
+    .scp-paa-fold-label { font-size: 10px; color: rgba(245,158,11,0.5); text-align: right; letter-spacing: 0.03em; }
 
-.page-wrap { max-width: 900px; margin: 0 auto; padding: 0 20px 60px; }
+    /* ── Actor rows — uses <details>/<summary> ── */
+    .scp-actor { border-bottom: 1px solid rgba(255,255,255,0.03); }
+    .scp-actor[open] > .scp-row { background: rgba(51,65,85,0.15); }
+    .scp-actor[open] .scp-row-chev { transform: rotate(180deg); color: #94A3B8; }
 
-/* ── Page header ── */
-.page-header {
-  padding: 48px 0 36px;
-  border-bottom: 1px solid var(--weo-border-primary);
-  margin-bottom: 40px;
-}
-.page-header h1 {
-  font-size: 28px; color: var(--weo-text-primary);
-  letter-spacing: -0.02em; margin-bottom: 6px;
-}
-.page-subtitle { font-size: 15px; color: var(--weo-text-secondary); margin-bottom: 18px; }
-.page-framework {
-  font-size: 13px; color: var(--weo-text-secondary); line-height: 1.7;
-  max-width: 720px; margin-bottom: 20px;
-}
-.page-meta {
-  display: flex; gap: 20px; flex-wrap: wrap;
-  font-size: 12px; color: #64748B; margin-bottom: 24px;
-}
+    .scp-row {
+      display: flex; align-items: center; padding: 10px 0;
+      cursor: pointer; transition: background var(--duration-fast) var(--ease-out);
+      list-style: none; /* removes default <summary> marker */
+    }
+    .scp-row::-webkit-details-marker { display: none; }
+    .scp-row::marker { display: none; content: ''; }
+    .scp-row:hover { background: rgba(255,255,255,0.03); }
 
-/* ── Dimension legend ── */
-.legend-heading {
-  font-size: 11px; color: var(--weo-text-muted);
-  letter-spacing: 0.08em; text-transform: uppercase; margin-bottom: 10px;
-}
-.dim-legend {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
-  gap: 6px;
-}
-.legend-item {
-  display: flex; align-items: center; gap: 7px;
-  font-size: 12px; padding: 6px 8px;
-  background: rgba(30,41,59,0.5); border-radius: var(--weo-radius-sm);
-  border: 1px solid var(--weo-border-primary);
-  min-width: 0;
-}
-.legend-dot { width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0; }
-.legend-key {
-  font-family: 'Geist Mono', 'Fira Code', 'Consolas', monospace; font-size: 10px;
-  color: #64748B; flex-shrink: 0; min-width: 20px;
-}
-.legend-name { color: var(--weo-text-muted); flex-shrink: 0; min-width: 100px; }
-.legend-desc {
-  color: #64748B; font-size: 11px;
-  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
-}
+    .scp-row-name {
+      font-size: 14px; font-weight: 480; color: #E2E8F0;
+      width: 160px; flex-shrink: 0;
+      white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+    }
+    .scp-row-bar { display: flex; gap: 3px; flex: 1; max-width: 140px; margin: 0 16px; }
+    .scp-row-seg {
+      flex: 1; height: 9px; border-radius: 2px;
+      background: rgba(255,255,255,0.06);
+      transition: all var(--duration-fast); position: relative;
+    }
+    .scp-row-seg.hw-m { background: var(--scp-hw); }
+    .scp-row-seg.pl-m { background: var(--scp-plat); }
+    .scp-row-seg.gv-m { background: var(--scp-gov); }
+    .scp-row-seg.col-hl { outline: 2px solid rgba(255,255,255,0.5); outline-offset: 1px; z-index: 1; }
+    .scp-row-seg.col-hl.hw-m { outline-color: rgba(96,165,250,0.8); }
+    .scp-row-seg.col-hl.pl-m { outline-color: rgba(167,139,250,0.8); }
+    .scp-row-seg.col-hl.gv-m { outline-color: rgba(45,212,191,0.8); }
+    .scp-row-seg.col-dim { opacity: 0.2; }
 
-/* ── Designation groups ── */
-.desig-section { margin-bottom: 48px; }
-.desig-heading { display: flex; align-items: center; gap: 12px; margin-bottom: 18px; }
-.desig-heading h2 { font-size: 14px; letter-spacing: 0.01em; white-space: nowrap; }
-.desig-line { flex: 1; height: 1px; background: var(--weo-border-primary); }
-.desig-paa .desig-heading h2         { color: var(--scp-paa); }
-.desig-aik .desig-heading h2         { color: var(--scp-aik); }
-.desig-acs .desig-heading h2         { color: var(--scp-acs); }
-.desig-participant .desig-heading h2 { color: var(--scp-part); }
+    .scp-row-score {
+      font-family: 'Geist Mono','Fira Code',monospace;
+      font-size: 13px; font-weight: 480; color: #94A3B8;
+      width: 36px; text-align: right; flex-shrink: 0;
+    }
+    .scp-row-badge { margin-left: 12px; flex-shrink: 0; }
+    .scp-badge {
+      display: inline-block; padding: 3px 10px; border-radius: 12px;
+      font-size: 11px; font-weight: 580; letter-spacing: 0.05em; text-transform: uppercase;
+    }
+    .scp-badge-paa { background: rgba(245,158,11,0.15); color: var(--scp-paa); border: 1px solid rgba(245,158,11,0.35); }
+    .scp-badge-aik { background: rgba(6,182,212,0.12); color: #22D3EE; border: 1px solid rgba(6,182,212,0.3); }
+    .scp-badge-acs { background: rgba(168,85,247,0.12); color: #C084FC; border: 1px solid rgba(168,85,247,0.3); }
+    .scp-badge-part { background: rgba(100,116,139,0.12); color: var(--scp-part); border: 1px solid rgba(100,116,139,0.25); }
 
-/* ── Actor cards ── */
-.actor-card {
-  background: var(--weo-surface-raised);
-  border: 1px solid var(--weo-border-primary);
-  border-radius: var(--weo-radius-md);
-  box-shadow: 0 1px 3px rgba(0,0,0,0.2), 0 0 0 1px rgba(255,255,255,0.03);
-  margin-bottom: 14px; overflow: hidden;
-}
-.actor-header {
-  padding: 14px 20px 12px; border-bottom: 1px solid var(--weo-border-primary);
-}
-.actor-title-row {
-  display: flex; align-items: center; justify-content: space-between;
-  flex-wrap: wrap; gap: 8px; margin-bottom: 10px;
-}
-.actor-name {
-  font-size: 17px; color: var(--weo-text-primary);
-  display: flex; align-items: center; gap: 8px;
-}
-.actor-meta { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
-.actor-score {
-  font-family: 'Geist Mono', 'Fira Code', 'Consolas', monospace; font-size: 13px;
-  color: var(--weo-text-muted);
-  background: rgba(255,255,255,0.05); padding: 2px 8px;
-  border-radius: var(--weo-radius-sm); border: 1px solid var(--weo-border-primary);
-}
-.actor-badge {
-  font-size: 11px; letter-spacing: 0.04em;
-  padding: 3px 10px; border-radius: var(--r-pill); border: 1px solid;
-}
-.badge-paa         { background: rgba(245,158,11,0.15); color: #F59E0B;  border-color: rgba(245,158,11,0.35); }
-.badge-aik         { background: rgba(6,182,212,0.12);  color: #22D3EE;  border-color: rgba(6,182,212,0.3); }
-.badge-acs         { background: rgba(168,85,247,0.12); color: #C084FC;  border-color: rgba(168,85,247,0.3); }
-.badge-participant { background: rgba(100,116,139,0.12); color: #64748B; border-color: rgba(100,116,139,0.25); }
-.sample-badge {
-  font-size: 10px;
-  background: rgba(255,215,0,0.1); color: #FFD700;
-  border: 1px solid rgba(255,215,0,0.25); padding: 1px 6px;
-  border-radius: 3px; letter-spacing: 0.03em;
-}
+    .scp-row-chev { font-size: 10px; color: #475569; margin-left: 10px; transition: transform var(--duration-normal) var(--ease-out); flex-shrink: 0; }
 
-/* ── Dimension bar ── */
-.dim-bar { display: flex; gap: 4px; align-items: center; }
-.dim-bar-dot {
-  width: 10px; height: 10px; border-radius: 50%; border: 1.5px solid;
-  flex-shrink: 0;
-}
-.dim-bar-dot.hw.met  { background: var(--scp-hw); border-color: var(--scp-hw); }
-.dim-bar-dot.pl.met  { background: var(--scp-pl); border-color: var(--scp-pl); }
-.dim-bar-dot.gv.met  { background: var(--scp-gv); border-color: var(--scp-gv); }
-.dim-bar-dot.hw.nmet { background: transparent; border-color: rgba(96,165,250,0.3); }
-.dim-bar-dot.pl.nmet { background: transparent; border-color: rgba(167,139,250,0.3); }
-.dim-bar-dot.gv.nmet { background: transparent; border-color: rgba(45,212,191,0.3); }
+    /* ── Expanded detail — exact match ── */
+    .scp-detail {
+      padding: 10px 16px 18px;
+      background: rgba(15,23,42,0.3);
+    }
+    .scp-dim-row { display: flex; align-items: baseline; justify-content: space-between; padding: 5px 0; font-size: 13px; }
+    .scp-dim-name { color: #94A3B8; display: flex; align-items: center; gap: 7px; }
+    .scp-dim-dot { width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }
+    .scp-dim-dot.hw { background: var(--scp-hw); }
+    .scp-dim-dot.pl { background: var(--scp-plat); }
+    .scp-dim-dot.gv { background: var(--scp-gov); }
+    .scp-dim-st { font-weight: 580; }
+    .scp-dim-met { color: #22C55E; }
+    .scp-dim-not { color: var(--scp-part); }
+    .scp-dim-constraint { font-size: 12px; color: #64748B; padding: 2px 0 5px 13px; font-style: italic; line-height: 1.5; }
+    .scp-dim-qual-hl { font-size: 12px; color: #CBD5E1; padding: 2px 0 5px 13px; line-height: 1.5; }
+    .scp-dim-con-label { font-style: normal; font-weight: 580; color: #94A3B8; letter-spacing: 0.01em; }
 
-/* ── Actor body ── */
-.actor-body { padding: 0 20px 14px; }
+    /* ── Expandable triggers ── */
+    .scp-expand { margin-left: 13px; }
+    .scp-expand summary {
+      font-size: 11px; color: #475569; cursor: pointer;
+      padding: 2px 0; display: inline-flex; align-items: center; gap: 4px;
+      list-style: none; transition: color var(--duration-fast);
+    }
+    .scp-expand summary::-webkit-details-marker { display: none; }
+    .scp-expand summary::marker { display: none; content: ''; }
+    .scp-expand summary:hover { color: #94A3B8; }
 
-/* ── Dimensions list ── */
-.dimensions-list { list-style: none; }
+    .scp-qual-trigger { font-size: 11px; color: #475569; }
+    .scp-src-trigger { font-size: 11px; color: #475569; }
+    .scp-src-icon { font-size: 10px; }
 
-.dim-item { border-bottom: 1px solid rgba(255,255,255,0.04); padding: 9px 0; }
-.dim-item:last-of-type { border-bottom: none; }
+    .scp-qual-block {
+      margin: 4px 0 8px; padding: 10px 14px;
+      background: rgba(15,23,42,0.5); border-radius: var(--weo-radius-sm);
+      border: 1px solid rgba(255,255,255,0.04);
+      font-size: 11px; color: #94A3B8; line-height: 1.6;
+    }
+    .scp-src-block {
+      margin: 4px 0 8px; padding: 10px 14px;
+      background: rgba(15,23,42,0.5); border-radius: var(--weo-radius-sm);
+      border: 1px solid rgba(255,255,255,0.04);
+    }
+    .scp-src-entry { font-size: 11px; color: #94A3B8; line-height: 1.6; margin-bottom: 6px; }
+    .scp-src-entry:last-child { margin-bottom: 0; }
+    .scp-src-label { font-weight: 580; color: #64748B; text-transform: uppercase; letter-spacing: 0.04em; font-size: 10px; }
+    .scp-src-grade { font-family: 'Geist Mono',monospace; font-size: 10px; padding: 1px 6px; border-radius: 3px; margin-right: 4px; font-weight: 480; }
+    .scp-src-g1 { background: rgba(45,212,191,0.12); color: #5EEAD4; }
+    .scp-src-g2 { background: rgba(96,165,250,0.12); color: #93C5FD; }
+    .scp-src-g3 { background: rgba(148,163,184,0.12); color: #94A3B8; }
+    .scp-src-fact { color: #CBD5E1; }
+    .scp-src-link { color: var(--scp-aik); text-decoration: none; font-size: 10px; margin-left: 4px; }
+    .scp-src-link:hover { text-decoration: underline; }
+    .scp-src-lock { font-size: 11px; color: #475569; margin-left: 13px; padding: 3px 0; }
 
-.dim-header {
-  display: flex; align-items: center; gap: 7px;
-  font-size: 13px; flex-wrap: wrap;
-}
-.dim-dot { width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }
-.dim-dot.hw     { background: rgba(96,165,250,0.3); }
-.dim-dot.pl     { background: rgba(167,139,250,0.3); }
-.dim-dot.gv     { background: rgba(45,212,191,0.3); }
-.dim-dot.hw.met { background: var(--scp-hw); }
-.dim-dot.pl.met { background: var(--scp-pl); }
-.dim-dot.gv.met { background: var(--scp-gv); }
-.dim-key {
-  font-family: 'Geist Mono', 'Fira Code', 'Consolas', monospace; font-size: 10px;
-  color: #64748B; flex-shrink: 0; min-width: 20px;
-}
-.dim-name  { color: var(--weo-text-muted); flex: 1; }
-.dim-status { font-size: 11px; flex-shrink: 0; }
-.dim-met   { color: var(--scp-met); }
-.dim-nmet  { color: #64748B; }
+    /* ── AIK Chokepoint ── */
+    .scp-aik {
+      margin-top: 10px; padding: 9px 10px;
+      background: rgba(6,182,212,0.04);
+      border: 1px solid rgba(6,182,212,0.12);
+      border-radius: var(--weo-radius-sm);
+    }
+    .scp-aik-label { font-size: 10px; font-weight: 580; color: #94A3B8; letter-spacing: 0.06em; text-transform: uppercase; margin-bottom: 4px; }
+    .scp-aik-nature { font-size: 13px; color: #CBD5E1; font-weight: 380; line-height: 1.4; }
+    .scp-aik-entities { font-size: 12px; color: #64748B; font-style: italic; font-weight: 380; line-height: 1.5; margin-top: 3px; }
 
-.dim-qual-hl {
-  font-size: 12px; color: var(--weo-text-secondary); line-height: 1.55;
-  padding: 4px 0 2px 13px;
-}
-.dim-constraint {
-  font-size: 12px; color: #64748B; line-height: 1.55;
-  padding: 4px 0 2px 13px; font-style: italic;
-}
-.constraint-label { font-style: normal; color: var(--weo-text-secondary); }
+    /* ── Severance ── */
+    .scp-sev { font-size: 12px; color: #64748B; margin-top: 10px; padding-top: 10px; border-top: 1px solid rgba(255,255,255,0.04); line-height: 1.5; }
+    .scp-sev strong { color: #94A3B8; font-weight: 580; }
 
-.dim-details-dd { padding: 2px 0 2px 13px; }
-details.dim-details summary {
-  font-size: 11px; color: #64748B; cursor: pointer;
-  padding: 3px 0; display: inline-flex; align-items: center; gap: 5px;
-  list-style: none; -webkit-appearance: none; transition: color 0.15s;
-}
-details.dim-details summary::-webkit-details-marker { display: none; }
-details.dim-details summary::before { content: '▸'; font-size: 9px; }
-details.dim-details[open] summary::before { content: '▾'; }
-details.dim-details summary:hover { color: var(--weo-text-muted); }
+    /* ── Participant group ── */
+    .scp-part-group > summary {
+      padding: 10px 0; font-size: 12px; color: #94A3B8;
+      cursor: pointer; display: flex; align-items: center; gap: 6px;
+      border-bottom: 1px solid rgba(255,255,255,0.04);
+      transition: background var(--duration-fast); user-select: none;
+      list-style: none;
+    }
+    .scp-part-group > summary::-webkit-details-marker { display: none; }
+    .scp-part-group > summary::marker { display: none; content: ''; }
+    .scp-part-group > summary:hover { background: rgba(255,255,255,0.03); }
+    .scp-part-arr { font-size: 10px; transition: transform var(--duration-normal) var(--ease-out); display: inline-block; }
+    .scp-part-group[open] .scp-part-arr { transform: rotate(90deg); }
 
-.dim-qual-block {
-  margin-top: 6px; padding: 10px 12px;
-  background: rgba(15,23,42,0.6); border-radius: var(--weo-radius-sm);
-  border: 1px solid var(--weo-border-primary);
-  font-size: 12px; color: var(--weo-text-secondary); line-height: 1.65;
-}
+    /* ── Dimension Watch ── */
+    .scp-watch {
+      margin-top: 32px; padding-top: 24px;
+      border-top: 1px solid rgba(51,65,85,0.5);
+    }
+    .scp-watch-title { font-size: 16px; font-weight: 580; color: #F1F5F9; margin-bottom: 6px; }
+    .scp-watch-desc { font-size: 12px; color: #64748B; margin-bottom: 16px; font-weight: 380; }
+    .scp-watch-wrap { overflow-x: auto; -webkit-overflow-scrolling: touch; }
+    .scp-watch-table { width: 100%; border-collapse: collapse; font-size: 12px; }
+    .scp-watch-table th {
+      text-align: left; font-size: 10px; font-weight: 580;
+      color: #64748B; text-transform: uppercase;
+      letter-spacing: 0.06em; padding: 8px 10px;
+      border-bottom: 1px solid #334155; white-space: nowrap;
+    }
+    .scp-watch-table td {
+      padding: 10px; border-bottom: 1px solid rgba(255,255,255,0.03);
+      vertical-align: top; color: #94A3B8; line-height: 1.5; font-weight: 380;
+    }
+    .scp-watch-table tr:last-child td { border-bottom: none; }
+    .scp-watch-table tr:hover td { background: rgba(255,255,255,0.01); }
+    .scp-watch-actor { color: var(--scp-aik); text-decoration: none; font-weight: 480; }
+    .scp-watch-actor:hover { text-decoration: underline; }
 
-/* ── Sources ── */
-.src-block {
-  margin-top: 6px; padding: 10px 12px;
-  background: rgba(15,23,42,0.6); border-radius: var(--weo-radius-sm);
-  border: 1px solid var(--weo-border-primary);
-}
-.src-entry {
-  padding: 8px 0; border-bottom: 1px solid rgba(255,255,255,0.04);
-}
-.src-entry:last-child { border-bottom: none; padding-bottom: 0; }
-.src-meta {
-  display: flex; flex-wrap: wrap; align-items: center; gap: 8px; margin-bottom: 5px;
-}
-.src-type  { font-size: 10px; color: var(--weo-text-muted); text-transform: uppercase; letter-spacing: 0.05em; }
-.src-grade { font-size: 10px; padding: 1px 7px; border-radius: 3px; }
-.src-pub   { font-size: 11px; color: var(--weo-text-muted); }
-.src-date  { font-size: 10px; color: #64748B; }
-.src-fact  { font-size: 11px; color: var(--weo-text-secondary); line-height: 1.55; margin-bottom: 5px; }
-.src-link  { font-size: 11px; color: var(--weo-accent-hover); }
+    /* ── Footer ── */
+    .scp-page-footer {
+      margin-top: 40px; padding-top: 20px;
+      border-top: 1px solid rgba(51,65,85,0.5);
+    }
+    .scp-footer-cta {
+      font-size: 12px; color: #94A3B8; margin-bottom: 12px;
+      padding: 10px 14px;
+      background: rgba(59,130,246,0.04); border: 1px solid rgba(59,130,246,0.12);
+      border-radius: var(--weo-radius-sm); font-weight: 380;
+    }
+    .scp-footer-links { display: flex; gap: 16px; margin-bottom: 10px; font-size: 12px; }
+    .scp-footer-links a { color: var(--scp-aik); text-decoration: none; }
+    .scp-footer-links a:hover { text-decoration: underline; }
+    .scp-footer-disclaimer {
+      font-size: 10px; color: #94A3B8; line-height: 1.5; opacity: 0.7; font-style: italic;
+    }
+    .scp-footer-version {
+      font-family: 'Geist Mono','Fira Code',monospace;
+      font-size: 10px; font-weight: 480; color: #94A3B8; opacity: 0.5; margin-top: 8px;
+    }
+    .scp-footer-copy { font-size: 11px; color: #64748B; margin-top: 8px; }
 
-/* ── AIK chokepoint ── */
-.aik-profile {
-  margin-top: 12px; padding: 10px 12px;
-  background: rgba(6,182,212,0.06); border: 1px solid rgba(6,182,212,0.15);
-  border-radius: var(--weo-radius-sm);
-}
-.aik-label  {
-  font-size: 10px; color: var(--weo-text-muted);
-  letter-spacing: 0.07em; text-transform: uppercase; margin-bottom: 4px;
-}
-.aik-nature   { font-size: 13px; color: var(--weo-text-secondary); line-height: 1.45; }
-.aik-entities { font-size: 11px; color: #64748B; font-style: italic; line-height: 1.55; margin-top: 3px; }
+    /* ── Responsive ── */
+    @media (max-width: 768px) {
+      .page-wrap { padding: 24px 16px 40px; }
+      .scp-row-name { width: 120px; font-size: 13px; }
+      .scp-row-bar { max-width: 100px; margin: 0 10px; }
+      .nav-links { gap: 10px; font-size: 11px; }
+    }
+    @media (max-width: 480px) {
+      .scp-row-name { width: 100px; font-size: 12px; }
+      .scp-row-bar { max-width: 80px; margin: 0 6px; }
+      .scp-dim-row { font-size: 12px; }
+      .scp-page-title { font-size: 18px; }
+      .page-nav { padding: 10px 16px; }
+    }
 
-/* ── Severance ── */
-.actor-severance {
-  font-size: 12px; color: #64748B; margin-top: 12px;
-  padding-top: 10px; border-top: 1px solid rgba(255,255,255,0.04);
-  line-height: 1.55;
-}
-.sev-label  { color: var(--weo-text-secondary); }
-.sev-pass   { color: var(--scp-met); }
-.sev-fail   { color: #F87171; }
-
-/* ── Dimension watch ── */
-.watch-section {
-  margin-top: 48px; padding-top: 32px; border-top: 1px solid var(--weo-border-primary);
-}
-.watch-section h2 {
-  font-size: 17px; color: var(--weo-text-primary); margin-bottom: 8px;
-}
-.watch-desc { font-size: 13px; color: #64748B; margin-bottom: 16px; }
-.table-wrap { overflow-x: auto; -webkit-overflow-scrolling: touch; }
-.watch-table { width: 100%; border-collapse: collapse; font-size: 12px; }
-.watch-table th {
-  text-align: left; font-size: 10px;
-  color: var(--weo-text-muted); text-transform: uppercase;
-  letter-spacing: 0.06em; padding: 8px 12px;
-  border-bottom: 1px solid var(--weo-border-primary); white-space: nowrap;
-}
-.watch-table td {
-  padding: 10px 12px; border-bottom: 1px solid rgba(255,255,255,0.03);
-  vertical-align: top; color: var(--weo-text-secondary); line-height: 1.5;
-}
-.watch-table tr:last-child td { border-bottom: none; }
-.watch-table tr:hover td { background: rgba(255,255,255,0.01); }
-.dim-ref {
-  font-family: 'Geist Mono', 'Fira Code', 'Consolas', monospace; font-size: 10px;
-  color: var(--weo-text-muted);
-}
-.w-met  { color: var(--scp-met); }
-.w-nmet { color: #64748B; }
-
-/* ── Footer ── */
-.page-footer {
-  margin-top: 56px; padding-top: 24px; border-top: 1px solid var(--weo-border-primary);
-  font-size: 12px; color: #64748B; line-height: 1.8;
-}
-.footer-cta {
-  font-size: 13px; color: var(--weo-text-secondary); margin-bottom: 14px;
-  padding: 10px 14px;
-  background: rgba(96,165,250,0.05); border: 1px solid rgba(96,165,250,0.15);
-  border-radius: var(--weo-radius-sm);
-}
-.footer-links { display: flex; flex-wrap: wrap; gap: 16px; margin-bottom: 12px; }
-.footer-links a { color: var(--weo-accent-hover); }
-.footer-mono {
-  font-family: 'Geist Mono', 'Fira Code', 'Consolas', monospace;
-  font-size: 11px; color: var(--weo-text-muted); opacity: 0.5;
-  letter-spacing: 0.04em;
-}
-
-/* ── Responsive ── */
-@media (max-width: 600px) {
-  .page-header h1 { font-size: 22px; }
-  .actor-title-row { flex-direction: column; align-items: flex-start; }
-  .dim-legend { grid-template-columns: 1fr; }
-  .page-meta { flex-direction: column; gap: 4px; }
-  .actor-name { font-size: 15px; }
-}
-@media (max-width: 375px) {
-  .page-wrap { padding: 0 12px 40px; }
-  .page-header { padding: 32px 0 24px; }
-}
-
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+      }
+    }
   </style>
 </head>
 <body>
+  <nav class="page-nav">
+    <a href="/" class="nav-brand"><span>Warmth Engine Observatory</span></a>
+    <div class="nav-links">
+      <a href="/">Map</a>
+      <a href="/atlas.html">Atlas</a>
+      <a href="/events.html">Events</a>
+      <a href="/profiles/" aria-current="page" style="color:#E2E8F0;">Profiles</a>
+      <a href="/about.html">About</a>
+    </div>
+  </nav>
+
   <div class="page-wrap">
-    <header class="page-header">
-      <h1>Sovereign Capability Profiles</h1>
-      <p class="page-subtitle">Actor Designation Framework — 14 actors assessed</p>
-      <p class="page-framework">The Sovereign Capability Profile (SCP) framework assesses nation-state control of the AI infrastructure stack across seven dimensions: chip design, advanced fabrication, critical equipment, AI compute, frontier models, AI regulation, and sovereign investment. Actors are designated as Principal AI Actors (PAA), AI Infrastructure Keystones (AIK), Advanced Capability States (ACS), or Participants through a three-gate framework evaluating dimensional breadth, severance resilience, and platform sustainability.</p>
-      <div class="page-meta">
-        <span>Assessment date: 2026-05-06</span>
-        <span>Methodology: V1.4</span>
-        <span>Register: SCP-REG-009</span>
-      </div>
-      <p class="legend-heading">Dimensions</p>
-      <div class="dim-legend">
-<div class="legend-item">
-  <span class="legend-dot" style="background:var(--scp-hw);flex-shrink:0;"></span>
-  <span class="legend-key">D1</span>
-  <span class="legend-name">AI Chip Design</span>
-  <span class="legend-desc">Designs and commercially sells training-class AI accelerators under domestic IP control.</span>
-</div>
-<div class="legend-item">
-  <span class="legend-dot" style="background:var(--scp-hw);flex-shrink:0;"></span>
-  <span class="legend-key">D2</span>
-  <span class="legend-name">Advanced Fabrication</span>
-  <span class="legend-desc">Operates production-capable semiconductor fabrication at process nodes of 7nm or below.</span>
-</div>
-<div class="legend-item">
-  <span class="legend-dot" style="background:var(--scp-hw);flex-shrink:0;"></span>
-  <span class="legend-key">D3</span>
-  <span class="legend-name">Critical Equipment</span>
-  <span class="legend-desc">Hosts entities that design and manufacture globally essential semiconductor production equipment or sole-sourced subsystems for advanced fabrication.</span>
-</div>
-<div class="legend-item">
-  <span class="legend-dot" style="background:var(--scp-pl);flex-shrink:0;"></span>
-  <span class="legend-key">D4</span>
-  <span class="legend-name">AI Compute</span>
-  <span class="legend-desc">Hosts hyperscale cloud providers operating AI training infrastructure sufficient to train current-generation frontier models, with compute physically on the actor&#x27;s territory.</span>
-</div>
-<div class="legend-item">
-  <span class="legend-dot" style="background:var(--scp-pl);flex-shrink:0;"></span>
-  <span class="legend-key">D5</span>
-  <span class="legend-name">Frontier Models</span>
-  <span class="legend-desc">Hosts organisations developing state-of-the-art foundation models competitive with the current global frontier across multiple capability domains.</span>
-</div>
-<div class="legend-item">
-  <span class="legend-dot" style="background:var(--scp-gv);flex-shrink:0;"></span>
-  <span class="legend-key">D6</span>
-  <span class="legend-name">AI Regulation</span>
-  <span class="legend-desc">Enforces AI-relevant compliance frameworks with binding obligations for entities outside its own jurisdiction.</span>
-</div>
-<div class="legend-item">
-  <span class="legend-dot" style="background:var(--scp-gv);flex-shrink:0;"></span>
-  <span class="legend-key">D7</span>
-  <span class="legend-name">Sovereign Investment</span>
-  <span class="legend-desc">Operates a national programme directing significant public capital toward AI compute, semiconductor fabrication, or AI-specific physical infrastructure at nationally transformative scale.</span>
-</div>
-</div>
-    </header>
+    <div class="scp-page-header">
+      <h1 class="scp-page-title">Sovereign Capability Profiles</h1>
+      <div class="scp-page-subtitle">Actor Designation Framework — 14 actors assessed</div>
+      <div class="scp-page-meta">Assessment: 2026 05 06 · Methodology V1.4 · SCP-REG-009</div>
+    </div>
 
-    <main>
-<section class="desig-section desig-paa">
-  <div class="desig-heading">
-    <h2>Principal AI Actors (2)</h2>
-    <div class="desig-line"></div>
-  </div>
-  <article id="us" class="actor-card">
-  <header class="actor-header">
-    <div class="actor-title-row">
-      <h3 class="actor-name"><span class="sample-badge">Sample</span> United States</h3>
-      <div class="actor-meta">
-        <span class="actor-score">7/7</span>
-        <span class="actor-badge badge-paa">PAA</span>
-      </div>
-    </div>
-    <div class="dim-bar"><span class="dim-bar-dot hw met" title="D1"></span><span class="dim-bar-dot hw met" title="D2"></span><span class="dim-bar-dot hw met" title="D3"></span><span class="dim-bar-dot pl met" title="D4"></span><span class="dim-bar-dot pl met" title="D5"></span><span class="dim-bar-dot gv met" title="D6"></span><span class="dim-bar-dot gv met" title="D7"></span></div>
-  </header>
-  <div class="actor-body">
-    <dl class="dimensions-list">
-<div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot hw met"></span>
-  <span class="dim-key">D1</span>
-  <span class="dim-name">AI Chip Design</span>
-  <span class="dim-status dim-met">Met</span>
-</dt>
-<dd class="dim-qual-hl">Three independent training-class accelerator programmes — NVIDIA Blackwell Ultra, AMD Instinct, Trainium — under US IP control</dd>
-<dd class="dim-details-dd">
-  <details class="dim-details">
-    <summary>Qualification</summary>
-    <div class="dim-qual-block">NVIDIA Data Centre compute revenue reached US$43.0 billion (Q3 FY2026, up 56%) with Blackwell Ultra as leading architecture. Amazon deployed 1.4 million Trainium chips; combined custom silicon revenue exceeds US$10 billion annually. AMD ships the Instinct MI series. No other jurisdiction hosts more than one competitive programme.</div>
-  </details>
-</dd>
-<dd class="dim-details-dd">
-  <details class="dim-details">
-    <summary>Sources</summary>
-    <div class="src-block"><div class="src-entry">
-  <div class="src-meta">
-    <span class="src-type">Primary</span>
-    <span class="src-grade" style="background:rgba(59,130,246,0.15);color:#3B82F6;border:1px solid rgba(59,130,246,0.35);">Grade 2</span>
-    <span class="src-pub">NVIDIA (SEC 10-Q Q3 FY2026)</span>
-    <span class="src-date">2025-Q3</span>
-  </div>
-  <p class="src-fact">Data Centre compute revenue $43.0 billion, up 56%. Blackwell Ultra leading architecture across all customer categories.</p>
-  <a href="https://investor.nvidia.com/files/doc_financials/2026/q3/13e6981b-95ed-4aac-a602-ebc5865d0590.pdf" class="src-link" target="_blank" rel="noopener noreferrer">View source →</a>
-</div><div class="src-entry">
-  <div class="src-meta">
-    <span class="src-type">Corroborating</span>
-    <span class="src-grade" style="background:rgba(59,130,246,0.15);color:#3B82F6;border:1px solid rgba(59,130,246,0.35);">Grade 2</span>
-    <span class="src-pub">Amazon (SEC 8-K FY2025 Q4)</span>
-    <span class="src-date">2025-Q4</span>
-  </div>
-  <p class="src-fact">Trainium fully subscribed with 1.4 million chips landed across all generations. Combined custom silicon annual revenue run rate over US$10 billion (Trainium, Graviton, Nitro).</p>
-  <a href="https://www.sec.gov/Archives/edgar/data/0001018724/000101872426000002/amzn-20251231xex991.htm" class="src-link" target="_blank" rel="noopener noreferrer">View source →</a>
-</div></div>
-  </details>
-</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot hw met"></span>
-  <span class="dim-key">D2</span>
-  <span class="dim-name">Advanced Fabrication</span>
-  <span class="dim-status dim-met">Met</span>
-</dt>
-<dd class="dim-qual-hl">Intel Fab 52 manufactures Intel 18A wafers and TSMC Arizona is in volume production, both operating on US territory</dd>
-<dd class="dim-details-dd">
-  <details class="dim-details">
-    <summary>Qualification</summary>
-    <div class="dim-qual-block">Intel&#x27;s Fab 52 is fully operational producing Intel 18A wafers — the most advanced logic process manufactured in the United States at time of assessment. TSMC&#x27;s Arizona facility entered volume production in late 2024. Both sites operate on US soil under territorial jurisdiction regardless of corporate parent.</div>
-  </details>
-</dd>
-<dd class="dim-details-dd">
-  <details class="dim-details">
-    <summary>Sources</summary>
-    <div class="src-block"><div class="src-entry">
-  <div class="src-meta">
-    <span class="src-type">Primary</span>
-    <span class="src-grade" style="background:rgba(59,130,246,0.15);color:#3B82F6;border:1px solid rgba(59,130,246,0.35);">Grade 2</span>
-    <span class="src-pub">Intel (SEC 8-K Q3 FY2025)</span>
-    <span class="src-date">2025-Q3</span>
-  </div>
-  <p class="src-fact">Fab 52 fully operational, manufacturing Intel 18A wafers — most advanced logic wafers produced in the United States at time of assessment.</p>
-  <a href="https://www.sec.gov/Archives/edgar/data/0000050863/000005086325000169/q325earningsrelease.htm" class="src-link" target="_blank" rel="noopener noreferrer">View source →</a>
-</div><div class="src-entry">
-  <div class="src-meta">
-    <span class="src-type">Corroborating</span>
-    <span class="src-grade" style="background:rgba(59,130,246,0.15);color:#3B82F6;border:1px solid rgba(59,130,246,0.35);">Grade 2</span>
-    <span class="src-pub">TSMC</span>
-    <span class="src-date">2025-03</span>
-  </div>
-  <p class="src-fact">TSMC Arizona site in volume production since late 2024.</p>
-  <a href="https://pr.tsmc.com/english/news/3210" class="src-link" target="_blank" rel="noopener noreferrer">View source →</a>
-</div></div>
-  </details>
-</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot hw met"></span>
-  <span class="dim-key">D3</span>
-  <span class="dim-name">Critical Equipment</span>
-  <span class="dim-status dim-met">Met</span>
-</dt>
-<dd class="dim-qual-hl">KLA holds 73.8% of the global metrology and inspection market, described as indispensable to advanced process control</dd>
-<dd class="dim-details-dd">
-  <details class="dim-details">
-    <summary>Qualification</summary>
-    <div class="dim-qual-block">KLA increased its metrology and inspection market share from 72.6% in 2024 to 73.8% in 2025. Applied Materials and Lam Research hold dominant positions in deposition and etch respectively. No advanced fabrication facility at any node operates without US-designed process control equipment.</div>
-  </details>
-</dd>
-<dd class="dim-details-dd">
-  <details class="dim-details">
-    <summary>Sources</summary>
-    <div class="src-block"><div class="src-entry">
-  <div class="src-meta">
-    <span class="src-type">Primary</span>
-    <span class="src-grade" style="background:rgba(100,116,139,0.15);color:#94A3B8;border:1px solid rgba(100,116,139,0.3);">Grade 3</span>
-    <span class="src-pub">247 Wall St citing SEMI</span>
-    <span class="src-date">2026-05</span>
-  </div>
-  <p class="src-fact">KLA increased metrology and inspection share from 72.6% in 2024 to 73.8% in 2025.</p>
-  <a href="https://247wallst.com/technology-3/2026/05/04/kla-is-gaining-share-as-ai-chip-complexity-drives-up-yield-costs/" class="src-link" target="_blank" rel="noopener noreferrer">View source →</a>
-</div><div class="src-entry">
-  <div class="src-meta">
-    <span class="src-type">Corroborating</span>
-    <span class="src-grade" style="background:rgba(59,130,246,0.15);color:#3B82F6;border:1px solid rgba(59,130,246,0.35);">Grade 2</span>
-    <span class="src-pub">KLA 2026 Investor Day</span>
-    <span class="src-date">2026-03</span>
-  </div>
-  <p class="src-fact">CEO: KLA is indispensable to advanced process control regardless of fab operator.</p>
-  <a href="https://ir.kla.com/news-events/press-releases/detail/512/kla-hosts-investor-day-announces-7-billion-share" class="src-link" target="_blank" rel="noopener noreferrer">View source →</a>
-</div></div>
-  </details>
-</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot pl met"></span>
-  <span class="dim-key">D4</span>
-  <span class="dim-name">AI Compute</span>
-  <span class="dim-status dim-met">Met</span>
-</dt>
-<dd class="dim-qual-hl">xAI Colossus comprises 100,000 GPUs expanded to 555,000 at 2 GW; multiple US hyperscalers train frontier models on US territory</dd>
-<dd class="dim-details-dd">
-  <details class="dim-details">
-    <summary>Qualification</summary>
-    <div class="dim-qual-block">xAI&#x27;s Colossus cluster operates 100,000 NVIDIA Hopper GPUs, built in 122 days, and expanded to 555,000 GPUs at 2 GW capacity. Anthropic, xAI, Google, and OpenAI all occupy the top tier on Arena Elo rankings. US territory hosts the largest concentration of frontier-class AI training infrastructure globally at time of assessment.</div>
-  </details>
-</dd>
-<dd class="dim-details-dd">
-  <details class="dim-details">
-    <summary>Sources</summary>
-    <div class="src-block"><div class="src-entry">
-  <div class="src-meta">
-    <span class="src-type">Primary</span>
-    <span class="src-grade" style="background:rgba(59,130,246,0.15);color:#3B82F6;border:1px solid rgba(59,130,246,0.35);">Grade 2</span>
-    <span class="src-pub">NVIDIA Newsroom (Colossus/Spectrum-X)</span>
-    <span class="src-date">2026-01</span>
-  </div>
-  <p class="src-fact">xAI Colossus: 100,000 NVIDIA Hopper GPUs, built in 122 days. Expanded to 555,000 GPUs at 2 GW.</p>
-  <a href="https://nvidianews.nvidia.com/news/spectrum-x-ethernet-networking-xai-colossus" class="src-link" target="_blank" rel="noopener noreferrer">View source →</a>
-</div><div class="src-entry">
-  <div class="src-meta">
-    <span class="src-type">Corroborating</span>
-    <span class="src-grade" style="background:rgba(100,116,139,0.15);color:#94A3B8;border:1px solid rgba(100,116,139,0.3);">Grade 3</span>
-    <span class="src-pub">Stanford HAI AI Index 2026</span>
-    <span class="src-date">2026</span>
-  </div>
-  <p class="src-fact">Anthropic, xAI, Google, OpenAI all occupy the top tier on Arena Elo.</p>
-  <a href="https://hai.stanford.edu/ai-index/2026-ai-index-report/technical-performance" class="src-link" target="_blank" rel="noopener noreferrer">View source →</a>
-</div></div>
-  </details>
-</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot pl met"></span>
-  <span class="dim-key">D5</span>
-  <span class="dim-name">Frontier Models</span>
-  <span class="dim-status dim-met">Met</span>
-</dt>
-<dd class="dim-qual-hl">Anthropic, OpenAI, Google, and xAI all occupy the top benchmark tier; no other jurisdiction hosts four frontier labs</dd>
-<dd class="dim-details-dd">
-  <details class="dim-details">
-    <summary>Qualification</summary>
-    <div class="dim-qual-block">Stanford HAI&#x27;s 2026 AI Index confirms Anthropic, xAI, Google, and OpenAI in the top Arena Elo tier. Frontier models gained 30 percentage points on Humanity&#x27;s Last Exam in a single year. Multiple US-headquartered organisations hold frontier positions across reasoning, coding, and knowledge benchmarks.</div>
-  </details>
-</dd>
-<dd class="dim-details-dd">
-  <details class="dim-details">
-    <summary>Sources</summary>
-    <div class="src-block"><div class="src-entry">
-  <div class="src-meta">
-    <span class="src-type">Primary</span>
-    <span class="src-grade" style="background:rgba(100,116,139,0.15);color:#94A3B8;border:1px solid rgba(100,116,139,0.3);">Grade 3</span>
-    <span class="src-pub">Stanford HAI AI Index 2026</span>
-    <span class="src-date">2026</span>
-  </div>
-  <p class="src-fact">Frontier models gained 30 percentage points in a single year on Humanity&#x27;s Last Exam.</p>
-  <a href="https://hai.stanford.edu/ai-index/2026-ai-index-report/technical-performance" class="src-link" target="_blank" rel="noopener noreferrer">View source →</a>
-</div><div class="src-entry">
-  <div class="src-meta">
-    <span class="src-type">Corroborating</span>
-    <span class="src-grade" style="background:rgba(100,116,139,0.15);color:#94A3B8;border:1px solid rgba(100,116,139,0.3);">Grade 3</span>
-    <span class="src-pub">Artificial Analysis / LMArena</span>
-    <span class="src-date">2026-05</span>
-  </div>
-  <p class="src-fact">Multiple US-headquartered models (Anthropic, OpenAI, Google, xAI) at global frontier across reasoning, coding, and knowledge benchmarks.</p>
-  <a href="https://artificialanalysis.ai" class="src-link" target="_blank" rel="noopener noreferrer">View source →</a>
-</div></div>
-  </details>
-</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot gv met"></span>
-  <span class="dim-key">D6</span>
-  <span class="dim-name">AI Regulation</span>
-  <span class="dim-status dim-met">Met</span>
-</dt>
-<dd class="dim-qual-hl">Export controls enforced extraterritorially — Operation Gatekeeper prosecuted US$160 million GPU smuggling conspiracy</dd>
-<dd class="dim-details-dd">
-  <details class="dim-details">
-    <summary>Qualification</summary>
-    <div class="dim-qual-block">The Department of Justice prosecuted conspiracy to export at least US$160 million in controlled GPUs destined for China. Operation Gatekeeper seized over US$50 million in NVIDIA H100 and H200 GPUs and obtained guilty pleas, demonstrating active extraterritorial enforcement of AI-relevant export control instruments.</div>
-  </details>
-</dd>
-<dd class="dim-details-dd">
-  <details class="dim-details">
-    <summary>Sources</summary>
-    <div class="src-block"><div class="src-entry">
-  <div class="src-meta">
-    <span class="src-type">Primary</span>
-    <span class="src-grade" style="background:rgba(245,158,11,0.15);color:#F59E0B;border:1px solid rgba(245,158,11,0.35);">Grade 1</span>
-    <span class="src-pub">US Department of Justice</span>
-    <span class="src-date">2025-11</span>
-  </div>
-  <p class="src-fact">Prosecution for conspiracy to violate export controls by illegally exporting advanced GPUs to the PRC.</p>
-  <a href="https://www.justice.gov/opa/pr/us-citizens-and-chinese-nationals-arrested-exporting-artificial-intelligence-technology" class="src-link" target="_blank" rel="noopener noreferrer">View source →</a>
-</div><div class="src-entry">
-  <div class="src-meta">
-    <span class="src-type">Corroborating</span>
-    <span class="src-grade" style="background:rgba(245,158,11,0.15);color:#F59E0B;border:1px solid rgba(245,158,11,0.35);">Grade 1</span>
-    <span class="src-pub">US Department of Justice (Operation Gatekeeper)</span>
-    <span class="src-date">2025-12</span>
-  </div>
-  <p class="src-fact">Conspiracy to export at least US$160 million in export-controlled NVIDIA H100 and H200 GPUs. Over US$50 million seized. Guilty pleas obtained.</p>
-  <a href="https://www.justice.gov/opa/pr/us-authorities-shut-down-major-china-linked-ai-tech-smuggling-network" class="src-link" target="_blank" rel="noopener noreferrer">View source →</a>
-</div></div>
-  </details>
-</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot gv met"></span>
-  <span class="dim-key">D7</span>
-  <span class="dim-name">Sovereign Investment</span>
-  <span class="dim-status dim-met">Met</span>
-</dt>
-<dd class="dim-qual-hl">CHIPS for America awarded over US$33 billion in fabrication incentives; Intel alone received US$5.7 billion</dd>
-<dd class="dim-details-dd">
-  <details class="dim-details">
-    <summary>Qualification</summary>
-    <div class="dim-qual-block">The CHIPS for America programme awarded over US$33 billion of the US$36 billion in proposed incentives, directed at semiconductor fabrication on US territory. Intel received US$5.695 billion in CHIPS incentives and issued equity instruments. The programme is the largest single sovereign investment in domestic semiconductor manufacturing at time of assessment.</div>
-  </details>
-</dd>
-<dd class="dim-details-dd">
-  <details class="dim-details">
-    <summary>Sources</summary>
-    <div class="src-block"><div class="src-entry">
-  <div class="src-meta">
-    <span class="src-type">Primary</span>
-    <span class="src-grade" style="background:rgba(245,158,11,0.15);color:#F59E0B;border:1px solid rgba(245,158,11,0.35);">Grade 1</span>
-    <span class="src-pub">US Department of Commerce (CHIPS for America)</span>
-    <span class="src-date">2025-01</span>
-  </div>
-  <p class="src-fact">CHIPS for America awarded over $33 billion of the over $36 billion in proposed incentives funding.</p>
-  <a href="https://www.commerce.gov/news/press-releases/2025/01/us-department-commerce-announces-chips-incentives-awards-corning" class="src-link" target="_blank" rel="noopener noreferrer">View source →</a>
-</div><div class="src-entry">
-  <div class="src-meta">
-    <span class="src-type">Corroborating</span>
-    <span class="src-grade" style="background:rgba(59,130,246,0.15);color:#3B82F6;border:1px solid rgba(59,130,246,0.35);">Grade 2</span>
-    <span class="src-pub">Intel (SEC 8-K)</span>
-    <span class="src-date">2025-08-27</span>
-  </div>
-  <p class="src-fact">Intel received $5.695 billion in CHIPS incentives; issued 274.6M shares of common stock and a warrant.</p>
-  <a href="https://www.sec.gov/Archives/edgar/data/0000050863/000005086325000135/intc-20250827.htm" class="src-link" target="_blank" rel="noopener noreferrer">View source →</a>
-</div></div>
-  </details>
-</dd>
-</div>
-    </dl>
-    
-    <div class="actor-severance"><span class="sev-label">Severance:</span> <span class="sev-pass">PASS</span> — All 7 dimensions sustainable under severance. Full-stack ecosystem anchor.</div>
-  </div>
-</article><article id="cn" class="actor-card">
-  <header class="actor-header">
-    <div class="actor-title-row">
-      <h3 class="actor-name">China</h3>
-      <div class="actor-meta">
-        <span class="actor-score">6/7</span>
-        <span class="actor-badge badge-paa">PAA</span>
-      </div>
-    </div>
-    <div class="dim-bar"><span class="dim-bar-dot hw met" title="D1"></span><span class="dim-bar-dot hw met" title="D2"></span><span class="dim-bar-dot hw nmet" title="D3"></span><span class="dim-bar-dot pl met" title="D4"></span><span class="dim-bar-dot pl met" title="D5"></span><span class="dim-bar-dot gv met" title="D6"></span><span class="dim-bar-dot gv met" title="D7"></span></div>
-  </header>
-  <div class="actor-body">
-    <dl class="dimensions-list">
-<div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot hw met"></span>
-  <span class="dim-key">D1</span>
-  <span class="dim-name">AI Chip Design</span>
-  <span class="dim-status dim-met">Met</span>
-</dt>
-<dd class="dim-qual-hl">Huawei&#x27;s Ascend 910B/910C uses the domestically designed DaVinci architecture with confirmed commercial hyperscale deployment</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot hw met"></span>
-  <span class="dim-key">D2</span>
-  <span class="dim-name">Advanced Fabrication</span>
-  <span class="dim-status dim-met">Met</span>
-</dt>
-<dd class="dim-qual-hl">SMIC produces 7nm-class wafers using multi-patterning DUV lithography; DUV-only fabrication with no EUV access</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot hw"></span>
-  <span class="dim-key">D3</span>
-  <span class="dim-name">Critical Equipment</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> No Chinese tool globally non-substitutable at ≤7nm; all functions replaceable by US/Japan/Netherlands alternatives</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot pl met"></span>
-  <span class="dim-key">D4</span>
-  <span class="dim-name">AI Compute</span>
-  <span class="dim-status dim-met">Met</span>
-</dt>
-<dd class="dim-qual-hl">Frontier training on Chinese territory via Ascend clusters and pre-restriction NVIDIA H800; Ascend performance gap persists</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot pl met"></span>
-  <span class="dim-key">D5</span>
-  <span class="dim-name">Frontier Models</span>
-  <span class="dim-status dim-met">Met</span>
-</dt>
-<dd class="dim-qual-hl">Alibaba and DeepSeek place in the top Arena Elo tier alongside US frontier labs across multiple capability domains</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot gv met"></span>
-  <span class="dim-key">D6</span>
-  <span class="dim-name">AI Regulation</span>
-  <span class="dim-status dim-met">Met</span>
-</dt>
-<dd class="dim-qual-hl">Article 49 extends jurisdiction to transfers outside China; REE extraterritorial controls exercised then suspended</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot gv met"></span>
-  <span class="dim-key">D7</span>
-  <span class="dim-name">Sovereign Investment</span>
-  <span class="dim-status dim-met">Met</span>
-</dt>
-<dd class="dim-qual-hl">Big Fund III raised RMB 344 billion (US$47.5 billion) from 19 state-backed investors for semiconductor development</dd>
-</div>
-    </dl>
-    
-    <div class="actor-severance"><span class="sev-label">Severance:</span> <span class="sev-pass">PASS</span></div>
-  </div>
-</article>
-</section>
-<section class="desig-section desig-aik">
-  <div class="desig-heading">
-    <h2>AI Infrastructure Keystones (3)</h2>
-    <div class="desig-line"></div>
-  </div>
-  <article id="jp" class="actor-card">
-  <header class="actor-header">
-    <div class="actor-title-row">
-      <h3 class="actor-name">Japan</h3>
-      <div class="actor-meta">
-        <span class="actor-score">4/7</span>
-        <span class="actor-badge badge-aik">AIK</span>
-      </div>
-    </div>
-    <div class="dim-bar"><span class="dim-bar-dot hw nmet" title="D1"></span><span class="dim-bar-dot hw nmet" title="D2"></span><span class="dim-bar-dot hw met" title="D3"></span><span class="dim-bar-dot pl met" title="D4"></span><span class="dim-bar-dot pl nmet" title="D5"></span><span class="dim-bar-dot gv met" title="D6"></span><span class="dim-bar-dot gv met" title="D7"></span></div>
-  </header>
-  <div class="actor-body">
-    <dl class="dimensions-list">
-<div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot hw"></span>
-  <span class="dim-key">D1</span>
-  <span class="dim-name">AI Chip Design</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Only domestic training accelerator (PFN MN-Core 2) deployed in low thousands; Japan&#x27;s own flagship HPC selects NVIDIA for AI workloads</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot hw"></span>
-  <span class="dim-key">D2</span>
-  <span class="dim-name">Advanced Fabrication</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Zero ≤7nm fabs in volume manufacturing; Rapidus 2nm in pilot only, mass production targeted H2 FY2027</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot hw met"></span>
-  <span class="dim-key">D3</span>
-  <span class="dim-name">Critical Equipment</span>
-  <span class="dim-status dim-met">Met</span>
-</dt>
-<dd class="dim-qual-hl">TEL holds ~100% EUV coater/developer share and Lasertec sole-sources actinic mask inspection; US-dependency exposure documented</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot pl met"></span>
-  <span class="dim-key">D4</span>
-  <span class="dim-name">AI Compute</span>
-  <span class="dim-status dim-met">Met</span>
-</dt>
-<dd class="dim-qual-hl">SoftBank cluster delivers 13.7 ExaFLOPS on Japanese territory; domestically scaled but GPU procurement dependent on US ecosystem</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot pl"></span>
-  <span class="dim-key">D5</span>
-  <span class="dim-name">Frontier Models</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> No Japanese-developed model places in the global top tier on any canonical discriminating benchmark</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot gv met"></span>
-  <span class="dim-key">D6</span>
-  <span class="dim-name">AI Regulation</span>
-  <span class="dim-status dim-met">Met</span>
-</dt>
-<dd class="dim-qual-hl">FEFTA controls 23 types of advanced semiconductor manufacturing equipment; catch-all controls strengthened October 2025</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot gv met"></span>
-  <span class="dim-key">D7</span>
-  <span class="dim-name">Sovereign Investment</span>
-  <span class="dim-status dim-met">Met</span>
-</dt>
-<dd class="dim-qual-hl">AI budgeted support nearly quadrupled to approximately ¥1.23 trillion; Rapidus received ¥2.35 trillion in total state backing</dd>
-</div>
-    </dl>
-    <div class="aik-profile">
-  <div class="aik-label">Chokepoint Profile</div>
-  <div class="aik-nature">Front-end process tools and materials</div>
-  <div class="aik-entities">TEL coater/developer (~90–100% EUV), Lasertec actinic mask inspection (100%), SCREEN single-wafer cleans, Shin-Etsu/JSR/TOK/SUMCO materials</div>
-</div>
-    <div class="actor-severance"><span class="sev-label">Severance:</span> <span class="sev-pass">PASS</span></div>
-  </div>
-</article><article id="kr" class="actor-card">
-  <header class="actor-header">
-    <div class="actor-title-row">
-      <h3 class="actor-name">South Korea</h3>
-      <div class="actor-meta">
-        <span class="actor-score">4/7</span>
-        <span class="actor-badge badge-aik">AIK</span>
-      </div>
-    </div>
-    <div class="dim-bar"><span class="dim-bar-dot hw nmet" title="D1"></span><span class="dim-bar-dot hw met" title="D2"></span><span class="dim-bar-dot hw met" title="D3"></span><span class="dim-bar-dot pl nmet" title="D4"></span><span class="dim-bar-dot pl nmet" title="D5"></span><span class="dim-bar-dot gv met" title="D6"></span><span class="dim-bar-dot gv met" title="D7"></span></div>
-  </header>
-  <div class="actor-body">
-    <dl class="dimensions-list">
-<div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot hw"></span>
-  <span class="dim-key">D1</span>
-  <span class="dim-name">AI Chip Design</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> All shipping Korean-designed accelerators are inference-only; training compute runs on imported NVIDIA silicon</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot hw met"></span>
-  <span class="dim-key">D2</span>
-  <span class="dim-name">Advanced Fabrication</span>
-  <span class="dim-status dim-met">Met</span>
-</dt>
-<dd class="dim-qual-hl">Samsung Foundry produces at 3nm and commenced 2nm GAA mass production; fabrication dependent on imported ASML EUV equipment</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot hw met"></span>
-  <span class="dim-key">D3</span>
-  <span class="dim-name">Critical Equipment</span>
-  <span class="dim-status dim-met">Met</span>
-</dt>
-<dd class="dim-qual-hl">HPSP is sole-source for high-pressure annealing and Hanmi holds 71.2% TC bonder share; FDPR and BIS exposure documented</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot pl"></span>
-  <span class="dim-key">D4</span>
-  <span class="dim-name">AI Compute</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Largest coherent Korean-owned training cluster is ~4,000 GPUs; major facilities are US-hyperscaler-anchored</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot pl"></span>
-  <span class="dim-key">D5</span>
-  <span class="dim-name">Frontier Models</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Best Korean models score ~25-30 points below frontier flagships on aggregated capability leaderboards</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot gv met"></span>
-  <span class="dim-key">D6</span>
-  <span class="dim-name">AI Regulation</span>
-  <span class="dim-status dim-met">Met</span>
-</dt>
-<dd class="dim-qual-hl">AI Basic Act (Law 20676) Article 4(1) applies to acts conducted abroad affecting the Korean domestic market or users</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot gv met"></span>
-  <span class="dim-key">D7</span>
-  <span class="dim-name">Sovereign Investment</span>
-  <span class="dim-status dim-met">Met</span>
-</dt>
-<dd class="dim-qual-hl">KRW 10.1 trillion allocated in the 2026 AI budget; AI Growth Fund expanded to over KRW 150 trillion</dd>
-</div>
-    </dl>
-    <div class="aik-profile">
-  <div class="aik-label">Chokepoint Profile</div>
-  <div class="aik-nature">Memory packaging, fabrication, and sovereign equipment monopolies</div>
-  <div class="aik-entities">HPSP sole-source high-pressure annealing, Hanmi 71.2% TC bonder share, Samsung Foundry 2nm GAA HVM</div>
-</div>
-    <div class="actor-severance"><span class="sev-label">Severance:</span> <span class="sev-pass">PASS</span></div>
-  </div>
-</article><article id="nl" class="actor-card">
-  <header class="actor-header">
-    <div class="actor-title-row">
-      <h3 class="actor-name">Netherlands</h3>
-      <div class="actor-meta">
-        <span class="actor-score">3/7</span>
-        <span class="actor-badge badge-aik">AIK</span>
-      </div>
-    </div>
-    <div class="dim-bar"><span class="dim-bar-dot hw nmet" title="D1"></span><span class="dim-bar-dot hw nmet" title="D2"></span><span class="dim-bar-dot hw met" title="D3"></span><span class="dim-bar-dot pl nmet" title="D4"></span><span class="dim-bar-dot pl nmet" title="D5"></span><span class="dim-bar-dot gv met" title="D6"></span><span class="dim-bar-dot gv met" title="D7"></span></div>
-  </header>
-  <div class="actor-body">
-    <dl class="dimensions-list">
-<div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot hw"></span>
-  <span class="dim-key">D1</span>
-  <span class="dim-name">AI Chip Design</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Dutch chip designers (NXP, Axelera) produce inference/edge silicon only; no training-class accelerator exists</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot hw"></span>
-  <span class="dim-key">D2</span>
-  <span class="dim-name">Advanced Fabrication</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> No ≤7nm fab on Dutch territory; NXP Nijmegen operates at 200mm (~140nm), slated for closure</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot hw met"></span>
-  <span class="dim-key">D3</span>
-  <span class="dim-name">Critical Equipment</span>
-  <span class="dim-status dim-met">Met</span>
-</dt>
-<dd class="dim-qual-hl">ASML holds 100% EUV monopoly and Besi leads hybrid bonding from Dutch territory; Cymer and multiple US leverage vectors documented</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot pl"></span>
-  <span class="dim-key">D4</span>
-  <span class="dim-name">AI Compute</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Nebius Group N.V. Dutch-domiciled; zero qualifying compute on Dutch territory (all operational in Finland)</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot pl"></span>
-  <span class="dim-key">D5</span>
-  <span class="dim-name">Frontier Models</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> GPT-NL targets Dutch-language sovereignty at ~1/100th frontier budget; no Dutch model ranks on global benchmarks</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot gv met"></span>
-  <span class="dim-key">D6</span>
-  <span class="dim-name">AI Regulation</span>
-  <span class="dim-status dim-met">Met</span>
-</dt>
-<dd class="dim-qual-hl">Strategic Goods Decree expanded semiconductor equipment export controls with national authorisation requirements</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot gv met"></span>
-  <span class="dim-key">D7</span>
-  <span class="dim-name">Sovereign Investment</span>
-  <span class="dim-status dim-met">Met</span>
-</dt>
-<dd class="dim-qual-hl">Project Beethoven committed €2.51 billion to the Brainport Eindhoven chip ecosystem; AI Factory received €200 million</dd>
-</div>
-    </dl>
-    <div class="aik-profile">
-  <div class="aik-label">Chokepoint Profile</div>
-  <div class="aik-nature">Core lithography integration and advanced packaging</div>
-  <div class="aik-entities">ASML 100% EUV monopoly, ASM International (ALD/epi), Besi (hybrid bonding)</div>
-</div>
-    <div class="actor-severance"><span class="sev-label">Severance:</span> <span class="sev-pass">PASS</span></div>
-  </div>
-</article>
-</section>
-<section class="desig-section desig-acs">
-  <div class="desig-heading">
-    <h2>Advanced Capability States (2)</h2>
-    <div class="desig-line"></div>
-  </div>
-  <article id="eu" class="actor-card">
-  <header class="actor-header">
-    <div class="actor-title-row">
-      <h3 class="actor-name">European Union</h3>
-      <div class="actor-meta">
-        <span class="actor-score">4/7</span>
-        <span class="actor-badge badge-acs">ACS</span>
-      </div>
-    </div>
-    <div class="dim-bar"><span class="dim-bar-dot hw nmet" title="D1"></span><span class="dim-bar-dot hw met" title="D2"></span><span class="dim-bar-dot hw met" title="D3"></span><span class="dim-bar-dot pl nmet" title="D4"></span><span class="dim-bar-dot pl nmet" title="D5"></span><span class="dim-bar-dot gv met" title="D6"></span><span class="dim-bar-dot gv met" title="D7"></span></div>
-  </header>
-  <div class="actor-body">
-    <dl class="dimensions-list">
-<div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot hw"></span>
-  <span class="dim-key">D1</span>
-  <span class="dim-name">AI Chip Design</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> No EU entity designs a datacenter training accelerator; closest candidate (SiPearl Rhea1) is an HPC CPU for inference</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot hw met"></span>
-  <span class="dim-key">D2</span>
-  <span class="dim-name">Advanced Fabrication</span>
-  <span class="dim-status dim-met">Met</span>
-</dt>
-<dd class="dim-qual-hl">Intel Fab 34 in Ireland is the first European facility using EUV in volume production; the facility is US-owned</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot hw met"></span>
-  <span class="dim-key">D3</span>
-  <span class="dim-name">Critical Equipment</span>
-  <span class="dim-status dim-met">Met</span>
-</dt>
-<dd class="dim-qual-hl">ASML shipped 44 EUV systems as sole global supplier; Zeiss holds 100% EUV optics share — Cymer light source under US jurisdiction</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot pl"></span>
-  <span class="dim-key">D4</span>
-  <span class="dim-name">AI Compute</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Largest EU-controlled coherent training cluster is ~1,016 H100s; frontier training requires 50,000-200,000+</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot pl"></span>
-  <span class="dim-key">D5</span>
-  <span class="dim-name">Frontier Models</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Mistral&#x27;s best model scores 39/100 on composite intelligence index; frontier models score 57-61</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot gv met"></span>
-  <span class="dim-key">D6</span>
-  <span class="dim-name">AI Regulation</span>
-  <span class="dim-status dim-met">Met</span>
-</dt>
-<dd class="dim-qual-hl">EU AI Act Article 2(1)(c) applies to providers placing AI systems on the EU market regardless of establishment location</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot gv met"></span>
-  <span class="dim-key">D7</span>
-  <span class="dim-name">Sovereign Investment</span>
-  <span class="dim-status dim-met">Met</span>
-</dt>
-<dd class="dim-qual-hl">EuroHPC mandate expanded with AI Gigafactories programme; JUPITER operational at exascale, LUMI at pre-exascale</dd>
-</div>
-    </dl>
-    
-    <div class="actor-severance"><span class="sev-label">Severance:</span> <span class="sev-fail">FAIL</span></div>
-  </div>
-</article><article id="tw" class="actor-card">
-  <header class="actor-header">
-    <div class="actor-title-row">
-      <h3 class="actor-name">Taiwan</h3>
-      <div class="actor-meta">
-        <span class="actor-score">3/7</span>
-        <span class="actor-badge badge-acs">ACS</span>
-      </div>
-    </div>
-    <div class="dim-bar"><span class="dim-bar-dot hw nmet" title="D1"></span><span class="dim-bar-dot hw met" title="D2"></span><span class="dim-bar-dot hw met" title="D3"></span><span class="dim-bar-dot pl nmet" title="D4"></span><span class="dim-bar-dot pl nmet" title="D5"></span><span class="dim-bar-dot gv nmet" title="D6"></span><span class="dim-bar-dot gv met" title="D7"></span></div>
-  </header>
-  <div class="actor-body">
-    <dl class="dimensions-list">
-<div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot hw"></span>
-  <span class="dim-key">D1</span>
-  <span class="dim-name">AI Chip Design</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Taiwan&#x27;s ASIC design firms execute foreign clients&#x27; architectures; core accelerator IP remains abroad</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot hw met"></span>
-  <span class="dim-key">D2</span>
-  <span class="dim-name">Advanced Fabrication</span>
-  <span class="dim-status dim-met">Met</span>
-</dt>
-<dd class="dim-qual-hl">TSMC operates 3nm volume production at Fab 18 with N2 GAA on roadmap; fabrication dependent on US-origin equipment and EDA tools</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot hw met"></span>
-  <span class="dim-key">D3</span>
-  <span class="dim-name">Critical Equipment</span>
-  <span class="dim-status dim-met">Met</span>
-</dt>
-<dd class="dim-qual-hl">Gudeng Precision holds approximately 80% of the global EUV photomask pod market and is sole supplier to TSMC</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot pl"></span>
-  <span class="dim-key">D4</span>
-  <span class="dim-name">AI Compute</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Aggregate national compute (~114 PFLOPS) is roughly two orders of magnitude below frontier-training scale</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot pl"></span>
-  <span class="dim-key">D5</span>
-  <span class="dim-name">Frontier Models</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> All domestic models are foreign-base fine-tunes; none rank on any global benchmark leaderboard</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot gv"></span>
-  <span class="dim-key">D6</span>
-  <span class="dim-name">AI Regulation</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Export controls bind domestic exporters only; AI Basic Act is soft law with no extraterritorial reach</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot gv met"></span>
-  <span class="dim-key">D7</span>
-  <span class="dim-name">Sovereign Investment</span>
-  <span class="dim-status dim-met">Met</span>
-</dt>
-<dd class="dim-qual-hl">NT$30–31.1 billion first-year AI strategy allocation under NSTC; FY2026 budget at legislative risk, compute procures NVIDIA GPUs</dd>
-</div>
-    </dl>
-    
-    <div class="actor-severance"><span class="sev-label">Severance:</span> <span class="sev-fail">FAIL</span></div>
-  </div>
-</article>
-</section>
-<section class="desig-section desig-participant">
-  <div class="desig-heading">
-    <h2>Participants (7)</h2>
-    <div class="desig-line"></div>
-  </div>
-  <article id="fr" class="actor-card">
-  <header class="actor-header">
-    <div class="actor-title-row">
-      <h3 class="actor-name">France</h3>
-      <div class="actor-meta">
-        <span class="actor-score">2/7</span>
-        <span class="actor-badge badge-participant">Participant</span>
-      </div>
-    </div>
-    <div class="dim-bar"><span class="dim-bar-dot hw nmet" title="D1"></span><span class="dim-bar-dot hw nmet" title="D2"></span><span class="dim-bar-dot hw nmet" title="D3"></span><span class="dim-bar-dot pl nmet" title="D4"></span><span class="dim-bar-dot pl nmet" title="D5"></span><span class="dim-bar-dot gv met" title="D6"></span><span class="dim-bar-dot gv met" title="D7"></span></div>
-  </header>
-  <div class="actor-body">
-    <dl class="dimensions-list">
-<div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot hw"></span>
-  <span class="dim-key">D1</span>
-  <span class="dim-name">AI Chip Design</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> All French AI chip designs use licensed ARM architecture; no sovereign training-class accelerator exists</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot hw"></span>
-  <span class="dim-key">D2</span>
-  <span class="dim-name">Advanced Fabrication</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Most advanced French volume node is 18nm FD-SOI; no FinFET or GAA fab exists at any node</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot hw"></span>
-  <span class="dim-key">D3</span>
-  <span class="dim-name">Critical Equipment</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Soitec&#x27;s SOI substrates serve 22-90nm nodes, not ≤7nm FinFET/GAA process flows</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot pl"></span>
-  <span class="dim-key">D4</span>
-  <span class="dim-name">AI Compute</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Largest sovereign cluster (Mistral Compute, ~13,800 GB300s) is commissioning, not operational</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot pl"></span>
-  <span class="dim-key">D5</span>
-  <span class="dim-name">Frontier Models</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Mistral scores ~35% below frontier on aggregate intelligence indices across key benchmarks</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot gv met"></span>
-  <span class="dim-key">D6</span>
-  <span class="dim-name">AI Regulation</span>
-  <span class="dim-status dim-met">Met</span>
-</dt>
-<dd class="dim-qual-hl">Exercises EU AI Act authority with demonstrated extraterritorial enforcement — CNIL fined Clearview AI €20 million</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot gv met"></span>
-  <span class="dim-key">D7</span>
-  <span class="dim-name">Sovereign Investment</span>
-  <span class="dim-status dim-met">Met</span>
-</dt>
-<dd class="dim-qual-hl">France 2030 provides a €54 billion investment envelope; national AI strategy spending totals €2.4 billion across two phases</dd>
-</div>
-    </dl>
-    
-    
-  </div>
-</article><article id="de" class="actor-card">
-  <header class="actor-header">
-    <div class="actor-title-row">
-      <h3 class="actor-name">Germany</h3>
-      <div class="actor-meta">
-        <span class="actor-score">2/7</span>
-        <span class="actor-badge badge-participant">Participant</span>
-      </div>
-    </div>
-    <div class="dim-bar"><span class="dim-bar-dot hw nmet" title="D1"></span><span class="dim-bar-dot hw nmet" title="D2"></span><span class="dim-bar-dot hw met" title="D3"></span><span class="dim-bar-dot pl nmet" title="D4"></span><span class="dim-bar-dot pl nmet" title="D5"></span><span class="dim-bar-dot gv met" title="D6"></span><span class="dim-bar-dot gv nmet" title="D7"></span></div>
-  </header>
-  <div class="actor-body">
-    <dl class="dimensions-list">
-<div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot hw"></span>
-  <span class="dim-key">D1</span>
-  <span class="dim-name">AI Chip Design</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> No German entity designs or markets a datacenter AI training accelerator; full NVIDIA dependency for all sovereign compute</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot hw"></span>
-  <span class="dim-key">D2</span>
-  <span class="dim-name">Advanced Fabrication</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> No fab on German territory produces at ≤7nm; Intel Magdeburg cancelled, ESMC Dresden targets ≥12nm only</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot hw met"></span>
-  <span class="dim-key">D3</span>
-  <span class="dim-name">Critical Equipment</span>
-  <span class="dim-status dim-met">Met</span>
-</dt>
-<dd class="dim-qual-hl">Zeiss holds 100% EUV optics share and TRUMPF sole-sources EUV drive lasers; leverage operates through ASML, not independently</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot pl"></span>
-  <span class="dim-key">D4</span>
-  <span class="dim-name">AI Compute</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Largest German-controlled AI cluster (~10,000 GPUs / 0.5 ExaFLOPS) is ~1/10th frontier training scale</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot pl"></span>
-  <span class="dim-key">D5</span>
-  <span class="dim-name">Frontier Models</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> No German-controlled entity produces a top-tier foundation model; Aleph Alpha absorbed by Canadian Cohere (90/10 split)</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot gv met"></span>
-  <span class="dim-key">D6</span>
-  <span class="dim-name">AI Regulation</span>
-  <span class="dim-status dim-met">Met</span>
-</dt>
-<dd class="dim-qual-hl">21st AWV amendment added AI systems and semiconductor technology to the national export control list in July 2024</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot gv"></span>
-  <span class="dim-key">D7</span>
-  <span class="dim-name">Sovereign Investment</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> JUPITER is genuine (~€250M national share) but not &#x27;at scale&#x27;; collapsed Intel subsidy and foreign-controlled ESMC subsidy cannot be credited</dd>
-</div>
-    </dl>
-    
-    
-  </div>
-</article><article id="gb" class="actor-card">
-  <header class="actor-header">
-    <div class="actor-title-row">
-      <h3 class="actor-name">United Kingdom</h3>
-      <div class="actor-meta">
-        <span class="actor-score">1/7</span>
-        <span class="actor-badge badge-participant">Participant</span>
-      </div>
-    </div>
-    <div class="dim-bar"><span class="dim-bar-dot hw nmet" title="D1"></span><span class="dim-bar-dot hw nmet" title="D2"></span><span class="dim-bar-dot hw nmet" title="D3"></span><span class="dim-bar-dot pl nmet" title="D4"></span><span class="dim-bar-dot pl nmet" title="D5"></span><span class="dim-bar-dot gv nmet" title="D6"></span><span class="dim-bar-dot gv met" title="D7"></span></div>
-  </header>
-  <div class="actor-body">
-    <dl class="dimensions-list">
-<div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot hw"></span>
-  <span class="dim-key">D1</span>
-  <span class="dim-name">AI Chip Design</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Sole UK AI accelerator designer (Graphcore) acquired by SoftBank July 2024; no IP-transfer restrictions imposed</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot hw"></span>
-  <span class="dim-key">D2</span>
-  <span class="dim-name">Advanced Fabrication</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> No UK fab operates at or below 7nm; domestic capacity limited to mature and compound semiconductor nodes</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot hw"></span>
-  <span class="dim-key">D3</span>
-  <span class="dim-name">Critical Equipment</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> UK equipment firms serve advanced fabs but none is sole-sourced for ≤7nm lithographic fabrication</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot pl"></span>
-  <span class="dim-key">D4</span>
-  <span class="dim-name">AI Compute</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> No UK-HQ provider operates frontier-training-class compute on UK soil at assessment date; Nscale flagship facility scheduled Q4 2026-Q1 2027</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot pl"></span>
-  <span class="dim-key">D5</span>
-  <span class="dim-name">Frontier Models</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> DeepMind IP owned by Alphabet (US); no independent UK lab ranks top-tier across broad reasoning benchmarks</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot gv"></span>
-  <span class="dim-key">D6</span>
-  <span class="dim-name">AI Regulation</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> No AI-specific binding framework enacted; AISI evaluations voluntary; anticipated UK AI bill did not materialise</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot gv met"></span>
-  <span class="dim-key">D7</span>
-  <span class="dim-name">Sovereign Investment</span>
-  <span class="dim-status dim-met">Met</span>
-</dt>
-<dd class="dim-qual-hl">UK Compute Roadmap commits up to £2 billion for public AI compute infrastructure, confirmed by Parliament</dd>
-</div>
-    </dl>
-    
-    
-  </div>
-</article><article id="in" class="actor-card">
-  <header class="actor-header">
-    <div class="actor-title-row">
-      <h3 class="actor-name">India</h3>
-      <div class="actor-meta">
-        <span class="actor-score">1/7</span>
-        <span class="actor-badge badge-participant">Participant</span>
-      </div>
-    </div>
-    <div class="dim-bar"><span class="dim-bar-dot hw nmet" title="D1"></span><span class="dim-bar-dot hw nmet" title="D2"></span><span class="dim-bar-dot hw nmet" title="D3"></span><span class="dim-bar-dot pl nmet" title="D4"></span><span class="dim-bar-dot pl nmet" title="D5"></span><span class="dim-bar-dot gv nmet" title="D6"></span><span class="dim-bar-dot gv met" title="D7"></span></div>
-  </header>
-  <div class="actor-body">
-    <dl class="dimensions-list">
-<div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot hw"></span>
-  <span class="dim-key">D1</span>
-  <span class="dim-name">AI Chip Design</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> No commercially marketed datacenter AI training accelerator with domestically controlled core microarchitectural IP</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot hw"></span>
-  <span class="dim-key">D2</span>
-  <span class="dim-name">Advanced Fabrication</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> No ≤7nm wafer fab on Indian territory; most advanced approved project (Tata Dholera) targets 28nm-110nm</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot hw"></span>
-  <span class="dim-key">D3</span>
-  <span class="dim-name">Critical Equipment</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> No Indian sole-source position in the ≤7nm semiconductor equipment supply chain</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot pl"></span>
-  <span class="dim-key">D4</span>
-  <span class="dim-name">AI Compute</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Largest sovereign compute allocation (4,096 H100s, IndiaAI Mission) empirically exercised; produced sub-frontier result</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot pl"></span>
-  <span class="dim-key">D5</span>
-  <span class="dim-name">Frontier Models</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Sole candidate (Sarvam-105B) trails absolute May 2026 frontier; independent evaluation limited</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot gv"></span>
-  <span class="dim-key">D6</span>
-  <span class="dim-name">AI Regulation</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> No AI-specific statute in force; DPDPA core obligations delayed to May 2027; IT Rules 2026 limited to content moderation</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot gv met"></span>
-  <span class="dim-key">D7</span>
-  <span class="dim-name">Sovereign Investment</span>
-  <span class="dim-status dim-met">Met</span>
-</dt>
-<dd class="dim-qual-hl">IndiaAI Mission budgets Rs 10,372 crore across seven pillars with a 10,000 GPU target; compute runs on US ecosystem infrastructure</dd>
-</div>
-    </dl>
-    
-    
-  </div>
-</article><article id="il" class="actor-card">
-  <header class="actor-header">
-    <div class="actor-title-row">
-      <h3 class="actor-name">Israel</h3>
-      <div class="actor-meta">
-        <span class="actor-score">1/7</span>
-        <span class="actor-badge badge-participant">Participant</span>
-      </div>
-    </div>
-    <div class="dim-bar"><span class="dim-bar-dot hw nmet" title="D1"></span><span class="dim-bar-dot hw nmet" title="D2"></span><span class="dim-bar-dot hw met" title="D3"></span><span class="dim-bar-dot pl nmet" title="D4"></span><span class="dim-bar-dot pl nmet" title="D5"></span><span class="dim-bar-dot gv nmet" title="D6"></span><span class="dim-bar-dot gv nmet" title="D7"></span></div>
-  </header>
-  <div class="actor-body">
-    <dl class="dimensions-list">
-<div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot hw"></span>
-  <span class="dim-key">D1</span>
-  <span class="dim-name">AI Chip Design</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Habana Labs/Gaudi IP wholly owned by Intel US; no independent Israeli training-class accelerator programme remains</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot hw"></span>
-  <span class="dim-key">D2</span>
-  <span class="dim-name">Advanced Fabrication</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Fab 28 runs Intel 7 (10nm-class DUV, no EUV); Fab 38 frozen since mid-2024 with no restart date</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot hw met"></span>
-  <span class="dim-key">D3</span>
-  <span class="dim-name">Critical Equipment</span>
-  <span class="dim-status dim-met">Met</span>
-</dt>
-<dd class="dim-qual-hl">Nova holds sole-source metrology and Camtek is tool of reference for HBM4; limited to inspection, US-parented entities excluded</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot pl"></span>
-  <span class="dim-key">D4</span>
-  <span class="dim-name">AI Compute</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Largest Israeli-controlled GPU clusters are an order of magnitude below frontier training scale</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot pl"></span>
-  <span class="dim-key">D5</span>
-  <span class="dim-name">Frontier Models</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> AI21 Jamba scores 40-50 percentage points behind frontier benchmarks; company has pivoted away from scale competition</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot gv"></span>
-  <span class="dim-key">D6</span>
-  <span class="dim-name">AI Regulation</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> No enacted AI-specific law with extraterritorial reach; existing controls are privacy-based or dual-use export</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot gv"></span>
-  <span class="dim-key">D7</span>
-  <span class="dim-name">Sovereign Investment</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> ~$140M deployed AI-specific capital over six years; two orders of magnitude below $1B-$10B+ peer programmes</dd>
-</div>
-    </dl>
-    
-    
-  </div>
-</article><article id="ru" class="actor-card">
-  <header class="actor-header">
-    <div class="actor-title-row">
-      <h3 class="actor-name">Russia</h3>
-      <div class="actor-meta">
-        <span class="actor-score">0/7</span>
-        <span class="actor-badge badge-participant">Participant</span>
-      </div>
-    </div>
-    <div class="dim-bar"><span class="dim-bar-dot hw nmet" title="D1"></span><span class="dim-bar-dot hw nmet" title="D2"></span><span class="dim-bar-dot hw nmet" title="D3"></span><span class="dim-bar-dot pl nmet" title="D4"></span><span class="dim-bar-dot pl nmet" title="D5"></span><span class="dim-bar-dot gv nmet" title="D6"></span><span class="dim-bar-dot gv nmet" title="D7"></span></div>
-  </header>
-  <div class="actor-body">
-    <dl class="dimensions-list">
-<div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot hw"></span>
-  <span class="dim-key">D1</span>
-  <span class="dim-name">AI Chip Design</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> No domestically designed training-class accelerator in production; ARM/MIPS licenses revoked, foundry access severed</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot hw"></span>
-  <span class="dim-key">D2</span>
-  <span class="dim-name">Advanced Fabrication</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Most advanced operational node is 90nm at Mikron; state roadmap targets 28nm no earlier than 2028-2030</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot hw"></span>
-  <span class="dim-key">D3</span>
-  <span class="dim-name">Critical Equipment</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Best domestic lithography tool operates at 350nm on 200mm wafers; no global supply role</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot pl"></span>
-  <span class="dim-key">D4</span>
-  <span class="dim-name">AI Compute</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Total national AI compute 0.073 exaflops; largest cluster ~1,600 A100 nodes</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot pl"></span>
-  <span class="dim-key">D5</span>
-  <span class="dim-name">Frontier Models</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Flagship LLMs trail frontier by 34-55% on key benchmarks; two of three built on Chinese Qwen base weights</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot gv"></span>
-  <span class="dim-key">D6</span>
-  <span class="dim-name">AI Regulation</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> No enacted AI-specific extraterritorial framework; enforcement model produces market exit, not foreign compliance</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot gv"></span>
-  <span class="dim-key">D7</span>
-  <span class="dim-name">Sovereign Investment</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Executed federal AI spending ~$80-90M/year; announced budgets systematically revised downward 5-20×</dd>
-</div>
-    </dl>
-    
-    
-  </div>
-</article><article id="ca" class="actor-card">
-  <header class="actor-header">
-    <div class="actor-title-row">
-      <h3 class="actor-name">Canada</h3>
-      <div class="actor-meta">
-        <span class="actor-score">0/7</span>
-        <span class="actor-badge badge-participant">Participant</span>
-      </div>
-    </div>
-    <div class="dim-bar"><span class="dim-bar-dot hw nmet" title="D1"></span><span class="dim-bar-dot hw nmet" title="D2"></span><span class="dim-bar-dot hw nmet" title="D3"></span><span class="dim-bar-dot pl nmet" title="D4"></span><span class="dim-bar-dot pl nmet" title="D5"></span><span class="dim-bar-dot gv nmet" title="D6"></span><span class="dim-bar-dot gv nmet" title="D7"></span></div>
-  </header>
-  <div class="actor-body">
-    <dl class="dimensions-list">
-<div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot hw"></span>
-  <span class="dim-key">D1</span>
-  <span class="dim-name">AI Chip Design</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Tenstorrent redomiciled to Delaware 2023; no Canadian-controlled accelerator in volume production</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot hw"></span>
-  <span class="dim-key">D2</span>
-  <span class="dim-name">Advanced Fabrication</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Zero front-end logic fabs at ≤7nm on Canadian territory; ecosystem is packaging and specialty nodes</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot hw"></span>
-  <span class="dim-key">D3</span>
-  <span class="dim-name">Critical Equipment</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> US-parented entity (Teledyne Technologies); pellicle manufacturing credits to parent jurisdiction</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot pl"></span>
-  <span class="dim-key">D4</span>
-  <span class="dim-name">AI Compute</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> No Canadian-HQ entity operates GPU clusters at frontier-training scale; all hyperscalers US-controlled</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot pl"></span>
-  <span class="dim-key">D5</span>
-  <span class="dim-name">Frontier Models</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> Cohere ranks decisively second-tier on flagship cross-domain benchmarks (GPQA, Arena, SWE-bench)</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot gv"></span>
-  <span class="dim-key">D6</span>
-  <span class="dim-name">AI Regulation</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> AIDA died on the order paper January 2025; ECL export controls bind Canadian exporters only, no extraterritorial reach</dd>
-</div><div class="dim-item">
-<dt class="dim-header">
-  <span class="dim-dot gv"></span>
-  <span class="dim-key">D7</span>
-  <span class="dim-name">Sovereign Investment</span>
-  <span class="dim-status dim-nmet">Not Met</span>
-</dt>
-<dd class="dim-constraint"><span class="constraint-label">Constraint:</span> ~CAD $2.9B over five years (~0.02% GDP/yr); flagship SCIP supercomputer not yet operational</dd>
-</div>
-    </dl>
-    
-    
-  </div>
-</article>
-</section>
+    <div class="scp-pills"><span class="scp-pill hw" data-dim="0"><span class="scp-pill-dot"></span>Chip <span class="scp-pill-ct">2</span></span><span class="scp-pill hw" data-dim="1"><span class="scp-pill-dot"></span>Fab <span class="scp-pill-ct">5</span></span><span class="scp-pill hw" data-dim="2"><span class="scp-pill-dot"></span>Equip <span class="scp-pill-ct">8</span></span><span class="scp-pill pl" data-dim="3"><span class="scp-pill-dot"></span>Compute <span class="scp-pill-ct">3</span></span><span class="scp-pill pl" data-dim="4"><span class="scp-pill-dot"></span>Models <span class="scp-pill-ct">2</span></span><span class="scp-pill gv" data-dim="5"><span class="scp-pill-dot"></span>Reg <span class="scp-pill-ct">8</span></span><span class="scp-pill gv" data-dim="6"><span class="scp-pill-dot"></span>Invest <span class="scp-pill-ct">10</span></span></div><div class="scp-body"><div class="scp-grp">Principal AI Actors (2)<span class="scp-grp-line"></span></div><details class="scp-actor" id="us"><summary class="scp-row"><span class="scp-row-name" title="United States">United States<span style="display:inline-block;vertical-align:super;margin-left:3px;line-height:1;"><svg width="10" height="10" viewBox="0 0 24 24" fill="rgba(255,215,0,0.25)" stroke="#FFD700" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg></span></span><div class="scp-row-bar"><div class="scp-row-seg hw-m" data-di="0"></div><div class="scp-row-seg hw-m" data-di="1"></div><div class="scp-row-seg hw-m" data-di="2"></div><div class="scp-row-seg pl-m" data-di="3"></div><div class="scp-row-seg pl-m" data-di="4"></div><div class="scp-row-seg gv-m" data-di="5"></div><div class="scp-row-seg gv-m" data-di="6"></div></div><span class="scp-row-score">7/7</span><span class="scp-row-badge"><span class="scp-badge scp-badge-paa">PAA</span></span><span class="scp-row-chev">▼</span></summary><div class="scp-detail"><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot hw"></span>AI Chip Design</span><span class="scp-dim-st scp-dim-met">Met</span></div><div class="scp-dim-qual-hl">Three independent training-class accelerator programmes — NVIDIA Blackwell Ultra, AMD Instinct, Trainium — under US IP control</div><details class="scp-expand"><summary class="scp-qual-trigger"><span class="scp-src-icon">▸</span> Qualification</summary><div class="scp-qual-block">NVIDIA Data Centre compute revenue reached US$43.0 billion (Q3 FY2026, up 56%) with Blackwell Ultra as leading architecture. Amazon deployed 1.4 million Trainium chips; combined custom silicon revenue exceeds US$10 billion annually. AMD ships the Instinct MI series. No other jurisdiction hosts more than one competitive programme.</div></details><details class="scp-expand"><summary class="scp-src-trigger"><span class="scp-src-icon">ⓘ</span> Sources</summary><div class="scp-src-block"><div class="scp-src-entry"><span class="scp-src-label">Primary</span> <span class="scp-src-grade scp-src-g2">Grade 2</span>NVIDIA (SEC 10-Q Q3 FY2026) · 2025-Q3 <a href="https://investor.nvidia.com/files/doc_financials/2026/q3/13e6981b-95ed-4aac-a602-ebc5865d0590.pdf" target="_blank" rel="noopener" class="scp-src-link">↗</a><br><span class="scp-src-fact">Data Centre compute revenue $43.0 billion, up 56%. Blackwell Ultra leading architecture across all customer categories.</span></div><div class="scp-src-entry"><span class="scp-src-label">Corroborating</span> <span class="scp-src-grade scp-src-g2">Grade 2</span>Amazon (SEC 8-K FY2025 Q4) · 2025-Q4 <a href="https://www.sec.gov/Archives/edgar/data/0001018724/000101872426000002/amzn-20251231xex991.htm" target="_blank" rel="noopener" class="scp-src-link">↗</a><br><span class="scp-src-fact">Trainium fully subscribed with 1.4 million chips landed across all generations. Combined custom silicon annual revenue run rate over US$10 billion (Trainium, Graviton, Nitro).</span></div></div></details><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot hw"></span>Advanced Fabrication</span><span class="scp-dim-st scp-dim-met">Met</span></div><div class="scp-dim-qual-hl">Intel Fab 52 manufactures Intel 18A wafers and TSMC Arizona is in volume production, both operating on US territory</div><details class="scp-expand"><summary class="scp-qual-trigger"><span class="scp-src-icon">▸</span> Qualification</summary><div class="scp-qual-block">Intel&#x27;s Fab 52 is fully operational producing Intel 18A wafers — the most advanced logic process manufactured in the United States at time of assessment. TSMC&#x27;s Arizona facility entered volume production in late 2024. Both sites operate on US soil under territorial jurisdiction regardless of corporate parent.</div></details><details class="scp-expand"><summary class="scp-src-trigger"><span class="scp-src-icon">ⓘ</span> Sources</summary><div class="scp-src-block"><div class="scp-src-entry"><span class="scp-src-label">Primary</span> <span class="scp-src-grade scp-src-g2">Grade 2</span>Intel (SEC 8-K Q3 FY2025) · 2025-Q3 <a href="https://www.sec.gov/Archives/edgar/data/0000050863/000005086325000169/q325earningsrelease.htm" target="_blank" rel="noopener" class="scp-src-link">↗</a><br><span class="scp-src-fact">Fab 52 fully operational, manufacturing Intel 18A wafers — most advanced logic wafers produced in the United States at time of assessment.</span></div><div class="scp-src-entry"><span class="scp-src-label">Corroborating</span> <span class="scp-src-grade scp-src-g2">Grade 2</span>TSMC · 2025-03 <a href="https://pr.tsmc.com/english/news/3210" target="_blank" rel="noopener" class="scp-src-link">↗</a><br><span class="scp-src-fact">TSMC Arizona site in volume production since late 2024.</span></div></div></details><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot hw"></span>Critical Equipment</span><span class="scp-dim-st scp-dim-met">Met</span></div><div class="scp-dim-qual-hl">KLA holds 73.8% of the global metrology and inspection market, described as indispensable to advanced process control</div><details class="scp-expand"><summary class="scp-qual-trigger"><span class="scp-src-icon">▸</span> Qualification</summary><div class="scp-qual-block">KLA increased its metrology and inspection market share from 72.6% in 2024 to 73.8% in 2025. Applied Materials and Lam Research hold dominant positions in deposition and etch respectively. No advanced fabrication facility at any node operates without US-designed process control equipment.</div></details><details class="scp-expand"><summary class="scp-src-trigger"><span class="scp-src-icon">ⓘ</span> Sources</summary><div class="scp-src-block"><div class="scp-src-entry"><span class="scp-src-label">Primary</span> <span class="scp-src-grade scp-src-g3">Grade 3</span>247 Wall St citing SEMI · 2026-05 <a href="https://247wallst.com/technology-3/2026/05/04/kla-is-gaining-share-as-ai-chip-complexity-drives-up-yield-costs/" target="_blank" rel="noopener" class="scp-src-link">↗</a><br><span class="scp-src-fact">KLA increased metrology and inspection share from 72.6% in 2024 to 73.8% in 2025.</span></div><div class="scp-src-entry"><span class="scp-src-label">Corroborating</span> <span class="scp-src-grade scp-src-g2">Grade 2</span>KLA 2026 Investor Day · 2026-03 <a href="https://ir.kla.com/news-events/press-releases/detail/512/kla-hosts-investor-day-announces-7-billion-share" target="_blank" rel="noopener" class="scp-src-link">↗</a><br><span class="scp-src-fact">CEO: KLA is indispensable to advanced process control regardless of fab operator.</span></div></div></details><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot pl"></span>AI Compute</span><span class="scp-dim-st scp-dim-met">Met</span></div><div class="scp-dim-qual-hl">xAI Colossus comprises 100,000 GPUs expanded to 555,000 at 2 GW; multiple US hyperscalers train frontier models on US territory</div><details class="scp-expand"><summary class="scp-qual-trigger"><span class="scp-src-icon">▸</span> Qualification</summary><div class="scp-qual-block">xAI&#x27;s Colossus cluster operates 100,000 NVIDIA Hopper GPUs, built in 122 days, and expanded to 555,000 GPUs at 2 GW capacity. Anthropic, xAI, Google, and OpenAI all occupy the top tier on Arena Elo rankings. US territory hosts the largest concentration of frontier-class AI training infrastructure globally at time of assessment.</div></details><details class="scp-expand"><summary class="scp-src-trigger"><span class="scp-src-icon">ⓘ</span> Sources</summary><div class="scp-src-block"><div class="scp-src-entry"><span class="scp-src-label">Primary</span> <span class="scp-src-grade scp-src-g2">Grade 2</span>NVIDIA Newsroom (Colossus/Spectrum-X) · 2026-01 <a href="https://nvidianews.nvidia.com/news/spectrum-x-ethernet-networking-xai-colossus" target="_blank" rel="noopener" class="scp-src-link">↗</a><br><span class="scp-src-fact">xAI Colossus: 100,000 NVIDIA Hopper GPUs, built in 122 days. Expanded to 555,000 GPUs at 2 GW.</span></div><div class="scp-src-entry"><span class="scp-src-label">Corroborating</span> <span class="scp-src-grade scp-src-g3">Grade 3</span>Stanford HAI AI Index 2026 · 2026 <a href="https://hai.stanford.edu/ai-index/2026-ai-index-report/technical-performance" target="_blank" rel="noopener" class="scp-src-link">↗</a><br><span class="scp-src-fact">Anthropic, xAI, Google, OpenAI all occupy the top tier on Arena Elo.</span></div></div></details><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot pl"></span>Frontier Models</span><span class="scp-dim-st scp-dim-met">Met</span></div><div class="scp-dim-qual-hl">Anthropic, OpenAI, Google, and xAI all occupy the top benchmark tier; no other jurisdiction hosts four frontier labs</div><details class="scp-expand"><summary class="scp-qual-trigger"><span class="scp-src-icon">▸</span> Qualification</summary><div class="scp-qual-block">Stanford HAI&#x27;s 2026 AI Index confirms Anthropic, xAI, Google, and OpenAI in the top Arena Elo tier. Frontier models gained 30 percentage points on Humanity&#x27;s Last Exam in a single year. Multiple US-headquartered organisations hold frontier positions across reasoning, coding, and knowledge benchmarks.</div></details><details class="scp-expand"><summary class="scp-src-trigger"><span class="scp-src-icon">ⓘ</span> Sources</summary><div class="scp-src-block"><div class="scp-src-entry"><span class="scp-src-label">Primary</span> <span class="scp-src-grade scp-src-g3">Grade 3</span>Stanford HAI AI Index 2026 · 2026 <a href="https://hai.stanford.edu/ai-index/2026-ai-index-report/technical-performance" target="_blank" rel="noopener" class="scp-src-link">↗</a><br><span class="scp-src-fact">Frontier models gained 30 percentage points in a single year on Humanity&#x27;s Last Exam.</span></div><div class="scp-src-entry"><span class="scp-src-label">Corroborating</span> <span class="scp-src-grade scp-src-g3">Grade 3</span>Artificial Analysis / LMArena · 2026-05 <a href="https://artificialanalysis.ai" target="_blank" rel="noopener" class="scp-src-link">↗</a><br><span class="scp-src-fact">Multiple US-headquartered models (Anthropic, OpenAI, Google, xAI) at global frontier across reasoning, coding, and knowledge benchmarks.</span></div></div></details><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot gv"></span>AI Regulation</span><span class="scp-dim-st scp-dim-met">Met</span></div><div class="scp-dim-qual-hl">Export controls enforced extraterritorially — Operation Gatekeeper prosecuted US$160 million GPU smuggling conspiracy</div><details class="scp-expand"><summary class="scp-qual-trigger"><span class="scp-src-icon">▸</span> Qualification</summary><div class="scp-qual-block">The Department of Justice prosecuted conspiracy to export at least US$160 million in controlled GPUs destined for China. Operation Gatekeeper seized over US$50 million in NVIDIA H100 and H200 GPUs and obtained guilty pleas, demonstrating active extraterritorial enforcement of AI-relevant export control instruments.</div></details><details class="scp-expand"><summary class="scp-src-trigger"><span class="scp-src-icon">ⓘ</span> Sources</summary><div class="scp-src-block"><div class="scp-src-entry"><span class="scp-src-label">Primary</span> <span class="scp-src-grade scp-src-g1">Grade 1</span>US Department of Justice · 2025-11 <a href="https://www.justice.gov/opa/pr/us-citizens-and-chinese-nationals-arrested-exporting-artificial-intelligence-technology" target="_blank" rel="noopener" class="scp-src-link">↗</a><br><span class="scp-src-fact">Prosecution for conspiracy to violate export controls by illegally exporting advanced GPUs to the PRC.</span></div><div class="scp-src-entry"><span class="scp-src-label">Corroborating</span> <span class="scp-src-grade scp-src-g1">Grade 1</span>US Department of Justice (Operation Gatekeeper) · 2025-12 <a href="https://www.justice.gov/opa/pr/us-authorities-shut-down-major-china-linked-ai-tech-smuggling-network" target="_blank" rel="noopener" class="scp-src-link">↗</a><br><span class="scp-src-fact">Conspiracy to export at least US$160 million in export-controlled NVIDIA H100 and H200 GPUs. Over US$50 million seized. Guilty pleas obtained.</span></div></div></details><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot gv"></span>Sovereign Investment</span><span class="scp-dim-st scp-dim-met">Met</span></div><div class="scp-dim-qual-hl">CHIPS for America awarded over US$33 billion in fabrication incentives; Intel alone received US$5.7 billion</div><details class="scp-expand"><summary class="scp-qual-trigger"><span class="scp-src-icon">▸</span> Qualification</summary><div class="scp-qual-block">The CHIPS for America programme awarded over US$33 billion of the US$36 billion in proposed incentives, directed at semiconductor fabrication on US territory. Intel received US$5.695 billion in CHIPS incentives and issued equity instruments. The programme is the largest single sovereign investment in domestic semiconductor manufacturing at time of assessment.</div></details><details class="scp-expand"><summary class="scp-src-trigger"><span class="scp-src-icon">ⓘ</span> Sources</summary><div class="scp-src-block"><div class="scp-src-entry"><span class="scp-src-label">Primary</span> <span class="scp-src-grade scp-src-g1">Grade 1</span>US Department of Commerce (CHIPS for America) · 2025-01 <a href="https://www.commerce.gov/news/press-releases/2025/01/us-department-commerce-announces-chips-incentives-awards-corning" target="_blank" rel="noopener" class="scp-src-link">↗</a><br><span class="scp-src-fact">CHIPS for America awarded over $33 billion of the over $36 billion in proposed incentives funding.</span></div><div class="scp-src-entry"><span class="scp-src-label">Corroborating</span> <span class="scp-src-grade scp-src-g2">Grade 2</span>Intel (SEC 8-K) · 2025-08-27 <a href="https://www.sec.gov/Archives/edgar/data/0000050863/000005086325000135/intc-20250827.htm" target="_blank" rel="noopener" class="scp-src-link">↗</a><br><span class="scp-src-fact">Intel received $5.695 billion in CHIPS incentives; issued 274.6M shares of common stock and a warrant.</span></div></div></details><div class="scp-sev"><strong>Severance:</strong> All 7 dimensions sustainable under severance. Full-stack ecosystem anchor.</div></div></details><details class="scp-actor" id="cn"><summary class="scp-row"><span class="scp-row-name" title="China">China</span><div class="scp-row-bar"><div class="scp-row-seg hw-m" data-di="0"></div><div class="scp-row-seg hw-m" data-di="1"></div><div class="scp-row-seg" data-di="2"></div><div class="scp-row-seg pl-m" data-di="3"></div><div class="scp-row-seg pl-m" data-di="4"></div><div class="scp-row-seg gv-m" data-di="5"></div><div class="scp-row-seg gv-m" data-di="6"></div></div><span class="scp-row-score">6/7</span><span class="scp-row-badge"><span class="scp-badge scp-badge-paa">PAA</span></span><span class="scp-row-chev">▼</span></summary><div class="scp-detail"><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot hw"></span>AI Chip Design</span><span class="scp-dim-st scp-dim-met">Met</span></div><div class="scp-dim-qual-hl">Huawei&#x27;s Ascend 910B/910C uses the domestically designed DaVinci architecture with confirmed commercial hyperscale deployment</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot hw"></span>Advanced Fabrication</span><span class="scp-dim-st scp-dim-met">Met</span></div><div class="scp-dim-qual-hl">SMIC produces 7nm-class wafers using multi-patterning DUV lithography; DUV-only fabrication with no EUV access</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot hw"></span>Critical Equipment</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> No Chinese tool globally non-substitutable at ≤7nm; all functions replaceable by US/Japan/Netherlands alternatives</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot pl"></span>AI Compute</span><span class="scp-dim-st scp-dim-met">Met</span></div><div class="scp-dim-qual-hl">Frontier training on Chinese territory via Ascend clusters and pre-restriction NVIDIA H800; Ascend performance gap persists</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot pl"></span>Frontier Models</span><span class="scp-dim-st scp-dim-met">Met</span></div><div class="scp-dim-qual-hl">Alibaba and DeepSeek place in the top Arena Elo tier alongside US frontier labs across multiple capability domains</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot gv"></span>AI Regulation</span><span class="scp-dim-st scp-dim-met">Met</span></div><div class="scp-dim-qual-hl">Article 49 extends jurisdiction to transfers outside China; REE extraterritorial controls exercised then suspended</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot gv"></span>Sovereign Investment</span><span class="scp-dim-st scp-dim-met">Met</span></div><div class="scp-dim-qual-hl">Big Fund III raised RMB 344 billion (US$47.5 billion) from 19 state-backed investors for semiconductor development</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-src-lock">🔒 Severance analysis (supporter access)</div></div></details><div class="scp-paa-fold"><div class="scp-paa-fold-label">Ecosystem anchors</div></div><div class="scp-grp">AI Infrastructure Keystones (3)<span class="scp-grp-line"></span></div><details class="scp-actor" id="jp"><summary class="scp-row"><span class="scp-row-name" title="Japan">Japan</span><div class="scp-row-bar"><div class="scp-row-seg" data-di="0"></div><div class="scp-row-seg" data-di="1"></div><div class="scp-row-seg hw-m" data-di="2"></div><div class="scp-row-seg pl-m" data-di="3"></div><div class="scp-row-seg" data-di="4"></div><div class="scp-row-seg gv-m" data-di="5"></div><div class="scp-row-seg gv-m" data-di="6"></div></div><span class="scp-row-score">4/7</span><span class="scp-row-badge"><span class="scp-badge scp-badge-aik">AIK</span></span><span class="scp-row-chev">▼</span></summary><div class="scp-detail"><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot hw"></span>AI Chip Design</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> Only domestic training accelerator (PFN MN-Core 2) deployed in low thousands; Japan&#x27;s own flagship HPC selects NVIDIA for AI workloads</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot hw"></span>Advanced Fabrication</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> Zero ≤7nm fabs in volume manufacturing; Rapidus 2nm in pilot only, mass production targeted H2 FY2027</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot hw"></span>Critical Equipment</span><span class="scp-dim-st scp-dim-met">Met</span></div><div class="scp-dim-qual-hl">TEL holds ~100% EUV coater/developer share and Lasertec sole-sources actinic mask inspection; US-dependency exposure documented</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot pl"></span>AI Compute</span><span class="scp-dim-st scp-dim-met">Met</span></div><div class="scp-dim-qual-hl">SoftBank cluster delivers 13.7 ExaFLOPS on Japanese territory; domestically scaled but GPU procurement dependent on US ecosystem</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot pl"></span>Frontier Models</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> No Japanese-developed model places in the global top tier on any canonical discriminating benchmark</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot gv"></span>AI Regulation</span><span class="scp-dim-st scp-dim-met">Met</span></div><div class="scp-dim-qual-hl">FEFTA controls 23 types of advanced semiconductor manufacturing equipment; catch-all controls strengthened October 2025</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot gv"></span>Sovereign Investment</span><span class="scp-dim-st scp-dim-met">Met</span></div><div class="scp-dim-qual-hl">AI budgeted support nearly quadrupled to approximately ¥1.23 trillion; Rapidus received ¥2.35 trillion in total state backing</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-aik"><div class="scp-aik-label">Chokepoint Profile</div><div class="scp-aik-nature">Front-end process tools and materials</div><div class="scp-aik-entities">TEL coater/developer (~90–100% EUV), Lasertec actinic mask inspection (100%), SCREEN single-wafer cleans, Shin-Etsu/JSR/TOK/SUMCO materials</div></div><div class="scp-src-lock">🔒 Severance analysis (supporter access)</div></div></details><details class="scp-actor" id="kr"><summary class="scp-row"><span class="scp-row-name" title="South Korea">South Korea</span><div class="scp-row-bar"><div class="scp-row-seg" data-di="0"></div><div class="scp-row-seg hw-m" data-di="1"></div><div class="scp-row-seg hw-m" data-di="2"></div><div class="scp-row-seg" data-di="3"></div><div class="scp-row-seg" data-di="4"></div><div class="scp-row-seg gv-m" data-di="5"></div><div class="scp-row-seg gv-m" data-di="6"></div></div><span class="scp-row-score">4/7</span><span class="scp-row-badge"><span class="scp-badge scp-badge-aik">AIK</span></span><span class="scp-row-chev">▼</span></summary><div class="scp-detail"><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot hw"></span>AI Chip Design</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> All shipping Korean-designed accelerators are inference-only; training compute runs on imported NVIDIA silicon</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot hw"></span>Advanced Fabrication</span><span class="scp-dim-st scp-dim-met">Met</span></div><div class="scp-dim-qual-hl">Samsung Foundry produces at 3nm and commenced 2nm GAA mass production; fabrication dependent on imported ASML EUV equipment</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot hw"></span>Critical Equipment</span><span class="scp-dim-st scp-dim-met">Met</span></div><div class="scp-dim-qual-hl">HPSP is sole-source for high-pressure annealing and Hanmi holds 71.2% TC bonder share; FDPR and BIS exposure documented</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot pl"></span>AI Compute</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> Largest coherent Korean-owned training cluster is ~4,000 GPUs; major facilities are US-hyperscaler-anchored</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot pl"></span>Frontier Models</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> Best Korean models score ~25-30 points below frontier flagships on aggregated capability leaderboards</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot gv"></span>AI Regulation</span><span class="scp-dim-st scp-dim-met">Met</span></div><div class="scp-dim-qual-hl">AI Basic Act (Law 20676) Article 4(1) applies to acts conducted abroad affecting the Korean domestic market or users</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot gv"></span>Sovereign Investment</span><span class="scp-dim-st scp-dim-met">Met</span></div><div class="scp-dim-qual-hl">KRW 10.1 trillion allocated in the 2026 AI budget; AI Growth Fund expanded to over KRW 150 trillion</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-aik"><div class="scp-aik-label">Chokepoint Profile</div><div class="scp-aik-nature">Memory packaging, fabrication, and sovereign equipment monopolies</div><div class="scp-aik-entities">HPSP sole-source high-pressure annealing, Hanmi 71.2% TC bonder share, Samsung Foundry 2nm GAA HVM</div></div><div class="scp-src-lock">🔒 Severance analysis (supporter access)</div></div></details><details class="scp-actor" id="nl"><summary class="scp-row"><span class="scp-row-name" title="Netherlands">Netherlands</span><div class="scp-row-bar"><div class="scp-row-seg" data-di="0"></div><div class="scp-row-seg" data-di="1"></div><div class="scp-row-seg hw-m" data-di="2"></div><div class="scp-row-seg" data-di="3"></div><div class="scp-row-seg" data-di="4"></div><div class="scp-row-seg gv-m" data-di="5"></div><div class="scp-row-seg gv-m" data-di="6"></div></div><span class="scp-row-score">3/7</span><span class="scp-row-badge"><span class="scp-badge scp-badge-aik">AIK</span></span><span class="scp-row-chev">▼</span></summary><div class="scp-detail"><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot hw"></span>AI Chip Design</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> Dutch chip designers (NXP, Axelera) produce inference/edge silicon only; no training-class accelerator exists</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot hw"></span>Advanced Fabrication</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> No ≤7nm fab on Dutch territory; NXP Nijmegen operates at 200mm (~140nm), slated for closure</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot hw"></span>Critical Equipment</span><span class="scp-dim-st scp-dim-met">Met</span></div><div class="scp-dim-qual-hl">ASML holds 100% EUV monopoly and Besi leads hybrid bonding from Dutch territory; Cymer and multiple US leverage vectors documented</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot pl"></span>AI Compute</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> Nebius Group N.V. Dutch-domiciled; zero qualifying compute on Dutch territory (all operational in Finland)</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot pl"></span>Frontier Models</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> GPT-NL targets Dutch-language sovereignty at ~1/100th frontier budget; no Dutch model ranks on global benchmarks</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot gv"></span>AI Regulation</span><span class="scp-dim-st scp-dim-met">Met</span></div><div class="scp-dim-qual-hl">Strategic Goods Decree expanded semiconductor equipment export controls with national authorisation requirements</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot gv"></span>Sovereign Investment</span><span class="scp-dim-st scp-dim-met">Met</span></div><div class="scp-dim-qual-hl">Project Beethoven committed €2.51 billion to the Brainport Eindhoven chip ecosystem; AI Factory received €200 million</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-aik"><div class="scp-aik-label">Chokepoint Profile</div><div class="scp-aik-nature">Core lithography integration and advanced packaging</div><div class="scp-aik-entities">ASML 100% EUV monopoly, ASM International (ALD/epi), Besi (hybrid bonding)</div></div><div class="scp-src-lock">🔒 Severance analysis (supporter access)</div></div></details><div class="scp-grp">Advanced Capability States (2)<span class="scp-grp-line"></span></div><details class="scp-actor" id="eu"><summary class="scp-row"><span class="scp-row-name" title="European Union">European Union</span><div class="scp-row-bar"><div class="scp-row-seg" data-di="0"></div><div class="scp-row-seg hw-m" data-di="1"></div><div class="scp-row-seg hw-m" data-di="2"></div><div class="scp-row-seg" data-di="3"></div><div class="scp-row-seg" data-di="4"></div><div class="scp-row-seg gv-m" data-di="5"></div><div class="scp-row-seg gv-m" data-di="6"></div></div><span class="scp-row-score">4/7</span><span class="scp-row-badge"><span class="scp-badge scp-badge-acs">ACS</span></span><span class="scp-row-chev">▼</span></summary><div class="scp-detail"><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot hw"></span>AI Chip Design</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> No EU entity designs a datacenter training accelerator; closest candidate (SiPearl Rhea1) is an HPC CPU for inference</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot hw"></span>Advanced Fabrication</span><span class="scp-dim-st scp-dim-met">Met</span></div><div class="scp-dim-qual-hl">Intel Fab 34 in Ireland is the first European facility using EUV in volume production; the facility is US-owned</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot hw"></span>Critical Equipment</span><span class="scp-dim-st scp-dim-met">Met</span></div><div class="scp-dim-qual-hl">ASML shipped 44 EUV systems as sole global supplier; Zeiss holds 100% EUV optics share — Cymer light source under US jurisdiction</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot pl"></span>AI Compute</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> Largest EU-controlled coherent training cluster is ~1,016 H100s; frontier training requires 50,000-200,000+</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot pl"></span>Frontier Models</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> Mistral&#x27;s best model scores 39/100 on composite intelligence index; frontier models score 57-61</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot gv"></span>AI Regulation</span><span class="scp-dim-st scp-dim-met">Met</span></div><div class="scp-dim-qual-hl">EU AI Act Article 2(1)(c) applies to providers placing AI systems on the EU market regardless of establishment location</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot gv"></span>Sovereign Investment</span><span class="scp-dim-st scp-dim-met">Met</span></div><div class="scp-dim-qual-hl">EuroHPC mandate expanded with AI Gigafactories programme; JUPITER operational at exascale, LUMI at pre-exascale</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-src-lock">🔒 Severance analysis (supporter access)</div></div></details><details class="scp-actor" id="tw"><summary class="scp-row"><span class="scp-row-name" title="Taiwan">Taiwan</span><div class="scp-row-bar"><div class="scp-row-seg" data-di="0"></div><div class="scp-row-seg hw-m" data-di="1"></div><div class="scp-row-seg hw-m" data-di="2"></div><div class="scp-row-seg" data-di="3"></div><div class="scp-row-seg" data-di="4"></div><div class="scp-row-seg" data-di="5"></div><div class="scp-row-seg gv-m" data-di="6"></div></div><span class="scp-row-score">3/7</span><span class="scp-row-badge"><span class="scp-badge scp-badge-acs">ACS</span></span><span class="scp-row-chev">▼</span></summary><div class="scp-detail"><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot hw"></span>AI Chip Design</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> Taiwan&#x27;s ASIC design firms execute foreign clients&#x27; architectures; core accelerator IP remains abroad</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot hw"></span>Advanced Fabrication</span><span class="scp-dim-st scp-dim-met">Met</span></div><div class="scp-dim-qual-hl">TSMC operates 3nm volume production at Fab 18 with N2 GAA on roadmap; fabrication dependent on US-origin equipment and EDA tools</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot hw"></span>Critical Equipment</span><span class="scp-dim-st scp-dim-met">Met</span></div><div class="scp-dim-qual-hl">Gudeng Precision holds approximately 80% of the global EUV photomask pod market and is sole supplier to TSMC</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot pl"></span>AI Compute</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> Aggregate national compute (~114 PFLOPS) is roughly two orders of magnitude below frontier-training scale</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot pl"></span>Frontier Models</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> All domestic models are foreign-base fine-tunes; none rank on any global benchmark leaderboard</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot gv"></span>AI Regulation</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> Export controls bind domestic exporters only; AI Basic Act is soft law with no extraterritorial reach</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot gv"></span>Sovereign Investment</span><span class="scp-dim-st scp-dim-met">Met</span></div><div class="scp-dim-qual-hl">NT$30–31.1 billion first-year AI strategy allocation under NSTC; FY2026 budget at legislative risk, compute procures NVIDIA GPUs</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-src-lock">🔒 Severance analysis (supporter access)</div></div></details><details class="scp-part-group"><summary class="scp-part-toggle"><span class="scp-part-arr">▶</span> 7 Participants</summary><div class="scp-part-rows"><details class="scp-actor" id="fr"><summary class="scp-row"><span class="scp-row-name" title="France">France</span><div class="scp-row-bar"><div class="scp-row-seg" data-di="0"></div><div class="scp-row-seg" data-di="1"></div><div class="scp-row-seg" data-di="2"></div><div class="scp-row-seg" data-di="3"></div><div class="scp-row-seg" data-di="4"></div><div class="scp-row-seg gv-m" data-di="5"></div><div class="scp-row-seg gv-m" data-di="6"></div></div><span class="scp-row-score">2/7</span><span class="scp-row-badge"><span class="scp-badge scp-badge-part">Part</span></span><span class="scp-row-chev">▼</span></summary><div class="scp-detail"><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot hw"></span>AI Chip Design</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> All French AI chip designs use licensed ARM architecture; no sovereign training-class accelerator exists</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot hw"></span>Advanced Fabrication</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> Most advanced French volume node is 18nm FD-SOI; no FinFET or GAA fab exists at any node</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot hw"></span>Critical Equipment</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> Soitec&#x27;s SOI substrates serve 22-90nm nodes, not ≤7nm FinFET/GAA process flows</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot pl"></span>AI Compute</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> Largest sovereign cluster (Mistral Compute, ~13,800 GB300s) is commissioning, not operational</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot pl"></span>Frontier Models</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> Mistral scores ~35% below frontier on aggregate intelligence indices across key benchmarks</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot gv"></span>AI Regulation</span><span class="scp-dim-st scp-dim-met">Met</span></div><div class="scp-dim-qual-hl">Exercises EU AI Act authority with demonstrated extraterritorial enforcement — CNIL fined Clearview AI €20 million</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot gv"></span>Sovereign Investment</span><span class="scp-dim-st scp-dim-met">Met</span></div><div class="scp-dim-qual-hl">France 2030 provides a €54 billion investment envelope; national AI strategy spending totals €2.4 billion across two phases</div><div class="scp-src-lock">🔒 Sources (supporter access)</div></div></details><details class="scp-actor" id="de"><summary class="scp-row"><span class="scp-row-name" title="Germany">Germany</span><div class="scp-row-bar"><div class="scp-row-seg" data-di="0"></div><div class="scp-row-seg" data-di="1"></div><div class="scp-row-seg hw-m" data-di="2"></div><div class="scp-row-seg" data-di="3"></div><div class="scp-row-seg" data-di="4"></div><div class="scp-row-seg gv-m" data-di="5"></div><div class="scp-row-seg" data-di="6"></div></div><span class="scp-row-score">2/7</span><span class="scp-row-badge"><span class="scp-badge scp-badge-part">Part</span></span><span class="scp-row-chev">▼</span></summary><div class="scp-detail"><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot hw"></span>AI Chip Design</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> No German entity designs or markets a datacenter AI training accelerator; full NVIDIA dependency for all sovereign compute</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot hw"></span>Advanced Fabrication</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> No fab on German territory produces at ≤7nm; Intel Magdeburg cancelled, ESMC Dresden targets ≥12nm only</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot hw"></span>Critical Equipment</span><span class="scp-dim-st scp-dim-met">Met</span></div><div class="scp-dim-qual-hl">Zeiss holds 100% EUV optics share and TRUMPF sole-sources EUV drive lasers; leverage operates through ASML, not independently</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot pl"></span>AI Compute</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> Largest German-controlled AI cluster (~10,000 GPUs / 0.5 ExaFLOPS) is ~1/10th frontier training scale</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot pl"></span>Frontier Models</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> No German-controlled entity produces a top-tier foundation model; Aleph Alpha absorbed by Canadian Cohere (90/10 split)</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot gv"></span>AI Regulation</span><span class="scp-dim-st scp-dim-met">Met</span></div><div class="scp-dim-qual-hl">21st AWV amendment added AI systems and semiconductor technology to the national export control list in July 2024</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot gv"></span>Sovereign Investment</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> JUPITER is genuine (~€250M national share) but not &#x27;at scale&#x27;; collapsed Intel subsidy and foreign-controlled ESMC subsidy cannot be credited</div><div class="scp-src-lock">🔒 Sources (supporter access)</div></div></details><details class="scp-actor" id="gb"><summary class="scp-row"><span class="scp-row-name" title="United Kingdom">United Kingdom</span><div class="scp-row-bar"><div class="scp-row-seg" data-di="0"></div><div class="scp-row-seg" data-di="1"></div><div class="scp-row-seg" data-di="2"></div><div class="scp-row-seg" data-di="3"></div><div class="scp-row-seg" data-di="4"></div><div class="scp-row-seg" data-di="5"></div><div class="scp-row-seg gv-m" data-di="6"></div></div><span class="scp-row-score">1/7</span><span class="scp-row-badge"><span class="scp-badge scp-badge-part">Part</span></span><span class="scp-row-chev">▼</span></summary><div class="scp-detail"><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot hw"></span>AI Chip Design</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> Sole UK AI accelerator designer (Graphcore) acquired by SoftBank July 2024; no IP-transfer restrictions imposed</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot hw"></span>Advanced Fabrication</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> No UK fab operates at or below 7nm; domestic capacity limited to mature and compound semiconductor nodes</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot hw"></span>Critical Equipment</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> UK equipment firms serve advanced fabs but none is sole-sourced for ≤7nm lithographic fabrication</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot pl"></span>AI Compute</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> No UK-HQ provider operates frontier-training-class compute on UK soil at assessment date; Nscale flagship facility scheduled Q4 2026-Q1 2027</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot pl"></span>Frontier Models</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> DeepMind IP owned by Alphabet (US); no independent UK lab ranks top-tier across broad reasoning benchmarks</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot gv"></span>AI Regulation</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> No AI-specific binding framework enacted; AISI evaluations voluntary; anticipated UK AI bill did not materialise</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot gv"></span>Sovereign Investment</span><span class="scp-dim-st scp-dim-met">Met</span></div><div class="scp-dim-qual-hl">UK Compute Roadmap commits up to £2 billion for public AI compute infrastructure, confirmed by Parliament</div><div class="scp-src-lock">🔒 Sources (supporter access)</div></div></details><details class="scp-actor" id="in"><summary class="scp-row"><span class="scp-row-name" title="India">India</span><div class="scp-row-bar"><div class="scp-row-seg" data-di="0"></div><div class="scp-row-seg" data-di="1"></div><div class="scp-row-seg" data-di="2"></div><div class="scp-row-seg" data-di="3"></div><div class="scp-row-seg" data-di="4"></div><div class="scp-row-seg" data-di="5"></div><div class="scp-row-seg gv-m" data-di="6"></div></div><span class="scp-row-score">1/7</span><span class="scp-row-badge"><span class="scp-badge scp-badge-part">Part</span></span><span class="scp-row-chev">▼</span></summary><div class="scp-detail"><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot hw"></span>AI Chip Design</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> No commercially marketed datacenter AI training accelerator with domestically controlled core microarchitectural IP</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot hw"></span>Advanced Fabrication</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> No ≤7nm wafer fab on Indian territory; most advanced approved project (Tata Dholera) targets 28nm-110nm</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot hw"></span>Critical Equipment</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> No Indian sole-source position in the ≤7nm semiconductor equipment supply chain</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot pl"></span>AI Compute</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> Largest sovereign compute allocation (4,096 H100s, IndiaAI Mission) empirically exercised; produced sub-frontier result</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot pl"></span>Frontier Models</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> Sole candidate (Sarvam-105B) trails absolute May 2026 frontier; independent evaluation limited</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot gv"></span>AI Regulation</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> No AI-specific statute in force; DPDPA core obligations delayed to May 2027; IT Rules 2026 limited to content moderation</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot gv"></span>Sovereign Investment</span><span class="scp-dim-st scp-dim-met">Met</span></div><div class="scp-dim-qual-hl">IndiaAI Mission budgets Rs 10,372 crore across seven pillars with a 10,000 GPU target; compute runs on US ecosystem infrastructure</div><div class="scp-src-lock">🔒 Sources (supporter access)</div></div></details><details class="scp-actor" id="il"><summary class="scp-row"><span class="scp-row-name" title="Israel">Israel</span><div class="scp-row-bar"><div class="scp-row-seg" data-di="0"></div><div class="scp-row-seg" data-di="1"></div><div class="scp-row-seg hw-m" data-di="2"></div><div class="scp-row-seg" data-di="3"></div><div class="scp-row-seg" data-di="4"></div><div class="scp-row-seg" data-di="5"></div><div class="scp-row-seg" data-di="6"></div></div><span class="scp-row-score">1/7</span><span class="scp-row-badge"><span class="scp-badge scp-badge-part">Part</span></span><span class="scp-row-chev">▼</span></summary><div class="scp-detail"><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot hw"></span>AI Chip Design</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> Habana Labs/Gaudi IP wholly owned by Intel US; no independent Israeli training-class accelerator programme remains</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot hw"></span>Advanced Fabrication</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> Fab 28 runs Intel 7 (10nm-class DUV, no EUV); Fab 38 frozen since mid-2024 with no restart date</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot hw"></span>Critical Equipment</span><span class="scp-dim-st scp-dim-met">Met</span></div><div class="scp-dim-qual-hl">Nova holds sole-source metrology and Camtek is tool of reference for HBM4; limited to inspection, US-parented entities excluded</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot pl"></span>AI Compute</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> Largest Israeli-controlled GPU clusters are an order of magnitude below frontier training scale</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot pl"></span>Frontier Models</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> AI21 Jamba scores 40-50 percentage points behind frontier benchmarks; company has pivoted away from scale competition</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot gv"></span>AI Regulation</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> No enacted AI-specific law with extraterritorial reach; existing controls are privacy-based or dual-use export</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot gv"></span>Sovereign Investment</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> ~$140M deployed AI-specific capital over six years; two orders of magnitude below $1B-$10B+ peer programmes</div><div class="scp-src-lock">🔒 Sources (supporter access)</div></div></details><details class="scp-actor" id="ru"><summary class="scp-row"><span class="scp-row-name" title="Russia">Russia</span><div class="scp-row-bar"><div class="scp-row-seg" data-di="0"></div><div class="scp-row-seg" data-di="1"></div><div class="scp-row-seg" data-di="2"></div><div class="scp-row-seg" data-di="3"></div><div class="scp-row-seg" data-di="4"></div><div class="scp-row-seg" data-di="5"></div><div class="scp-row-seg" data-di="6"></div></div><span class="scp-row-score">0/7</span><span class="scp-row-badge"><span class="scp-badge scp-badge-part">Part</span></span><span class="scp-row-chev">▼</span></summary><div class="scp-detail"><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot hw"></span>AI Chip Design</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> No domestically designed training-class accelerator in production; ARM/MIPS licenses revoked, foundry access severed</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot hw"></span>Advanced Fabrication</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> Most advanced operational node is 90nm at Mikron; state roadmap targets 28nm no earlier than 2028-2030</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot hw"></span>Critical Equipment</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> Best domestic lithography tool operates at 350nm on 200mm wafers; no global supply role</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot pl"></span>AI Compute</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> Total national AI compute 0.073 exaflops; largest cluster ~1,600 A100 nodes</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot pl"></span>Frontier Models</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> Flagship LLMs trail frontier by 34-55% on key benchmarks; two of three built on Chinese Qwen base weights</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot gv"></span>AI Regulation</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> No enacted AI-specific extraterritorial framework; enforcement model produces market exit, not foreign compliance</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot gv"></span>Sovereign Investment</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> Executed federal AI spending ~$80-90M/year; announced budgets systematically revised downward 5-20×</div><div class="scp-src-lock">🔒 Sources (supporter access)</div></div></details><details class="scp-actor" id="ca"><summary class="scp-row"><span class="scp-row-name" title="Canada">Canada</span><div class="scp-row-bar"><div class="scp-row-seg" data-di="0"></div><div class="scp-row-seg" data-di="1"></div><div class="scp-row-seg" data-di="2"></div><div class="scp-row-seg" data-di="3"></div><div class="scp-row-seg" data-di="4"></div><div class="scp-row-seg" data-di="5"></div><div class="scp-row-seg" data-di="6"></div></div><span class="scp-row-score">0/7</span><span class="scp-row-badge"><span class="scp-badge scp-badge-part">Part</span></span><span class="scp-row-chev">▼</span></summary><div class="scp-detail"><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot hw"></span>AI Chip Design</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> Tenstorrent redomiciled to Delaware 2023; no Canadian-controlled accelerator in volume production</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot hw"></span>Advanced Fabrication</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> Zero front-end logic fabs at ≤7nm on Canadian territory; ecosystem is packaging and specialty nodes</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot hw"></span>Critical Equipment</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> US-parented entity (Teledyne Technologies); pellicle manufacturing credits to parent jurisdiction</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot pl"></span>AI Compute</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> No Canadian-HQ entity operates GPU clusters at frontier-training scale; all hyperscalers US-controlled</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot pl"></span>Frontier Models</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> Cohere ranks decisively second-tier on flagship cross-domain benchmarks (GPQA, Arena, SWE-bench)</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot gv"></span>AI Regulation</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> AIDA died on the order paper January 2025; ECL export controls bind Canadian exporters only, no extraterritorial reach</div><div class="scp-src-lock">🔒 Sources (supporter access)</div><div class="scp-dim-row"><span class="scp-dim-name"><span class="scp-dim-dot gv"></span>Sovereign Investment</span><span class="scp-dim-st scp-dim-not">Not Met</span></div><div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> ~CAD $2.9B over five years (~0.02% GDP/yr); flagship SCIP supercomputer not yet operational</div><div class="scp-src-lock">🔒 Sources (supporter access)</div></div></details></div></details><div class="scp-watch"><h2 class="scp-watch-title">Dimension Watch</h2><p class="scp-watch-desc">Dimensions approaching a status change at the next assessment cycle.</p><div class="scp-watch-wrap"><table class="scp-watch-table"><thead><tr><th>Actor</th><th>Dimension</th><th>Current</th><th>Expected</th><th>Trigger</th><th>Timeline</th></tr></thead><tbody><tr><td><a href="#gb" class="scp-watch-actor">GB</a></td><td><span class="scp-dim-dot pl" style="display:inline-block;margin-right:4px;"></span>AI Compute</td><td class="scp-dim-not">NOT MET</td><td>Possible MET</td><td>Nscale Loughton 23,040-GPU cluster operational</td><td>Q1 2027</td></tr><tr><td><a href="#fr" class="scp-watch-actor">FR</a></td><td><span class="scp-dim-dot pl" style="display:inline-block;margin-right:4px;"></span>AI Compute</td><td class="scp-dim-not">NOT MET</td><td>Possible MET</td><td>Mistral Compute sustained frontier-class training runs</td><td>Q3/Q4 2026</td></tr><tr><td><a href="#fr" class="scp-watch-actor">FR</a></td><td><span class="scp-dim-dot pl" style="display:inline-block;margin-right:4px;"></span>Frontier Models</td><td class="scp-dim-not">NOT MET</td><td>Possible MET</td><td>Mistral release closing approximately 35% frontier gap</td><td>Unknown</td></tr><tr><td><a href="#kr" class="scp-watch-actor">KR</a></td><td><span class="scp-dim-dot pl" style="display:inline-block;margin-right:4px;"></span>AI Compute</td><td class="scp-dim-not">NOT MET</td><td>Possible MET</td><td>Sovereign compute exceeding 50,000 GPUs</td><td>2027–2028</td></tr><tr><td><a href="#in" class="scp-watch-actor">IN</a></td><td><span class="scp-dim-dot pl" style="display:inline-block;margin-right:4px;"></span>AI Compute</td><td class="scp-dim-not">NOT MET</td><td>Possible MET</td><td>Sovereign compute consolidation exceeding 50,000 GPUs</td><td>2027–2028</td></tr><tr><td><a href="#in" class="scp-watch-actor">IN</a></td><td><span class="scp-dim-dot pl" style="display:inline-block;margin-right:4px;"></span>Frontier Models</td><td class="scp-dim-not">NOT MET</td><td>Possible MET</td><td>Independent verification of Sarvam-105B benchmark claims</td><td>Near-term</td></tr><tr><td><a href="#tw" class="scp-watch-actor">TW</a></td><td><span class="scp-dim-dot gv" style="display:inline-block;margin-right:4px;"></span>Sovereign Investment</td><td class="scp-dim-met">MET</td><td>At risk</td><td>FY2026 budget blocked by opposition in Legislative Yuan</td><td>Ongoing</td></tr><tr><td><a href="#de" class="scp-watch-actor">DE</a></td><td><span class="scp-dim-dot gv" style="display:inline-block;margin-right:4px;"></span>Sovereign Investment</td><td class="scp-dim-not">NOT MET</td><td>Possible MET</td><td>STACKIT and sovereign AI programme scaling</td><td>End-2027+</td></tr><tr><td><a href="#il" class="scp-watch-actor">IL</a></td><td><span class="scp-dim-dot gv" style="display:inline-block;margin-right:4px;"></span>Sovereign Investment</td><td class="scp-dim-not">NOT MET</td><td>Possible MET</td><td>Nagel Committee NIS 25 billion legislatively appropriated</td><td>Unknown</td></tr><tr><td><a href="#ca" class="scp-watch-actor">CA</a></td><td><span class="scp-dim-dot pl" style="display:inline-block;margin-right:4px;"></span>Frontier Models</td><td class="scp-dim-not">NOT MET</td><td>Possible shift</td><td>Cohere–Aleph Alpha merger closes and combined capability assessed</td><td>Late 2026</td></tr><tr><td><a href="#ca" class="scp-watch-actor">CA</a></td><td><span class="scp-dim-dot gv" style="display:inline-block;margin-right:4px;"></span>Sovereign Investment</td><td class="scp-dim-not">NOT MET</td><td>Possible MET</td><td>SCIP operational and Budget 2026 scales commitment</td><td>2027–2028</td></tr></tbody></table></div></div></div>
 
-      <section class="watch-section">
-  <h2>Dimension Watch</h2>
-  <p class="watch-desc">Dimensions under active monitoring for potential status change at next assessment.</p>
-  <div class="table-wrap">
-    <table class="watch-table">
-      <thead>
-        <tr>
-          <th>Actor</th>
-          <th>Dimension</th>
-          <th>Current</th>
-          <th>Expected Change</th>
-          <th>Trigger</th>
-          <th>Timeline</th>
-        </tr>
-      </thead>
-      <tbody>
-<tr>
-  <td><a href="#gb">United Kingdom</a></td>
-  <td><span class="dim-ref">D4</span> AI Compute</td>
-  <td class="w-nmet">NOT MET</td>
-  <td>Probable MET</td>
-  <td>Nscale Loughton 23,040-GPU cluster operational</td>
-  <td>Q1 2027</td>
-</tr>
-<tr>
-  <td><a href="#fr">France</a></td>
-  <td><span class="dim-ref">D4</span> AI Compute</td>
-  <td class="w-nmet">NOT MET</td>
-  <td>Possible MET</td>
-  <td>Mistral Compute sustained frontier-class training runs</td>
-  <td>Q3/Q4 2026</td>
-</tr>
-<tr>
-  <td><a href="#fr">France</a></td>
-  <td><span class="dim-ref">D5</span> Frontier Models</td>
-  <td class="w-nmet">NOT MET</td>
-  <td>Possible MET</td>
-  <td>Mistral release closing approximately 35% frontier gap</td>
-  <td>Unknown</td>
-</tr>
-<tr>
-  <td><a href="#kr">South Korea</a></td>
-  <td><span class="dim-ref">D4</span> AI Compute</td>
-  <td class="w-nmet">NOT MET</td>
-  <td>Possible MET</td>
-  <td>Sovereign compute exceeding 50,000 GPUs</td>
-  <td>2027–2028</td>
-</tr>
-<tr>
-  <td><a href="#in">India</a></td>
-  <td><span class="dim-ref">D4</span> AI Compute</td>
-  <td class="w-nmet">NOT MET</td>
-  <td>Possible MET</td>
-  <td>Sovereign compute consolidation exceeding 50,000 GPUs</td>
-  <td>2027–2028</td>
-</tr>
-<tr>
-  <td><a href="#in">India</a></td>
-  <td><span class="dim-ref">D5</span> Frontier Models</td>
-  <td class="w-nmet">NOT MET</td>
-  <td>Possible MET</td>
-  <td>Independent verification of Sarvam-105B benchmark claims</td>
-  <td>Near-term</td>
-</tr>
-<tr>
-  <td><a href="#tw">Taiwan</a></td>
-  <td><span class="dim-ref">D7</span> Sovereign Investment</td>
-  <td class="w-met">MET</td>
-  <td>At risk</td>
-  <td>FY2026 budget blocked by opposition in Legislative Yuan</td>
-  <td>Ongoing</td>
-</tr>
-<tr>
-  <td><a href="#de">Germany</a></td>
-  <td><span class="dim-ref">D7</span> Sovereign Investment</td>
-  <td class="w-nmet">NOT MET</td>
-  <td>Possible MET</td>
-  <td>STACKIT and sovereign AI programme scaling</td>
-  <td>End-2027+</td>
-</tr>
-<tr>
-  <td><a href="#il">Israel</a></td>
-  <td><span class="dim-ref">D7</span> Sovereign Investment</td>
-  <td class="w-nmet">NOT MET</td>
-  <td>Possible MET</td>
-  <td>Nagel Committee NIS 25 billion legislatively appropriated</td>
-  <td>Unknown</td>
-</tr>
-<tr>
-  <td><a href="#ca">Canada</a></td>
-  <td><span class="dim-ref">D5</span> Frontier Models</td>
-  <td class="w-nmet">NOT MET</td>
-  <td>Possible shift</td>
-  <td>Cohere–Aleph Alpha merger closes and combined capability assessed</td>
-  <td>Late 2026</td>
-</tr>
-<tr>
-  <td><a href="#ca">Canada</a></td>
-  <td><span class="dim-ref">D7</span> Sovereign Investment</td>
-  <td class="w-nmet">NOT MET</td>
-  <td>Possible MET</td>
-  <td>SCIP operational and Budget 2026 scales commitment</td>
-  <td>2027–2028</td>
-</tr>
-
-      </tbody>
-    </table>
-  </div>
-</section>
-    </main>
-
-    <footer class="page-footer">
-      <p class="footer-cta">Full analysis and sources for all actors available with supporter access.</p>
-      <div class="footer-links">
-        <a href="/?scp=open">Explore the interactive Sovereign Capability Profiles →</a>
+    <div class="scp-page-footer">
+      <div class="scp-footer-cta">Full analysis and sources for all actors available with supporter access.</div>
+      <div class="scp-footer-links">
+        <a href="/">Explore the interactive map →</a>
         <a href="/research/methodology/manual/">Methodology Manual →</a>
       </div>
-      <p class="footer-mono">SCP Register v1.0 · Assessment: May 2026 · Methodology V1.4 · WEO v1.3.0</p>
-      <p class="footer-mono" style="margin-top:4px;opacity:0.5;">© 2026 Warmth Engine Observatory</p>
-    </footer>
+      <p class="scp-footer-disclaimer">Designation scores reflect assessed capabilities at the most recent evaluation date. They are not retrospective assessments of capabilities at the time each event in the database occurred.</p>
+      <div class="scp-footer-version">SCP Register v1.0 · Assessment: 2026-05-06 · Methodology V1.4</div>
+      <p class="scp-footer-copy">© 2026 Warmth Engine Observatory</p>
+    </div>
   </div>
-<script data-goatcounter="https://warmthengine.goatcounter.com/count"
-        async src="//gc.zgo.at/count.js"></script>
-<script>
-(function(){
-  var v = document.querySelector('meta[name="weo-version"]');
-  if (v) console.log('WEO v' + v.getAttribute('content'));
-})();
-</script>
+
+  <script>
+    /* Dimension pill column highlighting */
+    (function() {
+      var pills = document.querySelectorAll('.scp-pill');
+      var segs = document.querySelectorAll('.scp-row-seg');
+      var active = -1;
+      pills.forEach(function(p) {
+        p.addEventListener('click', function() {
+          var di = parseInt(p.getAttribute('data-dim'));
+          if (active === di) {
+            active = -1;
+            pills.forEach(function(pp) { pp.classList.remove('active'); });
+            segs.forEach(function(s) { s.classList.remove('col-hl','col-dim'); });
+          } else {
+            active = di;
+            pills.forEach(function(pp) { pp.classList.remove('active'); });
+            p.classList.add('active');
+            segs.forEach(function(s) {
+              var si = parseInt(s.getAttribute('data-di'));
+              if (si === di) { s.classList.add('col-hl'); s.classList.remove('col-dim'); }
+              else { s.classList.add('col-dim'); s.classList.remove('col-hl'); }
+            });
+          }
+        });
+      });
+    })();
+  </script>
+  <script data-goatcounter="https://warmthengine.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
+  <script>(function(){ var v=document.querySelector('meta[name="weo-version"]'); if(v) console.log('WEO v'+v.getAttribute('content')); })();</script>
 </body>
 </html>

--- a/scripts/generate_profiles.py
+++ b/scripts/generate_profiles.py
@@ -1,0 +1,699 @@
+#!/usr/bin/env python3
+"""
+generate_profiles.py — Generate static SCP profiles page for warmthengine.com/profiles/
+Usage: python3 scripts/generate_profiles.py --input path/to/actors-free.json --output profiles/index.html
+"""
+
+import json
+import argparse
+import html as _html
+from pathlib import Path
+
+
+def esc(s):
+    if s is None:
+        return ''
+    return _html.escape(str(s))
+
+
+DESIGNATION_ORDER = ['PAA', 'AIK', 'ACS', 'Participant']
+DESIGNATION_LABELS = {
+    'PAA': 'Principal AI Actors',
+    'AIK': 'AI Infrastructure Keystones',
+    'ACS': 'Advanced Capability States',
+    'Participant': 'Participants',
+}
+
+ACTOR_ORDER = ['US', 'CN', 'JP', 'KR', 'NL', 'EU', 'TW', 'FR', 'DE', 'GB', 'IN', 'IL', 'RU', 'CA']
+
+DIM_CATEGORIES = {
+    'D1': 'hw', 'D2': 'hw', 'D3': 'hw',
+    'D4': 'pl', 'D5': 'pl',
+    'D6': 'gv', 'D7': 'gv',
+}
+
+GRADE_STYLES = {
+    1: ('rgba(245,158,11,0.15)', '#F59E0B', 'rgba(245,158,11,0.35)'),
+    2: ('rgba(59,130,246,0.15)',  '#3B82F6', 'rgba(59,130,246,0.35)'),
+    3: ('rgba(100,116,139,0.15)', '#94A3B8', 'rgba(100,116,139,0.3)'),
+}
+
+INLINE_CSS = """
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+  --bg-primary: #0F172A;
+  --bg-card: #1E293B;
+  --bg-deep: #0B1120;
+  --text-primary: #E2E8F0;
+  --text-secondary: #94A3B8;
+  --text-muted: #64748B;
+  --accent: #3B82F6;
+  --border: rgba(255,255,255,0.07);
+  --scp-hw: #60A5FA;
+  --scp-pl: #A78BFA;
+  --scp-gv: #2DD4BF;
+  --scp-paa: #F59E0B;
+  --scp-aik: #06B6D4;
+  --scp-acs: #A855F7;
+  --scp-part: #64748B;
+  --scp-met: #22C55E;
+  --r-sm: 4px;
+  --r-md: 6px;
+  --r-pill: 20px;
+}
+
+html { scroll-behavior: smooth; }
+
+body {
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+.page-wrap { max-width: 900px; margin: 0 auto; padding: 0 20px 60px; }
+
+/* ── Page header ── */
+.page-header {
+  padding: 48px 0 36px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 40px;
+}
+.page-header h1 {
+  font-size: 28px; font-weight: 700; color: var(--text-primary);
+  letter-spacing: -0.02em; margin-bottom: 6px;
+}
+.page-subtitle { font-size: 15px; color: var(--text-secondary); margin-bottom: 18px; }
+.page-framework {
+  font-size: 13px; color: var(--text-secondary); line-height: 1.7;
+  max-width: 720px; margin-bottom: 20px;
+}
+.page-meta {
+  display: flex; gap: 20px; flex-wrap: wrap;
+  font-size: 12px; color: var(--text-muted); margin-bottom: 24px;
+}
+
+/* ── Dimension legend ── */
+.legend-heading {
+  font-size: 11px; font-weight: 700; color: var(--text-muted);
+  letter-spacing: 0.08em; text-transform: uppercase; margin-bottom: 10px;
+}
+.dim-legend {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 6px;
+}
+.legend-item {
+  display: flex; align-items: flex-start; gap: 7px;
+  font-size: 12px; line-height: 1.45; padding: 6px 8px;
+  background: rgba(30,41,59,0.5); border-radius: var(--r-sm);
+  border: 1px solid var(--border);
+}
+.legend-dot { width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0; margin-top: 3px; }
+.legend-key {
+  font-family: 'SF Mono','Fira Code',monospace; font-size: 10px;
+  color: var(--text-muted); flex-shrink: 0; min-width: 20px;
+}
+.legend-name { font-weight: 500; color: var(--text-secondary); flex-shrink: 0; min-width: 100px; }
+.legend-desc { color: var(--text-muted); font-size: 11px; }
+
+/* ── Designation groups ── */
+.desig-section { margin-bottom: 48px; }
+.desig-heading { display: flex; align-items: center; gap: 12px; margin-bottom: 18px; }
+.desig-heading h2 { font-size: 14px; font-weight: 700; letter-spacing: 0.01em; white-space: nowrap; }
+.desig-line { flex: 1; height: 1px; background: var(--border); }
+.desig-paa .desig-heading h2 { color: var(--scp-paa); }
+.desig-aik .desig-heading h2 { color: var(--scp-aik); }
+.desig-acs .desig-heading h2 { color: var(--scp-acs); }
+.desig-participant .desig-heading h2 { color: var(--scp-part); }
+
+/* ── Actor cards ── */
+.actor-card {
+  background: var(--bg-card); border: 1px solid var(--border);
+  border-radius: var(--r-md); margin-bottom: 14px; overflow: hidden;
+}
+.actor-header {
+  padding: 14px 20px 12px; border-bottom: 1px solid var(--border);
+}
+.actor-title-row {
+  display: flex; align-items: center; justify-content: space-between;
+  flex-wrap: wrap; gap: 8px; margin-bottom: 10px;
+}
+.actor-name {
+  font-size: 17px; font-weight: 700; color: var(--text-primary);
+  display: flex; align-items: center; gap: 8px;
+}
+.actor-meta { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+.actor-score {
+  font-family: 'SF Mono','Fira Code',monospace; font-size: 13px;
+  font-weight: 700; color: var(--text-secondary);
+  background: rgba(255,255,255,0.05); padding: 2px 8px;
+  border-radius: var(--r-sm); border: 1px solid var(--border);
+}
+.actor-badge {
+  font-size: 11px; font-weight: 700; letter-spacing: 0.04em;
+  padding: 3px 10px; border-radius: var(--r-pill); border: 1px solid;
+}
+.badge-paa   { background: rgba(245,158,11,0.15); color: #F59E0B;   border-color: rgba(245,158,11,0.35); }
+.badge-aik   { background: rgba(6,182,212,0.12);  color: #22D3EE;   border-color: rgba(6,182,212,0.3); }
+.badge-acs   { background: rgba(168,85,247,0.12); color: #C084FC;   border-color: rgba(168,85,247,0.3); }
+.badge-participant { background: rgba(100,116,139,0.12); color: #64748B; border-color: rgba(100,116,139,0.25); }
+.sample-badge {
+  font-size: 10px; font-weight: 600;
+  background: rgba(255,215,0,0.1); color: #FFD700;
+  border: 1px solid rgba(255,215,0,0.25); padding: 1px 6px;
+  border-radius: 3px; letter-spacing: 0.03em;
+}
+
+/* ── Dimension bar ── */
+.dim-bar { display: flex; gap: 4px; align-items: center; }
+.dim-bar-dot {
+  width: 10px; height: 10px; border-radius: 50%; border: 1.5px solid;
+  flex-shrink: 0;
+}
+.dim-bar-dot.hw.met  { background: var(--scp-hw);  border-color: var(--scp-hw); }
+.dim-bar-dot.pl.met  { background: var(--scp-pl);  border-color: var(--scp-pl); }
+.dim-bar-dot.gv.met  { background: var(--scp-gv);  border-color: var(--scp-gv); }
+.dim-bar-dot.hw.nmet { background: transparent; border-color: rgba(96,165,250,0.3); }
+.dim-bar-dot.pl.nmet { background: transparent; border-color: rgba(167,139,250,0.3); }
+.dim-bar-dot.gv.nmet { background: transparent; border-color: rgba(45,212,191,0.3); }
+
+/* ── Actor body ── */
+.actor-body { padding: 0 20px 14px; }
+
+/* ── Dimensions list ── */
+.dimensions-list { list-style: none; }
+
+.dim-item { border-bottom: 1px solid rgba(255,255,255,0.04); padding: 9px 0; }
+.dim-item:last-of-type { border-bottom: none; }
+
+.dim-header {
+  display: flex; align-items: center; gap: 7px;
+  font-size: 13px; flex-wrap: wrap;
+}
+.dim-dot { width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }
+.dim-dot.hw     { background: rgba(96,165,250,0.3); }
+.dim-dot.pl     { background: rgba(167,139,250,0.3); }
+.dim-dot.gv     { background: rgba(45,212,191,0.3); }
+.dim-dot.hw.met { background: var(--scp-hw); }
+.dim-dot.pl.met { background: var(--scp-pl); }
+.dim-dot.gv.met { background: var(--scp-gv); }
+.dim-key {
+  font-family: 'SF Mono','Fira Code',monospace; font-size: 10px;
+  color: var(--text-muted); flex-shrink: 0; min-width: 20px;
+}
+.dim-name  { color: var(--text-secondary); flex: 1; }
+.dim-status { font-size: 11px; font-weight: 700; flex-shrink: 0; }
+.dim-met   { color: var(--scp-met); }
+.dim-nmet  { color: var(--text-muted); }
+
+.dim-qual-hl {
+  font-size: 12px; color: #CBD5E1; line-height: 1.55;
+  padding: 4px 0 2px 13px;
+}
+.dim-constraint {
+  font-size: 12px; color: var(--text-muted); line-height: 1.55;
+  padding: 4px 0 2px 13px; font-style: italic;
+}
+.constraint-label { font-style: normal; font-weight: 700; color: var(--text-secondary); }
+
+.dim-details-dd { padding: 2px 0 2px 13px; }
+details.dim-details summary {
+  font-size: 11px; color: var(--text-muted); cursor: pointer;
+  padding: 3px 0; display: inline-flex; align-items: center; gap: 5px;
+  list-style: none; -webkit-appearance: none; transition: color 0.15s;
+}
+details.dim-details summary::-webkit-details-marker { display: none; }
+details.dim-details summary::before { content: '▸'; font-size: 9px; }
+details.dim-details[open] summary::before { content: '▾'; }
+details.dim-details summary:hover { color: var(--text-secondary); }
+
+.dim-qual-block {
+  margin-top: 6px; padding: 10px 12px;
+  background: rgba(15,23,42,0.6); border-radius: var(--r-sm);
+  border: 1px solid var(--border);
+  font-size: 12px; color: var(--text-secondary); line-height: 1.65;
+}
+
+/* ── Sources ── */
+.src-block {
+  margin-top: 6px; padding: 10px 12px;
+  background: rgba(15,23,42,0.6); border-radius: var(--r-sm);
+  border: 1px solid var(--border);
+}
+.src-entry {
+  padding: 8px 0; border-bottom: 1px solid rgba(255,255,255,0.04);
+}
+.src-entry:last-child { border-bottom: none; padding-bottom: 0; }
+.src-meta {
+  display: flex; flex-wrap: wrap; align-items: center; gap: 8px; margin-bottom: 5px;
+}
+.src-type  { font-size: 10px; font-weight: 700; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.05em; }
+.src-grade { font-size: 10px; font-weight: 700; padding: 1px 7px; border-radius: 3px; }
+.src-pub   { font-size: 11px; color: var(--text-secondary); }
+.src-date  { font-size: 10px; color: var(--text-muted); }
+.src-fact  { font-size: 11px; color: var(--text-secondary); line-height: 1.55; margin-bottom: 5px; }
+.src-link  { font-size: 11px; color: var(--accent); }
+
+/* ── AIK chokepoint ── */
+.aik-profile {
+  margin-top: 12px; padding: 10px 12px;
+  background: rgba(6,182,212,0.06); border: 1px solid rgba(6,182,212,0.15);
+  border-radius: var(--r-sm);
+}
+.aik-label  {
+  font-size: 10px; font-weight: 700; color: #94A3B8;
+  letter-spacing: 0.07em; text-transform: uppercase; margin-bottom: 4px;
+}
+.aik-nature   { font-size: 13px; color: #CBD5E1; font-weight: 500; line-height: 1.45; }
+.aik-entities { font-size: 11px; color: var(--text-muted); font-style: italic; line-height: 1.55; margin-top: 3px; }
+
+/* ── Severance ── */
+.actor-severance {
+  font-size: 12px; color: var(--text-muted); margin-top: 12px;
+  padding-top: 10px; border-top: 1px solid rgba(255,255,255,0.04);
+  line-height: 1.55;
+}
+.sev-label  { font-weight: 700; color: var(--text-secondary); }
+.sev-pass   { color: var(--scp-met); font-weight: 700; }
+.sev-fail   { color: #F87171; font-weight: 700; }
+
+/* ── Dimension watch ── */
+.watch-section {
+  margin-top: 48px; padding-top: 32px; border-top: 1px solid var(--border);
+}
+.watch-section h2 {
+  font-size: 17px; font-weight: 700; color: var(--text-primary); margin-bottom: 8px;
+}
+.watch-desc { font-size: 13px; color: var(--text-muted); margin-bottom: 16px; }
+.table-wrap { overflow-x: auto; -webkit-overflow-scrolling: touch; }
+.watch-table { width: 100%; border-collapse: collapse; font-size: 12px; }
+.watch-table th {
+  text-align: left; font-size: 10px; font-weight: 700;
+  color: var(--text-muted); text-transform: uppercase;
+  letter-spacing: 0.06em; padding: 8px 12px;
+  border-bottom: 1px solid var(--border); white-space: nowrap;
+}
+.watch-table td {
+  padding: 10px 12px; border-bottom: 1px solid rgba(255,255,255,0.03);
+  vertical-align: top; color: var(--text-secondary); line-height: 1.5;
+}
+.watch-table tr:last-child td { border-bottom: none; }
+.watch-table tr:hover td { background: rgba(255,255,255,0.01); }
+.dim-ref {
+  font-family: 'SF Mono','Fira Code',monospace; font-size: 10px;
+  color: var(--text-muted);
+}
+.w-met  { color: var(--scp-met); font-weight: 700; }
+.w-nmet { color: var(--text-muted); }
+
+/* ── Footer ── */
+.page-footer {
+  margin-top: 56px; padding-top: 24px; border-top: 1px solid var(--border);
+  font-size: 12px; color: var(--text-muted); line-height: 1.8;
+}
+.footer-cta {
+  font-size: 13px; color: var(--text-secondary); margin-bottom: 14px;
+  padding: 10px 14px;
+  background: rgba(59,130,246,0.05); border: 1px solid rgba(59,130,246,0.15);
+  border-radius: var(--r-sm);
+}
+.footer-links { display: flex; flex-wrap: wrap; gap: 16px; margin-bottom: 12px; }
+.footer-links a { color: var(--accent); }
+.footer-copy { font-size: 11px; color: var(--text-muted); }
+
+/* ── Responsive ── */
+@media (max-width: 600px) {
+  .page-header h1 { font-size: 22px; }
+  .actor-title-row { flex-direction: column; align-items: flex-start; }
+  .dim-legend { grid-template-columns: 1fr; }
+  .page-meta { flex-direction: column; gap: 4px; }
+  .actor-name { font-size: 15px; }
+}
+@media (max-width: 375px) {
+  .page-wrap { padding: 0 12px 40px; }
+  .page-header { padding: 32px 0 24px; }
+}
+"""
+
+
+def render_source(label, src):
+    grade = src.get('grade', 3)
+    bg, color, border = GRADE_STYLES.get(grade, GRADE_STYLES[3])
+    grade_label = f'Grade {grade}'
+    pub = esc(src.get('publisher', ''))
+    date = esc(src.get('date', ''))
+    fact = esc(src.get('qualifying_fact', ''))
+    url = esc(src.get('url', ''))
+    return f"""<div class="src-entry">
+  <div class="src-meta">
+    <span class="src-type">{label}</span>
+    <span class="src-grade" style="background:{bg};color:{color};border:1px solid {border};">{grade_label}</span>
+    <span class="src-pub">{pub}</span>
+    <span class="src-date">{date}</span>
+  </div>
+  <p class="src-fact">{fact}</p>
+  <a href="{url}" class="src-link" target="_blank" rel="noopener noreferrer">View source →</a>
+</div>"""
+
+
+def render_dimension(dim_key, dim_data, dim_info, is_sample):
+    met = dim_data.get('met', False)
+    cat = DIM_CATEGORIES.get(dim_key, 'hw')
+    dot_class = f"dim-dot {cat}{' met' if met else ''}"
+    dim_name = esc(dim_info.get('name', dim_key))
+    status_class = 'dim-met' if met else 'dim-nmet'
+    status_label = 'Met' if met else 'Not Met'
+
+    detail_rows = ''
+
+    if met:
+        qual_headline = dim_data.get('qualification_headline')
+        constraint = dim_data.get('constraint')
+        qualification = dim_data.get('qualification')
+        sources = dim_data.get('sources')
+
+        if qual_headline:
+            detail_rows += f'<dd class="dim-qual-hl">{esc(qual_headline)}</dd>\n'
+
+        if constraint:
+            detail_rows += f'<dd class="dim-constraint"><em>{esc(constraint)}</em></dd>\n'
+
+        if is_sample and qualification:
+            detail_rows += f"""<dd class="dim-details-dd">
+  <details class="dim-details">
+    <summary>Qualification</summary>
+    <div class="dim-qual-block">{esc(qualification)}</div>
+  </details>
+</dd>
+"""
+
+        if is_sample and sources:
+            src_entries = ''
+            for label, src in [('Primary', sources.get('primary')), ('Corroborating', sources.get('corroborating'))]:
+                if src:
+                    src_entries += render_source(label, src)
+            detail_rows += f"""<dd class="dim-details-dd">
+  <details class="dim-details">
+    <summary>Sources</summary>
+    <div class="src-block">{src_entries}</div>
+  </details>
+</dd>
+"""
+    else:
+        constraint_headline = dim_data.get('constraint_headline')
+        constraint = dim_data.get('constraint')
+
+        if constraint_headline:
+            detail_rows += (
+                f'<dd class="dim-constraint">'
+                f'<span class="constraint-label">Constraint:</span> {esc(constraint_headline)}'
+                f'</dd>\n'
+            )
+
+        if is_sample and constraint:
+            detail_rows += f'<dd class="dim-constraint">{esc(constraint)}</dd>\n'
+
+    return f"""<div class="dim-item">
+<dt class="dim-header">
+  <span class="{dot_class}"></span>
+  <span class="dim-key">{dim_key}</span>
+  <span class="dim-name">{dim_name}</span>
+  <span class="dim-status {status_class}">{status_label}</span>
+</dt>
+{detail_rows}</div>"""
+
+
+def render_dim_bar(dimensions):
+    dots = []
+    for dk in ['D1', 'D2', 'D3', 'D4', 'D5', 'D6', 'D7']:
+        met = dimensions.get(dk, {}).get('met', False)
+        cat = DIM_CATEGORIES[dk]
+        mc = 'met' if met else 'nmet'
+        dots.append(f'<span class="dim-bar-dot {cat} {mc}" title="{dk}"></span>')
+    return '<div class="dim-bar">' + ''.join(dots) + '</div>'
+
+
+def render_actor(actor, dimensions_meta):
+    actor_id = actor['id'].lower()
+    name = esc(actor['name'])
+    score = actor.get('score', 0)
+    designation = actor.get('designation', 'Participant')
+    is_sample = actor.get('sample', False)
+    severance = actor.get('severance')
+    severance_detail = actor.get('severance_detail', '')
+    aik_profile = actor.get('aik_profile')
+    dimensions = actor.get('dimensions', {})
+
+    badge_class = f'badge-{designation.lower()}'
+
+    dim_bar_html = render_dim_bar(dimensions)
+
+    dims_html = ''
+    for dk in ['D1', 'D2', 'D3', 'D4', 'D5', 'D6', 'D7']:
+        dims_html += render_dimension(dk, dimensions.get(dk, {}), dimensions_meta.get(dk, {}), is_sample)
+
+    aik_html = ''
+    if aik_profile:
+        nature = esc(aik_profile.get('chokepoint_nature', ''))
+        entities = esc(aik_profile.get('key_entities', ''))
+        aik_html = f"""<div class="aik-profile">
+  <div class="aik-label">Chokepoint Profile</div>
+  <div class="aik-nature">{nature}</div>
+  <div class="aik-entities">{entities}</div>
+</div>"""
+
+    sev_html = ''
+    if severance is not None:
+        sev_class = 'sev-pass' if severance == 'PASS' else 'sev-fail'
+        sev_text = f'<span class="{sev_class}">{esc(severance)}</span>'
+        if severance_detail:
+            sev_text += f' — {esc(severance_detail)}'
+        sev_html = f'<div class="actor-severance"><span class="sev-label">Severance:</span> {sev_text}</div>'
+
+    sample_badge = '<span class="sample-badge">Sample</span> ' if is_sample else ''
+
+    return f"""<article id="{actor_id}" class="actor-card">
+  <header class="actor-header">
+    <div class="actor-title-row">
+      <h3 class="actor-name">{sample_badge}{name}</h3>
+      <div class="actor-meta">
+        <span class="actor-score">{score}/7</span>
+        <span class="actor-badge {badge_class}">{esc(designation)}</span>
+      </div>
+    </div>
+    {dim_bar_html}
+  </header>
+  <div class="actor-body">
+    <dl class="dimensions-list">
+{dims_html}
+    </dl>
+    {aik_html}
+    {sev_html}
+  </div>
+</article>"""
+
+
+def render_watch(watch_list, actors_by_id, dimensions_meta):
+    rows = ''
+    for item in watch_list:
+        actor_id = item.get('actor_id', '')
+        actor_name = esc(actors_by_id.get(actor_id, {}).get('name', actor_id))
+        dim = item.get('dimension', '')
+        dim_name = esc(dimensions_meta.get(dim, {}).get('name', ''))
+        current = esc(item.get('current', ''))
+        expected = esc(item.get('expected_change', ''))
+        trigger = esc(item.get('trigger', ''))
+        timeline = esc(item.get('timeline', ''))
+        cur_class = 'w-met' if item.get('current') == 'MET' else 'w-nmet'
+        rows += f"""<tr>
+  <td><a href="#{actor_id.lower()}">{actor_name}</a></td>
+  <td><span class="dim-ref">{esc(dim)}</span> {dim_name}</td>
+  <td class="{cur_class}">{current}</td>
+  <td>{expected}</td>
+  <td>{trigger}</td>
+  <td>{timeline}</td>
+</tr>
+"""
+    return f"""<section class="watch-section">
+  <h2>Dimension Watch</h2>
+  <p class="watch-desc">Dimensions under active monitoring for potential status change at next assessment.</p>
+  <div class="table-wrap">
+    <table class="watch-table">
+      <thead>
+        <tr>
+          <th>Actor</th>
+          <th>Dimension</th>
+          <th>Current</th>
+          <th>Expected Change</th>
+          <th>Trigger</th>
+          <th>Timeline</th>
+        </tr>
+      </thead>
+      <tbody>
+{rows}
+      </tbody>
+    </table>
+  </div>
+</section>"""
+
+
+def render_legend(dimensions_meta):
+    items = ''
+    for dk in ['D1', 'D2', 'D3', 'D4', 'D5', 'D6', 'D7']:
+        info = dimensions_meta.get(dk, {})
+        cat = DIM_CATEGORIES[dk]
+        cat_var = {'hw': 'var(--scp-hw)', 'pl': 'var(--scp-pl)', 'gv': 'var(--scp-gv)'}[cat]
+        name = esc(info.get('name', dk))
+        desc = esc(info.get('description', ''))
+        items += f"""<div class="legend-item">
+  <span class="legend-dot" style="background:{cat_var};"></span>
+  <span class="legend-key">{dk}</span>
+  <span class="legend-name">{name}</span>
+  <span class="legend-desc">{desc}</span>
+</div>
+"""
+    return f'<div class="dim-legend">\n{items}</div>'
+
+
+def generate_html(data):
+    meta = data['metadata']
+    dims = data['dimensions']
+    actors = data['actors']
+    watch = data.get('dimension_watch', [])
+
+    actors_by_id = {a['id']: a for a in actors}
+
+    groups = {d: [] for d in DESIGNATION_ORDER}
+    for actor_id in ACTOR_ORDER:
+        if actor_id in actors_by_id:
+            actor = actors_by_id[actor_id]
+            groups.setdefault(actor.get('designation', 'Participant'), []).append(actor)
+
+    sections_html = ''
+    for des in DESIGNATION_ORDER:
+        group = groups.get(des, [])
+        if not group:
+            continue
+        label = DESIGNATION_LABELS.get(des, des)
+        des_class = f'desig-{des.lower()}'
+        actors_html = ''.join(render_actor(a, dims) for a in group)
+        sections_html += f"""<section class="desig-section {des_class}">
+  <div class="desig-heading">
+    <h2>{label} ({len(group)})</h2>
+    <div class="desig-line"></div>
+  </div>
+  {actors_html}
+</section>
+"""
+
+    assessment_date = esc(meta.get('assessment_date', ''))
+    methodology_version = esc(meta.get('methodology_version', ''))
+    total_actors = meta.get('total_actors', 14)
+
+    legend_html = render_legend(dims)
+    watch_html = render_watch(watch, actors_by_id, dims)
+
+    json_ld = json.dumps({
+        "@context": "https://schema.org",
+        "@type": "Dataset",
+        "name": "WEO Sovereign Capability Profiles",
+        "description": "Nation-state AI infrastructure capability assessments across 7 dimensions for 14 actors",
+        "url": "https://warmthengine.com/profiles/",
+        "creator": {
+            "@type": "Organisation",
+            "name": "Warmth Engine Observatory",
+            "url": "https://warmthengine.com"
+        },
+        "dateModified": "2026-06-03",
+        "license": "https://warmthengine.com/research/methodology/manual/"
+    }, indent=2)
+
+    framework_desc = (
+        "The Sovereign Capability Profile (SCP) framework assesses nation-state control of the AI infrastructure "
+        "stack across seven dimensions: chip design, advanced fabrication, critical equipment, AI compute, frontier "
+        "models, AI regulation, and sovereign investment. Actors are designated as Principal AI Actors (PAA), "
+        "AI Infrastructure Keystones (AIK), Advanced Capability States (ACS), or Participants through a three-gate "
+        "framework evaluating dimensional breadth, severance resilience, and platform sustainability."
+    )
+
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Sovereign Capability Profiles — AI Infrastructure Assessments | Warmth Engine Observatory</title>
+  <meta name="description" content="Nation-state AI infrastructure assessments across 14 actors. Chip design, fabrication, equipment, compute, frontier models, regulation, and sovereign investment dimensions evaluated with sourced evidence.">
+  <link rel="canonical" href="https://warmthengine.com/profiles/">
+  <meta property="og:title" content="Sovereign Capability Profiles — Warmth Engine Observatory">
+  <meta property="og:description" content="Which nations control the AI infrastructure stack? 14 actors assessed across 7 dimensions with sourced evidence.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://warmthengine.com/profiles/">
+  <script type="application/ld+json">
+{json_ld}
+  </script>
+  <style>
+{INLINE_CSS}
+  </style>
+</head>
+<body>
+  <div class="page-wrap">
+    <header class="page-header">
+      <h1>Sovereign Capability Profiles</h1>
+      <p class="page-subtitle">Actor Designation Framework — {total_actors} actors assessed</p>
+      <p class="page-framework">{framework_desc}</p>
+      <div class="page-meta">
+        <span>Assessment date: {assessment_date}</span>
+        <span>Methodology: V{methodology_version}</span>
+        <span>Register: SCP-REG-009</span>
+      </div>
+      <p class="legend-heading">Dimensions</p>
+      {legend_html}
+    </header>
+
+    <main>
+{sections_html}
+      {watch_html}
+    </main>
+
+    <footer class="page-footer">
+      <p class="footer-cta">Full analysis and sources for all actors available with supporter access.</p>
+      <div class="footer-links">
+        <a href="/?scp=open">Explore the interactive Sovereign Capability Profiles →</a>
+        <a href="/research/methodology/manual/">Methodology Manual →</a>
+      </div>
+      <p class="footer-copy">SCP Register v1.0 · Assessment: May 2026 · Methodology V1.4 · © 2026 Warmth Engine</p>
+    </footer>
+  </div>
+</body>
+</html>"""
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Generate static SCP profiles page')
+    parser.add_argument('--input',  required=True, help='Path to actors-free.json')
+    parser.add_argument('--output', required=True, help='Output path for index.html')
+    args = parser.parse_args()
+
+    input_path  = Path(args.input).expanduser()
+    output_path = Path(args.output).expanduser()
+
+    with open(input_path, encoding='utf-8') as f:
+        data = json.load(f)
+
+    html = generate_html(data)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, 'w', encoding='utf-8') as f:
+        f.write(html)
+
+    print(f'Generated: {output_path}')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/generate_profiles.py
+++ b/scripts/generate_profiles.py
@@ -1,684 +1,247 @@
 #!/usr/bin/env python3
 """
-generate_profiles.py — Generate static SCP profiles page for warmthengine.com/profiles/
-Usage: python3 scripts/generate_profiles.py --input path/to/actors-free.json --output profiles/index.html
+generate_profiles.py — Produces profiles/index.html from actors-free.json.
+
+Uses the exact SCP panel CSS classes and HTML structure from the homepage.
+Actors collapsed by default via <details>/<summary>.
+Run: python3 scripts/generate_profiles.py --input path/to/actors-free.json --output profiles/index.html
 """
 
-import json
-import argparse
-import html as _html
-from pathlib import Path
+import json, argparse, html as html_mod, os, sys
+from datetime import date
 
+# ── Constants matching index.html SCP panel ──
+DN = ['AI Chip Design','Advanced Fabrication','Critical Equipment','AI Compute','Frontier Models','AI Regulation','Sovereign Investment']
+DS = ['Chip','Fab','Equip','Compute','Models','Reg','Invest']
+DC = ['hw','hw','hw','pl','pl','gv','gv']
+DK = ['D1','D2','D3','D4','D5','D6','D7']
+BC = {'PAA':'scp-badge-paa','AIK':'scp-badge-aik','ACS':'scp-badge-acs','Part':'scp-badge-part'}
+BL = {'PAA':'PAA','AIK':'AIK','ACS':'ACS','Part':'Part'}
+GN = {'PAA':'Principal AI Actors','AIK':'AI Infrastructure Keystones','ACS':'Advanced Capability States'}
+GC = ['Grade 1','Grade 2','Grade 3']
+GCLS = ['scp-src-g1','scp-src-g2','scp-src-g3']
+LOCK_ICON = '🔒'
+
+GROUP_ORDER = ['PAA','AIK','ACS','Part']
 
 def esc(s):
-    if s is None:
-        return ''
-    return _html.escape(str(s))
-
-
-DESIGNATION_ORDER = ['PAA', 'AIK', 'ACS', 'Participant']
-DESIGNATION_LABELS = {
-    'PAA': 'Principal AI Actors',
-    'AIK': 'AI Infrastructure Keystones',
-    'ACS': 'Advanced Capability States',
-    'Participant': 'Participants',
-}
-
-ACTOR_ORDER = ['US', 'CN', 'JP', 'KR', 'NL', 'EU', 'TW', 'FR', 'DE', 'GB', 'IN', 'IL', 'RU', 'CA']
-
-DIM_CATEGORIES = {
-    'D1': 'hw', 'D2': 'hw', 'D3': 'hw',
-    'D4': 'pl', 'D5': 'pl',
-    'D6': 'gv', 'D7': 'gv',
-}
-
-GRADE_STYLES = {
-    1: ('rgba(245,158,11,0.15)', '#F59E0B', 'rgba(245,158,11,0.35)'),
-    2: ('rgba(59,130,246,0.15)',  '#3B82F6', 'rgba(59,130,246,0.35)'),
-    3: ('rgba(100,116,139,0.15)', '#94A3B8', 'rgba(100,116,139,0.3)'),
-}
-
-INLINE_CSS = """
-*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-
-:root {
-  /* WEO design tokens — aligned with index.html / 404.html */
-  --weo-surface-base:    #0F172A;
-  --weo-surface-raised:  #1E293B;
-  --weo-text-primary:    #E2E8F0;
-  --weo-text-secondary:  rgba(226, 232, 240, 0.7);
-  --weo-text-muted:      #94A3B8;
-  --weo-accent-hover:    #60A5FA;
-  --weo-border-primary:  #334155;
-  --weo-radius-sm:       4px;
-  --weo-radius-md:       8px;
-  --weo-radius-lg:       12px;
-
-  /* SCP palette */
-  --scp-hw:   #60A5FA;
-  --scp-pl:   #A78BFA;
-  --scp-gv:   #2DD4BF;
-  --scp-paa:  #F59E0B;
-  --scp-aik:  #06B6D4;
-  --scp-acs:  #A855F7;
-  --scp-part: #64748B;
-  --scp-met:  #22C55E;
-
-  /* local shorthand */
-  --r-pill: 20px;
-}
-
-html { scroll-behavior: smooth; }
-
-/* ── Focus & motion ── */
-*:focus { outline: none; }
-*:focus-visible { outline: 2px solid var(--weo-accent-hover); outline-offset: 2px; }
-
-@media (prefers-reduced-motion: reduce) {
-  *, *::before, *::after {
-    animation-duration: 0.01ms !important;
-    animation-iteration-count: 1 !important;
-    transition-duration: 0.01ms !important;
-  }
-}
-
-body {
-  background: var(--weo-surface-base);
-  color: var(--weo-text-primary);
-  font-family: 'Geist', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  line-height: 1.6;
-  -webkit-font-smoothing: antialiased;
-}
-
-/* ── Geist dark-mode weight compensation ──
-   Variable font weights adjusted for light-on-dark halation.
-   Standard 400 body → 380, standard 600 heading → 580, standard 500 data → 480. */
-body               { font-weight: 380; }
-.page-header h1    { font-weight: 580; }
-.actor-name        { font-weight: 580; }
-.desig-heading h2  { font-weight: 580; }
-.watch-section h2  { font-weight: 580; }
-.dim-status        { font-weight: 580; }
-.constraint-label  { font-weight: 580; }
-.sev-label         { font-weight: 580; }
-.aik-label         { font-weight: 580; }
-.actor-badge       { font-weight: 580; }
-.src-type          { font-weight: 580; }
-.src-grade         { font-weight: 580; }
-.actor-score       { font-weight: 480; }
-.dim-key           { font-weight: 480; }
-.dim-ref           { font-weight: 480; }
-.legend-key        { font-weight: 480; }
-
-a { color: var(--weo-accent-hover); text-decoration: none; }
-a:hover { text-decoration: underline; }
-
-.page-wrap { max-width: 900px; margin: 0 auto; padding: 0 20px 60px; }
-
-/* ── Page header ── */
-.page-header {
-  padding: 48px 0 36px;
-  border-bottom: 1px solid var(--weo-border-primary);
-  margin-bottom: 40px;
-}
-.page-header h1 {
-  font-size: 28px; color: var(--weo-text-primary);
-  letter-spacing: -0.02em; margin-bottom: 6px;
-}
-.page-subtitle { font-size: 15px; color: var(--weo-text-secondary); margin-bottom: 18px; }
-.page-framework {
-  font-size: 13px; color: var(--weo-text-secondary); line-height: 1.7;
-  max-width: 720px; margin-bottom: 20px;
-}
-.page-meta {
-  display: flex; gap: 20px; flex-wrap: wrap;
-  font-size: 12px; color: #64748B; margin-bottom: 24px;
-}
-
-/* ── Dimension legend ── */
-.legend-heading {
-  font-size: 11px; color: var(--weo-text-muted);
-  letter-spacing: 0.08em; text-transform: uppercase; margin-bottom: 10px;
-}
-.dim-legend {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
-  gap: 6px;
-}
-.legend-item {
-  display: flex; align-items: center; gap: 7px;
-  font-size: 12px; padding: 6px 8px;
-  background: rgba(30,41,59,0.5); border-radius: var(--weo-radius-sm);
-  border: 1px solid var(--weo-border-primary);
-  min-width: 0;
-}
-.legend-dot { width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0; }
-.legend-key {
-  font-family: 'Geist Mono', 'Fira Code', 'Consolas', monospace; font-size: 10px;
-  color: #64748B; flex-shrink: 0; min-width: 20px;
-}
-.legend-name { color: var(--weo-text-muted); flex-shrink: 0; min-width: 100px; }
-.legend-desc {
-  color: #64748B; font-size: 11px;
-  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
-}
-
-/* ── Designation groups ── */
-.desig-section { margin-bottom: 48px; }
-.desig-heading { display: flex; align-items: center; gap: 12px; margin-bottom: 18px; }
-.desig-heading h2 { font-size: 14px; letter-spacing: 0.01em; white-space: nowrap; }
-.desig-line { flex: 1; height: 1px; background: var(--weo-border-primary); }
-.desig-paa .desig-heading h2         { color: var(--scp-paa); }
-.desig-aik .desig-heading h2         { color: var(--scp-aik); }
-.desig-acs .desig-heading h2         { color: var(--scp-acs); }
-.desig-participant .desig-heading h2 { color: var(--scp-part); }
-
-/* ── Actor cards ── */
-.actor-card {
-  background: var(--weo-surface-raised);
-  border: 1px solid var(--weo-border-primary);
-  border-radius: var(--weo-radius-md);
-  box-shadow: 0 1px 3px rgba(0,0,0,0.2), 0 0 0 1px rgba(255,255,255,0.03);
-  margin-bottom: 14px; overflow: hidden;
-}
-.actor-header {
-  padding: 14px 20px 12px; border-bottom: 1px solid var(--weo-border-primary);
-}
-.actor-title-row {
-  display: flex; align-items: center; justify-content: space-between;
-  flex-wrap: wrap; gap: 8px; margin-bottom: 10px;
-}
-.actor-name {
-  font-size: 17px; color: var(--weo-text-primary);
-  display: flex; align-items: center; gap: 8px;
-}
-.actor-meta { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
-.actor-score {
-  font-family: 'Geist Mono', 'Fira Code', 'Consolas', monospace; font-size: 13px;
-  color: var(--weo-text-muted);
-  background: rgba(255,255,255,0.05); padding: 2px 8px;
-  border-radius: var(--weo-radius-sm); border: 1px solid var(--weo-border-primary);
-}
-.actor-badge {
-  font-size: 11px; letter-spacing: 0.04em;
-  padding: 3px 10px; border-radius: var(--r-pill); border: 1px solid;
-}
-.badge-paa         { background: rgba(245,158,11,0.15); color: #F59E0B;  border-color: rgba(245,158,11,0.35); }
-.badge-aik         { background: rgba(6,182,212,0.12);  color: #22D3EE;  border-color: rgba(6,182,212,0.3); }
-.badge-acs         { background: rgba(168,85,247,0.12); color: #C084FC;  border-color: rgba(168,85,247,0.3); }
-.badge-participant { background: rgba(100,116,139,0.12); color: #64748B; border-color: rgba(100,116,139,0.25); }
-.sample-badge {
-  font-size: 10px;
-  background: rgba(255,215,0,0.1); color: #FFD700;
-  border: 1px solid rgba(255,215,0,0.25); padding: 1px 6px;
-  border-radius: 3px; letter-spacing: 0.03em;
-}
-
-/* ── Dimension bar ── */
-.dim-bar { display: flex; gap: 4px; align-items: center; }
-.dim-bar-dot {
-  width: 10px; height: 10px; border-radius: 50%; border: 1.5px solid;
-  flex-shrink: 0;
-}
-.dim-bar-dot.hw.met  { background: var(--scp-hw); border-color: var(--scp-hw); }
-.dim-bar-dot.pl.met  { background: var(--scp-pl); border-color: var(--scp-pl); }
-.dim-bar-dot.gv.met  { background: var(--scp-gv); border-color: var(--scp-gv); }
-.dim-bar-dot.hw.nmet { background: transparent; border-color: rgba(96,165,250,0.3); }
-.dim-bar-dot.pl.nmet { background: transparent; border-color: rgba(167,139,250,0.3); }
-.dim-bar-dot.gv.nmet { background: transparent; border-color: rgba(45,212,191,0.3); }
-
-/* ── Actor body ── */
-.actor-body { padding: 0 20px 14px; }
-
-/* ── Dimensions list ── */
-.dimensions-list { list-style: none; }
-
-.dim-item { border-bottom: 1px solid rgba(255,255,255,0.04); padding: 9px 0; }
-.dim-item:last-of-type { border-bottom: none; }
-
-.dim-header {
-  display: flex; align-items: center; gap: 7px;
-  font-size: 13px; flex-wrap: wrap;
-}
-.dim-dot { width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }
-.dim-dot.hw     { background: rgba(96,165,250,0.3); }
-.dim-dot.pl     { background: rgba(167,139,250,0.3); }
-.dim-dot.gv     { background: rgba(45,212,191,0.3); }
-.dim-dot.hw.met { background: var(--scp-hw); }
-.dim-dot.pl.met { background: var(--scp-pl); }
-.dim-dot.gv.met { background: var(--scp-gv); }
-.dim-key {
-  font-family: 'Geist Mono', 'Fira Code', 'Consolas', monospace; font-size: 10px;
-  color: #64748B; flex-shrink: 0; min-width: 20px;
-}
-.dim-name  { color: var(--weo-text-muted); flex: 1; }
-.dim-status { font-size: 11px; flex-shrink: 0; }
-.dim-met   { color: var(--scp-met); }
-.dim-nmet  { color: #64748B; }
-
-.dim-qual-hl {
-  font-size: 12px; color: var(--weo-text-secondary); line-height: 1.55;
-  padding: 4px 0 2px 13px;
-}
-.dim-constraint {
-  font-size: 12px; color: #64748B; line-height: 1.55;
-  padding: 4px 0 2px 13px; font-style: italic;
-}
-.constraint-label { font-style: normal; color: var(--weo-text-secondary); }
-
-.dim-details-dd { padding: 2px 0 2px 13px; }
-details.dim-details summary {
-  font-size: 11px; color: #64748B; cursor: pointer;
-  padding: 3px 0; display: inline-flex; align-items: center; gap: 5px;
-  list-style: none; -webkit-appearance: none; transition: color 0.15s;
-}
-details.dim-details summary::-webkit-details-marker { display: none; }
-details.dim-details summary::before { content: '▸'; font-size: 9px; }
-details.dim-details[open] summary::before { content: '▾'; }
-details.dim-details summary:hover { color: var(--weo-text-muted); }
-
-.dim-qual-block {
-  margin-top: 6px; padding: 10px 12px;
-  background: rgba(15,23,42,0.6); border-radius: var(--weo-radius-sm);
-  border: 1px solid var(--weo-border-primary);
-  font-size: 12px; color: var(--weo-text-secondary); line-height: 1.65;
-}
-
-/* ── Sources ── */
-.src-block {
-  margin-top: 6px; padding: 10px 12px;
-  background: rgba(15,23,42,0.6); border-radius: var(--weo-radius-sm);
-  border: 1px solid var(--weo-border-primary);
-}
-.src-entry {
-  padding: 8px 0; border-bottom: 1px solid rgba(255,255,255,0.04);
-}
-.src-entry:last-child { border-bottom: none; padding-bottom: 0; }
-.src-meta {
-  display: flex; flex-wrap: wrap; align-items: center; gap: 8px; margin-bottom: 5px;
-}
-.src-type  { font-size: 10px; color: var(--weo-text-muted); text-transform: uppercase; letter-spacing: 0.05em; }
-.src-grade { font-size: 10px; padding: 1px 7px; border-radius: 3px; }
-.src-pub   { font-size: 11px; color: var(--weo-text-muted); }
-.src-date  { font-size: 10px; color: #64748B; }
-.src-fact  { font-size: 11px; color: var(--weo-text-secondary); line-height: 1.55; margin-bottom: 5px; }
-.src-link  { font-size: 11px; color: var(--weo-accent-hover); }
-
-/* ── AIK chokepoint ── */
-.aik-profile {
-  margin-top: 12px; padding: 10px 12px;
-  background: rgba(6,182,212,0.06); border: 1px solid rgba(6,182,212,0.15);
-  border-radius: var(--weo-radius-sm);
-}
-.aik-label  {
-  font-size: 10px; color: var(--weo-text-muted);
-  letter-spacing: 0.07em; text-transform: uppercase; margin-bottom: 4px;
-}
-.aik-nature   { font-size: 13px; color: var(--weo-text-secondary); line-height: 1.45; }
-.aik-entities { font-size: 11px; color: #64748B; font-style: italic; line-height: 1.55; margin-top: 3px; }
-
-/* ── Severance ── */
-.actor-severance {
-  font-size: 12px; color: #64748B; margin-top: 12px;
-  padding-top: 10px; border-top: 1px solid rgba(255,255,255,0.04);
-  line-height: 1.55;
-}
-.sev-label  { color: var(--weo-text-secondary); }
-.sev-pass   { color: var(--scp-met); }
-.sev-fail   { color: #F87171; }
-
-/* ── Dimension watch ── */
-.watch-section {
-  margin-top: 48px; padding-top: 32px; border-top: 1px solid var(--weo-border-primary);
-}
-.watch-section h2 {
-  font-size: 17px; color: var(--weo-text-primary); margin-bottom: 8px;
-}
-.watch-desc { font-size: 13px; color: #64748B; margin-bottom: 16px; }
-.table-wrap { overflow-x: auto; -webkit-overflow-scrolling: touch; }
-.watch-table { width: 100%; border-collapse: collapse; font-size: 12px; }
-.watch-table th {
-  text-align: left; font-size: 10px;
-  color: var(--weo-text-muted); text-transform: uppercase;
-  letter-spacing: 0.06em; padding: 8px 12px;
-  border-bottom: 1px solid var(--weo-border-primary); white-space: nowrap;
-}
-.watch-table td {
-  padding: 10px 12px; border-bottom: 1px solid rgba(255,255,255,0.03);
-  vertical-align: top; color: var(--weo-text-secondary); line-height: 1.5;
-}
-.watch-table tr:last-child td { border-bottom: none; }
-.watch-table tr:hover td { background: rgba(255,255,255,0.01); }
-.dim-ref {
-  font-family: 'Geist Mono', 'Fira Code', 'Consolas', monospace; font-size: 10px;
-  color: var(--weo-text-muted);
-}
-.w-met  { color: var(--scp-met); }
-.w-nmet { color: #64748B; }
-
-/* ── Footer ── */
-.page-footer {
-  margin-top: 56px; padding-top: 24px; border-top: 1px solid var(--weo-border-primary);
-  font-size: 12px; color: #64748B; line-height: 1.8;
-}
-.footer-cta {
-  font-size: 13px; color: var(--weo-text-secondary); margin-bottom: 14px;
-  padding: 10px 14px;
-  background: rgba(96,165,250,0.05); border: 1px solid rgba(96,165,250,0.15);
-  border-radius: var(--weo-radius-sm);
-}
-.footer-links { display: flex; flex-wrap: wrap; gap: 16px; margin-bottom: 12px; }
-.footer-links a { color: var(--weo-accent-hover); }
-.footer-mono {
-  font-family: 'Geist Mono', 'Fira Code', 'Consolas', monospace;
-  font-size: 11px; color: var(--weo-text-muted); opacity: 0.5;
-  letter-spacing: 0.04em;
-}
-
-/* ── Responsive ── */
-@media (max-width: 600px) {
-  .page-header h1 { font-size: 22px; }
-  .actor-title-row { flex-direction: column; align-items: flex-start; }
-  .dim-legend { grid-template-columns: 1fr; }
-  .page-meta { flex-direction: column; gap: 4px; }
-  .actor-name { font-size: 15px; }
-}
-@media (max-width: 375px) {
-  .page-wrap { padding: 0 12px 40px; }
-  .page-header { padding: 32px 0 24px; }
-}
-"""
-
-
-def render_source(label, src):
-    grade = src.get('grade', 3)
-    bg, color, border = GRADE_STYLES.get(grade, GRADE_STYLES[3])
-    grade_label = f'Grade {grade}'
-    pub = esc(src.get('publisher', ''))
-    date = esc(src.get('date', ''))
-    fact = esc(src.get('qualifying_fact', ''))
-    url = esc(src.get('url', ''))
-    return f"""<div class="src-entry">
-  <div class="src-meta">
-    <span class="src-type">{label}</span>
-    <span class="src-grade" style="background:{bg};color:{color};border:1px solid {border};">{grade_label}</span>
-    <span class="src-pub">{pub}</span>
-    <span class="src-date">{date}</span>
-  </div>
-  <p class="src-fact">{fact}</p>
-  <a href="{url}" class="src-link" target="_blank" rel="noopener noreferrer">View source →</a>
-</div>"""
-
-
-def render_dimension(dim_key, dim_data, dim_info, is_sample):
-    met = dim_data.get('met', False)
-    cat = DIM_CATEGORIES.get(dim_key, 'hw')
-    dot_class = f"dim-dot {cat}{' met' if met else ''}"
-    dim_name = esc(dim_info.get('name', dim_key))
-    status_class = 'dim-met' if met else 'dim-nmet'
-    status_label = 'Met' if met else 'Not Met'
-
-    detail_rows = ''
-
-    if met:
-        qual_headline = dim_data.get('qualification_headline')
-        constraint = dim_data.get('constraint')
-        qualification = dim_data.get('qualification')
-        sources = dim_data.get('sources')
-
-        if qual_headline:
-            detail_rows += f'<dd class="dim-qual-hl">{esc(qual_headline)}</dd>\n'
-
-        if constraint:
-            detail_rows += f'<dd class="dim-constraint"><em>{esc(constraint)}</em></dd>\n'
-
-        if is_sample and qualification:
-            detail_rows += f"""<dd class="dim-details-dd">
-  <details class="dim-details">
-    <summary>Qualification</summary>
-    <div class="dim-qual-block">{esc(qualification)}</div>
-  </details>
-</dd>
-"""
-
-        if is_sample and sources:
-            src_entries = ''
-            for label, src in [('Primary', sources.get('primary')), ('Corroborating', sources.get('corroborating'))]:
-                if src:
-                    src_entries += render_source(label, src)
-            detail_rows += f"""<dd class="dim-details-dd">
-  <details class="dim-details">
-    <summary>Sources</summary>
-    <div class="src-block">{src_entries}</div>
-  </details>
-</dd>
-"""
-    else:
-        constraint_headline = dim_data.get('constraint_headline')
-        constraint = dim_data.get('constraint')
-
-        if constraint_headline:
-            detail_rows += (
-                f'<dd class="dim-constraint">'
-                f'<span class="constraint-label">Constraint:</span> {esc(constraint_headline)}'
-                f'</dd>\n'
-            )
-
-        if is_sample and constraint:
-            detail_rows += f'<dd class="dim-constraint">{esc(constraint)}</dd>\n'
-
-    return f"""<div class="dim-item">
-<dt class="dim-header">
-  <span class="{dot_class}"></span>
-  <span class="dim-key">{dim_key}</span>
-  <span class="dim-name">{dim_name}</span>
-  <span class="dim-status {status_class}">{status_label}</span>
-</dt>
-{detail_rows}</div>"""
-
-
-def render_dim_bar(dimensions):
-    dots = []
-    for dk in ['D1', 'D2', 'D3', 'D4', 'D5', 'D6', 'D7']:
-        met = dimensions.get(dk, {}).get('met', False)
-        cat = DIM_CATEGORIES[dk]
-        mc = 'met' if met else 'nmet'
-        dots.append(f'<span class="dim-bar-dot {cat} {mc}" title="{dk}"></span>')
-    return '<div class="dim-bar">' + ''.join(dots) + '</div>'
-
-
-def render_actor(actor, dimensions_meta):
-    actor_id = actor['id'].lower()
-    name = esc(actor['name'])
-    score = actor.get('score', 0)
-    designation = actor.get('designation', 'Participant')
-    is_sample = actor.get('sample', False)
-    severance = actor.get('severance')
-    severance_detail = actor.get('severance_detail', '')
-    aik_profile = actor.get('aik_profile')
-    dimensions = actor.get('dimensions', {})
-
-    badge_class = f'badge-{designation.lower()}'
-
-    dim_bar_html = render_dim_bar(dimensions)
-
-    dims_html = ''
-    for dk in ['D1', 'D2', 'D3', 'D4', 'D5', 'D6', 'D7']:
-        dims_html += render_dimension(dk, dimensions.get(dk, {}), dimensions_meta.get(dk, {}), is_sample)
-
-    aik_html = ''
-    if aik_profile:
-        nature = esc(aik_profile.get('chokepoint_nature', ''))
-        entities = esc(aik_profile.get('key_entities', ''))
-        aik_html = f"""<div class="aik-profile">
-  <div class="aik-label">Chokepoint Profile</div>
-  <div class="aik-nature">{nature}</div>
-  <div class="aik-entities">{entities}</div>
-</div>"""
-
-    sev_html = ''
-    if severance is not None:
-        sev_class = 'sev-pass' if severance == 'PASS' else 'sev-fail'
-        sev_text = f'<span class="{sev_class}">{esc(severance)}</span>'
-        if severance_detail:
-            sev_text += f' — {esc(severance_detail)}'
-        sev_html = f'<div class="actor-severance"><span class="sev-label">Severance:</span> {sev_text}</div>'
-
-    sample_badge = '<span class="sample-badge">Sample</span> ' if is_sample else ''
-
-    return f"""<article id="{actor_id}" class="actor-card">
-  <header class="actor-header">
-    <div class="actor-title-row">
-      <h3 class="actor-name">{sample_badge}{name}</h3>
-      <div class="actor-meta">
-        <span class="actor-score">{score}/7</span>
-        <span class="actor-badge {badge_class}">{esc(designation)}</span>
-      </div>
-    </div>
-    {dim_bar_html}
-  </header>
-  <div class="actor-body">
-    <dl class="dimensions-list">
-{dims_html}
-    </dl>
-    {aik_html}
-    {sev_html}
-  </div>
-</article>"""
-
-
-def render_watch(watch_list, actors_by_id, dimensions_meta):
-    rows = ''
-    for item in watch_list:
-        actor_id = item.get('actor_id', '')
-        actor_name = esc(actors_by_id.get(actor_id, {}).get('name', actor_id))
-        dim = item.get('dimension', '')
-        dim_name = esc(dimensions_meta.get(dim, {}).get('name', ''))
-        current = esc(item.get('current', ''))
-        expected = esc(item.get('expected_change', ''))
-        trigger = esc(item.get('trigger', ''))
-        timeline = esc(item.get('timeline', ''))
-        cur_class = 'w-met' if item.get('current') == 'MET' else 'w-nmet'
-        rows += f"""<tr>
-  <td><a href="#{actor_id.lower()}">{actor_name}</a></td>
-  <td><span class="dim-ref">{esc(dim)}</span> {dim_name}</td>
-  <td class="{cur_class}">{current}</td>
-  <td>{expected}</td>
-  <td>{trigger}</td>
-  <td>{timeline}</td>
-</tr>
-"""
-    return f"""<section class="watch-section">
-  <h2>Dimension Watch</h2>
-  <p class="watch-desc">Dimensions under active monitoring for potential status change at next assessment.</p>
-  <div class="table-wrap">
-    <table class="watch-table">
-      <thead>
-        <tr>
-          <th>Actor</th>
-          <th>Dimension</th>
-          <th>Current</th>
-          <th>Expected Change</th>
-          <th>Trigger</th>
-          <th>Timeline</th>
-        </tr>
-      </thead>
-      <tbody>
-{rows}
-      </tbody>
-    </table>
-  </div>
-</section>"""
-
-
-def render_legend(dimensions_meta):
-    items = ''
-    for dk in ['D1', 'D2', 'D3', 'D4', 'D5', 'D6', 'D7']:
-        info = dimensions_meta.get(dk, {})
-        cat = DIM_CATEGORIES[dk]
-        cat_var = {'hw': 'var(--scp-hw)', 'pl': 'var(--scp-pl)', 'gv': 'var(--scp-gv)'}[cat]
-        name = esc(info.get('name', dk))
-        desc = esc(info.get('description', ''))
-        items += f"""<div class="legend-item">
-  <span class="legend-dot" style="background:{cat_var};flex-shrink:0;"></span>
-  <span class="legend-key">{dk}</span>
-  <span class="legend-name">{name}</span>
-  <span class="legend-desc">{desc}</span>
-</div>
-"""
-    return f'<div class="dim-legend">\n{items}</div>'
-
-
-def generate_html(data):
-    meta = data['metadata']
-    dims = data['dimensions']
-    actors = data['actors']
-    watch = data.get('dimension_watch', [])
-
-    actors_by_id = {a['id']: a for a in actors}
-
-    groups = {d: [] for d in DESIGNATION_ORDER}
-    for actor_id in ACTOR_ORDER:
-        if actor_id in actors_by_id:
-            actor = actors_by_id[actor_id]
-            groups.setdefault(actor.get('designation', 'Participant'), []).append(actor)
-
-    sections_html = ''
-    for des in DESIGNATION_ORDER:
-        group = groups.get(des, [])
-        if not group:
-            continue
-        label = DESIGNATION_LABELS.get(des, des)
-        des_class = f'desig-{des.lower()}'
-        actors_html = ''.join(render_actor(a, dims) for a in group)
-        sections_html += f"""<section class="desig-section {des_class}">
-  <div class="desig-heading">
-    <h2>{label} ({len(group)})</h2>
-    <div class="desig-line"></div>
-  </div>
-  {actors_html}
-</section>
-"""
-
-    assessment_date = esc(meta.get('assessment_date', ''))
-    methodology_version = esc(meta.get('methodology_version', ''))
-    total_actors = meta.get('total_actors', 14)
-
-    legend_html = render_legend(dims)
-    watch_html = render_watch(watch, actors_by_id, dims)
-
-    json_ld = json.dumps({
-        "@context": "https://schema.org",
-        "@type": "Dataset",
-        "name": "WEO Sovereign Capability Profiles",
-        "description": "Nation-state AI infrastructure capability assessments across 7 dimensions for 14 actors",
-        "url": "https://warmthengine.com/profiles/",
-        "creator": {
-            "@type": "Organisation",
-            "name": "Warmth Engine Observatory",
-            "url": "https://warmthengine.com"
-        },
-        "dateModified": "2026-06-03",
-        "license": "https://warmthengine.com/research/methodology/manual/"
-    }, indent=2)
-
-    framework_desc = (
-        "The Sovereign Capability Profile (SCP) framework assesses nation-state control of the AI infrastructure "
-        "stack across seven dimensions: chip design, advanced fabrication, critical equipment, AI compute, frontier "
-        "models, AI regulation, and sovereign investment. Actors are designated as Principal AI Actors (PAA), "
-        "AI Infrastructure Keystones (AIK), Advanced Capability States (ACS), or Participants through a three-gate "
-        "framework evaluating dimensional breadth, severance resilience, and platform sustainability."
-    )
-
-    return f"""<!DOCTYPE html>
+    return html_mod.escape(s or '', quote=True)
+
+def normalize(actor):
+    dims = [1 if actor['dimensions'].get(k,{}).get('met') else 0 for k in DK]
+    con = [actor['dimensions'].get(k,{}).get('constraint') for k in DK]
+    hl = [actor['dimensions'].get(k,{}).get('constraint_headline') for k in DK]
+    qhl = [actor['dimensions'].get(k,{}).get('qualification_headline') for k in DK]
+    qual = [actor['dimensions'].get(k,{}).get('qualification') for k in DK]
+    src = []
+    for k in DK:
+        dim = actor['dimensions'].get(k,{})
+        s = dim.get('sources')
+        if not s: src.append(None); continue
+        p = s.get('primary',{}); c = s.get('corroborating',{})
+        if not p.get('publisher'): src.append(None); continue
+        src.append([p.get('grade'),p.get('publisher'),p.get('date'),p.get('qualifying_fact'),p.get('url'),
+                     c.get('grade'),c.get('publisher'),c.get('date'),c.get('qualifying_fact'),c.get('url')])
+    desig = actor.get('designation','Participant')
+    d = 'Part' if desig == 'Participant' else desig
+    return {
+        'id': actor['id'], 'n': actor['name'], 's': actor.get('score',0),
+        'd': d, 'dims': dims, 'con': con, 'hl': hl, 'qhl': qhl, 'qual': qual,
+        'svd': actor.get('severance_detail'), 'src': src,
+        'aik': actor.get('aik_profile'), 'sample': actor.get('sample', False)
+    }
+
+def star_svg():
+    return '<span style="display:inline-block;vertical-align:super;margin-left:3px;line-height:1;"><svg width="10" height="10" viewBox="0 0 24 24" fill="rgba(255,215,0,0.25)" stroke="#FFD700" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg></span>'
+
+def src_entry_html(label, s, offset):
+    grade = s[offset]; pub = s[offset+1]; dt = s[offset+2]; fact = s[offset+3]; url = s[offset+4]
+    if not pub: return ''
+    gi = (grade or 1) - 1
+    h = f'<div class="scp-src-entry">'
+    h += f'<span class="scp-src-label">{label}</span> '
+    h += f'<span class="scp-src-grade {GCLS[gi]}">{GC[gi]}</span>'
+    h += f'{esc(pub)} · {esc(dt or "")}'
+    if url: h += f' <a href="{esc(url)}" target="_blank" rel="noopener" class="scp-src-link">↗</a>'
+    h += f'<br><span class="scp-src-fact">{esc(fact or "")}</span>'
+    h += '</div>'
+    return h
+
+def detail_html(a):
+    h = ''
+    for i in range(7):
+        d = a['dims'][i]
+        h += '<div class="scp-dim-row">'
+        h += f'<span class="scp-dim-name"><span class="scp-dim-dot {DC[i]}"></span>{DN[i]}</span>'
+        h += f'<span class="scp-dim-st {"scp-dim-met" if d else "scp-dim-not"}">{"Met" if d else "Not Met"}</span>'
+        h += '</div>'
+        # Qualification headline (MET)
+        if d and a['qhl'][i]:
+            h += f'<div class="scp-dim-qual-hl">{esc(a["qhl"][i])}</div>'
+        # Constraint
+        if d and a['con'][i]:
+            h += f'<div class="scp-dim-constraint">{esc(a["con"][i])}</div>'
+        elif not d and a['con'][i]:
+            h += f'<div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> {esc(a["con"][i])}</div>'
+        elif not d and a['hl'][i]:
+            h += f'<div class="scp-dim-constraint"><span class="scp-dim-con-label">Constraint:</span> {esc(a["hl"][i])}</div>'
+        # Qualification expandable (paid tier — only US sample has this data)
+        if d and a['qual'][i]:
+            h += '<details class="scp-expand"><summary class="scp-qual-trigger"><span class="scp-src-icon">▸</span> Qualification</summary>'
+            h += f'<div class="scp-qual-block">{esc(a["qual"][i])}</div></details>'
+        # Sources
+        if a['src'][i]:
+            s = a['src'][i]
+            h += '<details class="scp-expand"><summary class="scp-src-trigger"><span class="scp-src-icon">ⓘ</span> Sources</summary>'
+            h += '<div class="scp-src-block">'
+            h += src_entry_html('Primary', s, 0)
+            h += src_entry_html('Corroborating', s, 5)
+            h += '</div></details>'
+        elif d or (not d and (a['con'][i] or a['hl'][i])):
+            h += f'<div class="scp-src-lock">{LOCK_ICON} Sources (supporter access)</div>'
+
+    # AIK Chokepoint Profile
+    if a['aik'] and a['d'] == 'AIK':
+        h += '<div class="scp-aik">'
+        h += '<div class="scp-aik-label">Chokepoint Profile</div>'
+        h += f'<div class="scp-aik-nature">{esc(a["aik"].get("chokepoint_nature",""))}</div>'
+        h += f'<div class="scp-aik-entities">{esc(a["aik"].get("key_entities",""))}</div>'
+        h += '</div>'
+
+    # Severance
+    if a['svd']:
+        sev_word = 'PASS' if 'PASS' in (a.get('svd','') or '') or a.get('d') in ('PAA','AIK') else 'FAIL'
+        # Check actual data
+        h += f'<div class="scp-sev"><strong>Severance:</strong> {esc(a["svd"])}</div>'
+    elif a['d'] in ('PAA','AIK','ACS'):
+        h += f'<div class="scp-src-lock">{LOCK_ICON} Severance analysis (supporter access)</div>'
+
+    return h
+
+def row_html(a):
+    name_suffix = star_svg() if a['sample'] else ''
+    h = f'<span class="scp-row-name" title="{esc(a["n"])}">{esc(a["n"])}{name_suffix}</span>'
+    h += '<div class="scp-row-bar">'
+    for i in range(7):
+        seg_cls = f' {DC[i]}-m' if a['dims'][i] else ''
+        h += f'<div class="scp-row-seg{seg_cls}" data-di="{i}"></div>'
+    h += '</div>'
+    h += f'<span class="scp-row-score">{a["s"]}/7</span>'
+    h += f'<span class="scp-row-badge"><span class="scp-badge {BC[a["d"]]}">{BL[a["d"]]}</span></span>'
+    h += '<span class="scp-row-chev">▼</span>'
+    return h
+
+def dim_watch_html(watches):
+    if not watches: return ''
+    h = '<div class="scp-watch">'
+    h += '<h2 class="scp-watch-title">Dimension Watch</h2>'
+    h += '<p class="scp-watch-desc">Dimensions approaching a status change at the next assessment cycle.</p>'
+    h += '<div class="scp-watch-wrap"><table class="scp-watch-table">'
+    h += '<thead><tr><th>Actor</th><th>Dimension</th><th>Current</th><th>Expected</th><th>Trigger</th><th>Timeline</th></tr></thead>'
+    h += '<tbody>'
+    for w in watches:
+        dim_key = w.get('dimension','')
+        dim_idx = DK.index(dim_key) if dim_key in DK else -1
+        dim_name = DN[dim_idx] if dim_idx >= 0 else dim_key
+        dim_cat = DC[dim_idx] if dim_idx >= 0 else ''
+        current = w.get('current','')
+        expected = w.get('expected_change','')
+        # Fix "Probable MET" -> "Possible MET"
+        if expected == 'Probable MET': expected = 'Possible MET'
+        cur_cls = 'scp-dim-met' if current == 'MET' else 'scp-dim-not'
+        actor_id = w.get('actor_id','').lower()
+        h += '<tr>'
+        h += f'<td><a href="#{actor_id}" class="scp-watch-actor">{esc(w.get("actor_id",""))}</a></td>'
+        h += f'<td><span class="scp-dim-dot {dim_cat}" style="display:inline-block;margin-right:4px;"></span>{esc(dim_name)}</td>'
+        h += f'<td class="{cur_cls}">{esc(current)}</td>'
+        h += f'<td>{esc(expected)}</td>'
+        h += f'<td>{esc(w.get("trigger",""))}</td>'
+        h += f'<td>{esc(w.get("timeline",""))}</td>'
+        h += '</tr>'
+    h += '</tbody></table></div></div>'
+    return h
+
+def pills_html(actors):
+    # Count met dimensions
+    counts = [0]*7
+    for a in actors:
+        for i in range(7):
+            if a['dims'][i]: counts[i] += 1
+    h = '<div class="scp-pills">'
+    for i in range(7):
+        h += f'<span class="scp-pill {DC[i]}" data-dim="{i}">'
+        h += f'<span class="scp-pill-dot"></span>{DS[i]} <span class="scp-pill-ct">{counts[i]}</span>'
+        h += '</span>'
+    h += '</div>'
+    return h
+
+def build_page(data):
+    actors = [normalize(a) for a in data['actors']]
+    meta = data.get('metadata', {})
+    watches = data.get('dimension_watch', [])
+
+    # Map actor IDs to names for dimension watch
+    id_to_name = {a['id']: a['n'] for a in actors}
+
+    # Group actors
+    groups = {'PAA':[],'AIK':[],'ACS':[],'Part':[]}
+    for a in actors:
+        groups[a['d']].append(a)
+
+    # Fix dimension watch actor names
+    for w in watches:
+        aid = w.get('actor_id','')
+        if aid in id_to_name:
+            w['_name'] = id_to_name[aid]
+
+    # ── Build body content ──
+    body = ''
+    body += pills_html(actors)
+    body += '<div class="scp-body">'
+
+    idx = 0
+    for gk in ['PAA','AIK','ACS']:
+        grp = groups[gk]
+        if not grp: continue
+        body += f'<div class="scp-grp">{GN[gk]} ({len(grp)})<span class="scp-grp-line"></span></div>'
+        for a in grp:
+            aid = f'scp-r{idx}'
+            body += f'<details class="scp-actor" id="{a["id"].lower()}">'
+            body += f'<summary class="scp-row">{row_html(a)}</summary>'
+            body += f'<div class="scp-detail">{detail_html(a)}</div>'
+            body += '</details>'
+            idx += 1
+        if gk == 'PAA':
+            body += '<div class="scp-paa-fold"><div class="scp-paa-fold-label">Ecosystem anchors</div></div>'
+
+    # Participants
+    parts = groups['Part']
+    body += f'<details class="scp-part-group">'
+    body += f'<summary class="scp-part-toggle"><span class="scp-part-arr">▶</span> {len(parts)} Participants</summary>'
+    body += '<div class="scp-part-rows">'
+    for a in parts:
+        aid = f'scp-r{idx}'
+        body += f'<details class="scp-actor" id="{a["id"].lower()}">'
+        body += f'<summary class="scp-row">{row_html(a)}</summary>'
+        body += f'<div class="scp-detail">{detail_html(a)}</div>'
+        body += '</details>'
+        idx += 1
+    body += '</div></details>'
+
+    body += dim_watch_html(watches)
+    body += '</div>'  # scp-body
+
+    assessment_date = meta.get('assessment_date', '2026-05-06')
+    meth_version = meta.get('methodology_version', '1.4')
+    reg_version = meta.get('register_version', 'SCP-REG-009')
+    today = date.today().isoformat()
+
+    page = f'''<!DOCTYPE html>
 <html lang="en-GB">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="weo-version" content="1.3.0">
-  <link rel="icon" type="image/png" sizes="48x48" href="/favicon_48x48.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon_32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon_16x16.png">
   <title>Sovereign Capability Profiles — AI Infrastructure Assessments | Warmth Engine Observatory</title>
   <meta name="description" content="Nation-state AI infrastructure assessments across 14 actors. Chip design, fabrication, equipment, compute, frontier models, regulation, and sovereign investment dimensions evaluated with sourced evidence.">
   <link rel="canonical" href="https://warmthengine.com/profiles/">
@@ -687,78 +250,417 @@ def generate_html(data):
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://warmthengine.com/profiles/">
   <meta property="og:image" content="https://www.warmthengine.com/og-image.png">
+  <link rel="icon" type="image/png" sizes="48x48" href="/favicon_48x48.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon_32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon_16x16.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Geist:wght@100..900&family=Geist+Mono:wght@100..900&display=swap" rel="stylesheet">
   <script type="application/ld+json">
-{json_ld}
+  {{
+    "@context": "https://schema.org",
+    "@type": "Dataset",
+    "name": "WEO Sovereign Capability Profiles",
+    "description": "Nation-state AI infrastructure capability assessments across 7 dimensions for 14 actors",
+    "url": "https://warmthengine.com/profiles/",
+    "creator": {{ "@type": "Organization", "name": "Warmth Engine Observatory", "url": "https://warmthengine.com" }},
+    "dateModified": "{today}",
+    "license": "https://warmthengine.com/research/methodology/manual/"
+  }}
   </script>
   <style>
-{INLINE_CSS}
+    /* ── Reset ── */
+    *, *::before, *::after {{ box-sizing: border-box; margin: 0; padding: 0; }}
+    *:focus {{ outline: none; }}
+    *:focus-visible {{ outline: 2px solid #60a5fa; outline-offset: 2px; }}
+
+    /* ── Tokens — exact match to index.html ── */
+    :root {{
+      --scp-hw: #60A5FA; --scp-plat: #A78BFA; --scp-gov: #2DD4BF;
+      --scp-paa: #F59E0B; --scp-aik: #06B6D4; --scp-acs: #A855F7; --scp-part: #64748B;
+      --weo-radius-sm: 4px; --weo-radius-md: 8px; --weo-radius-lg: 12px;
+      --duration-fast: 150ms; --duration-normal: 250ms;
+      --ease-out: cubic-bezier(0.33, 1, 0.68, 1);
+    }}
+
+    html {{ scroll-behavior: smooth; }}
+
+    body {{
+      font-family: 'Geist', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      font-weight: 380;
+      background: #0F172A;
+      color: #E2E8F0;
+      min-height: 100vh;
+      -webkit-font-smoothing: antialiased;
+    }}
+
+    /* ── Page frame ── */
+    .page-nav {{
+      display: flex; justify-content: space-between; align-items: center;
+      padding: 12px 32px;
+      border-bottom: 1px solid rgba(51,65,85,0.5);
+      font-size: 12px; font-weight: 480;
+      background: #1E293B;
+      position: sticky; top: 0; z-index: 100;
+    }}
+    .page-nav a {{ color: #94A3B8; text-decoration: none; transition: color var(--duration-fast); }}
+    .page-nav a:hover {{ color: #E2E8F0; }}
+    .nav-brand {{ color: #CBD5E1; font-weight: 580; display: flex; align-items: center; gap: 6px; }}
+    .nav-brand span {{ font-size: 13px; }}
+    .nav-links {{ display: flex; gap: 16px; }}
+
+    .page-wrap {{
+      max-width: 800px;
+      margin: 0 auto;
+      padding: 32px 24px 60px;
+    }}
+
+    /* ── Header ── */
+    .scp-page-title {{ font-size: 22px; font-weight: 580; color: #F1F5F9; letter-spacing: 0.01em; }}
+    .scp-page-subtitle {{ font-size: 13px; color: #94A3B8; margin-top: 4px; font-weight: 380; }}
+    .scp-page-meta {{
+      font-family: 'Geist Mono', 'Fira Code', monospace;
+      font-size: 11px; font-weight: 480; color: #64748B;
+      margin-top: 10px; letter-spacing: 0.02em;
+    }}
+    .scp-page-header {{
+      padding-bottom: 20px;
+      border-bottom: 1px solid rgba(51,65,85,0.5);
+      margin-bottom: 4px;
+    }}
+
+    /* ── Dimension pills — exact match ── */
+    .scp-pills {{
+      display: flex; gap: 5px; padding: 14px 0;
+      border-bottom: 1px solid rgba(51,65,85,0.5);
+      flex-wrap: wrap;
+    }}
+    .scp-pill {{
+      font-size: 12px; font-weight: 480; padding: 4px 11px; border-radius: 12px;
+      border: 1px solid transparent; cursor: pointer;
+      transition: all var(--duration-fast); user-select: none; white-space: nowrap;
+      display: inline-flex; align-items: center; gap: 5px;
+    }}
+    .scp-pill .scp-pill-dot {{ width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }}
+    .scp-pill.hw {{ color: #7DB8F5; background: rgba(96,165,250,0.06); border-color: rgba(96,165,250,0.15); }}
+    .scp-pill.hw .scp-pill-dot {{ background: var(--scp-hw); }}
+    .scp-pill.pl {{ color: #B9A4F8; background: rgba(167,139,250,0.06); border-color: rgba(167,139,250,0.15); }}
+    .scp-pill.pl .scp-pill-dot {{ background: var(--scp-plat); }}
+    .scp-pill.gv {{ color: #5EDBC9; background: rgba(45,212,191,0.06); border-color: rgba(45,212,191,0.15); }}
+    .scp-pill.gv .scp-pill-dot {{ background: var(--scp-gov); }}
+    .scp-pill:hover.hw {{ background: rgba(96,165,250,0.12); border-color: rgba(96,165,250,0.3); }}
+    .scp-pill:hover.pl {{ background: rgba(167,139,250,0.12); border-color: rgba(167,139,250,0.3); }}
+    .scp-pill:hover.gv {{ background: rgba(45,212,191,0.12); border-color: rgba(45,212,191,0.3); }}
+    .scp-pill.active.hw {{ background: rgba(96,165,250,0.2); border-color: rgba(96,165,250,0.5); color: #93C5FD; }}
+    .scp-pill.active.pl {{ background: rgba(167,139,250,0.2); border-color: rgba(167,139,250,0.5); color: #C4B5FD; }}
+    .scp-pill.active.gv {{ background: rgba(45,212,191,0.2); border-color: rgba(45,212,191,0.5); color: #5EEAD4; }}
+    .scp-pill-ct {{ font-family: 'Geist Mono','Fira Code',monospace; font-size: 10px; opacity: 0.5; font-weight: 480; }}
+
+    /* ── Body ── */
+    .scp-body {{ padding-top: 4px; }}
+
+    /* ── Group headers — exact match ── */
+    .scp-grp {{
+      font-size: 11px; font-weight: 580; color: #64748B;
+      text-transform: uppercase; letter-spacing: 0.06em;
+      padding: 16px 0 6px;
+      display: flex; align-items: center; gap: 8px;
+    }}
+    .scp-grp-line {{ flex: 1; height: 1px; background: #334155; }}
+
+    .scp-paa-fold {{ margin: 6px 0 0; border-bottom: 2px solid rgba(245,158,11,0.3); padding-bottom: 6px; }}
+    .scp-paa-fold-label {{ font-size: 10px; color: rgba(245,158,11,0.5); text-align: right; letter-spacing: 0.03em; }}
+
+    /* ── Actor rows — uses <details>/<summary> ── */
+    .scp-actor {{ border-bottom: 1px solid rgba(255,255,255,0.03); }}
+    .scp-actor[open] > .scp-row {{ background: rgba(51,65,85,0.15); }}
+    .scp-actor[open] .scp-row-chev {{ transform: rotate(180deg); color: #94A3B8; }}
+
+    .scp-row {{
+      display: flex; align-items: center; padding: 10px 0;
+      cursor: pointer; transition: background var(--duration-fast) var(--ease-out);
+      list-style: none; /* removes default <summary> marker */
+    }}
+    .scp-row::-webkit-details-marker {{ display: none; }}
+    .scp-row::marker {{ display: none; content: ''; }}
+    .scp-row:hover {{ background: rgba(255,255,255,0.03); }}
+
+    .scp-row-name {{
+      font-size: 14px; font-weight: 480; color: #E2E8F0;
+      width: 160px; flex-shrink: 0;
+      white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+    }}
+    .scp-row-bar {{ display: flex; gap: 3px; flex: 1; max-width: 140px; margin: 0 16px; }}
+    .scp-row-seg {{
+      flex: 1; height: 9px; border-radius: 2px;
+      background: rgba(255,255,255,0.06);
+      transition: all var(--duration-fast); position: relative;
+    }}
+    .scp-row-seg.hw-m {{ background: var(--scp-hw); }}
+    .scp-row-seg.pl-m {{ background: var(--scp-plat); }}
+    .scp-row-seg.gv-m {{ background: var(--scp-gov); }}
+    .scp-row-seg.col-hl {{ outline: 2px solid rgba(255,255,255,0.5); outline-offset: 1px; z-index: 1; }}
+    .scp-row-seg.col-hl.hw-m {{ outline-color: rgba(96,165,250,0.8); }}
+    .scp-row-seg.col-hl.pl-m {{ outline-color: rgba(167,139,250,0.8); }}
+    .scp-row-seg.col-hl.gv-m {{ outline-color: rgba(45,212,191,0.8); }}
+    .scp-row-seg.col-dim {{ opacity: 0.2; }}
+
+    .scp-row-score {{
+      font-family: 'Geist Mono','Fira Code',monospace;
+      font-size: 13px; font-weight: 480; color: #94A3B8;
+      width: 36px; text-align: right; flex-shrink: 0;
+    }}
+    .scp-row-badge {{ margin-left: 12px; flex-shrink: 0; }}
+    .scp-badge {{
+      display: inline-block; padding: 3px 10px; border-radius: 12px;
+      font-size: 11px; font-weight: 580; letter-spacing: 0.05em; text-transform: uppercase;
+    }}
+    .scp-badge-paa {{ background: rgba(245,158,11,0.15); color: var(--scp-paa); border: 1px solid rgba(245,158,11,0.35); }}
+    .scp-badge-aik {{ background: rgba(6,182,212,0.12); color: #22D3EE; border: 1px solid rgba(6,182,212,0.3); }}
+    .scp-badge-acs {{ background: rgba(168,85,247,0.12); color: #C084FC; border: 1px solid rgba(168,85,247,0.3); }}
+    .scp-badge-part {{ background: rgba(100,116,139,0.12); color: var(--scp-part); border: 1px solid rgba(100,116,139,0.25); }}
+
+    .scp-row-chev {{ font-size: 10px; color: #475569; margin-left: 10px; transition: transform var(--duration-normal) var(--ease-out); flex-shrink: 0; }}
+
+    /* ── Expanded detail — exact match ── */
+    .scp-detail {{
+      padding: 10px 16px 18px;
+      background: rgba(15,23,42,0.3);
+    }}
+    .scp-dim-row {{ display: flex; align-items: baseline; justify-content: space-between; padding: 5px 0; font-size: 13px; }}
+    .scp-dim-name {{ color: #94A3B8; display: flex; align-items: center; gap: 7px; }}
+    .scp-dim-dot {{ width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }}
+    .scp-dim-dot.hw {{ background: var(--scp-hw); }}
+    .scp-dim-dot.pl {{ background: var(--scp-plat); }}
+    .scp-dim-dot.gv {{ background: var(--scp-gov); }}
+    .scp-dim-st {{ font-weight: 580; }}
+    .scp-dim-met {{ color: #22C55E; }}
+    .scp-dim-not {{ color: var(--scp-part); }}
+    .scp-dim-constraint {{ font-size: 12px; color: #64748B; padding: 2px 0 5px 13px; font-style: italic; line-height: 1.5; }}
+    .scp-dim-qual-hl {{ font-size: 12px; color: #CBD5E1; padding: 2px 0 5px 13px; line-height: 1.5; }}
+    .scp-dim-con-label {{ font-style: normal; font-weight: 580; color: #94A3B8; letter-spacing: 0.01em; }}
+
+    /* ── Expandable triggers ── */
+    .scp-expand {{ margin-left: 13px; }}
+    .scp-expand summary {{
+      font-size: 11px; color: #475569; cursor: pointer;
+      padding: 2px 0; display: inline-flex; align-items: center; gap: 4px;
+      list-style: none; transition: color var(--duration-fast);
+    }}
+    .scp-expand summary::-webkit-details-marker {{ display: none; }}
+    .scp-expand summary::marker {{ display: none; content: ''; }}
+    .scp-expand summary:hover {{ color: #94A3B8; }}
+
+    .scp-qual-trigger {{ font-size: 11px; color: #475569; }}
+    .scp-src-trigger {{ font-size: 11px; color: #475569; }}
+    .scp-src-icon {{ font-size: 10px; }}
+
+    .scp-qual-block {{
+      margin: 4px 0 8px; padding: 10px 14px;
+      background: rgba(15,23,42,0.5); border-radius: var(--weo-radius-sm);
+      border: 1px solid rgba(255,255,255,0.04);
+      font-size: 11px; color: #94A3B8; line-height: 1.6;
+    }}
+    .scp-src-block {{
+      margin: 4px 0 8px; padding: 10px 14px;
+      background: rgba(15,23,42,0.5); border-radius: var(--weo-radius-sm);
+      border: 1px solid rgba(255,255,255,0.04);
+    }}
+    .scp-src-entry {{ font-size: 11px; color: #94A3B8; line-height: 1.6; margin-bottom: 6px; }}
+    .scp-src-entry:last-child {{ margin-bottom: 0; }}
+    .scp-src-label {{ font-weight: 580; color: #64748B; text-transform: uppercase; letter-spacing: 0.04em; font-size: 10px; }}
+    .scp-src-grade {{ font-family: 'Geist Mono',monospace; font-size: 10px; padding: 1px 6px; border-radius: 3px; margin-right: 4px; font-weight: 480; }}
+    .scp-src-g1 {{ background: rgba(45,212,191,0.12); color: #5EEAD4; }}
+    .scp-src-g2 {{ background: rgba(96,165,250,0.12); color: #93C5FD; }}
+    .scp-src-g3 {{ background: rgba(148,163,184,0.12); color: #94A3B8; }}
+    .scp-src-fact {{ color: #CBD5E1; }}
+    .scp-src-link {{ color: var(--scp-aik); text-decoration: none; font-size: 10px; margin-left: 4px; }}
+    .scp-src-link:hover {{ text-decoration: underline; }}
+    .scp-src-lock {{ font-size: 11px; color: #475569; margin-left: 13px; padding: 3px 0; }}
+
+    /* ── AIK Chokepoint ── */
+    .scp-aik {{
+      margin-top: 10px; padding: 9px 10px;
+      background: rgba(6,182,212,0.04);
+      border: 1px solid rgba(6,182,212,0.12);
+      border-radius: var(--weo-radius-sm);
+    }}
+    .scp-aik-label {{ font-size: 10px; font-weight: 580; color: #94A3B8; letter-spacing: 0.06em; text-transform: uppercase; margin-bottom: 4px; }}
+    .scp-aik-nature {{ font-size: 13px; color: #CBD5E1; font-weight: 380; line-height: 1.4; }}
+    .scp-aik-entities {{ font-size: 12px; color: #64748B; font-style: italic; font-weight: 380; line-height: 1.5; margin-top: 3px; }}
+
+    /* ── Severance ── */
+    .scp-sev {{ font-size: 12px; color: #64748B; margin-top: 10px; padding-top: 10px; border-top: 1px solid rgba(255,255,255,0.04); line-height: 1.5; }}
+    .scp-sev strong {{ color: #94A3B8; font-weight: 580; }}
+
+    /* ── Participant group ── */
+    .scp-part-group > summary {{
+      padding: 10px 0; font-size: 12px; color: #94A3B8;
+      cursor: pointer; display: flex; align-items: center; gap: 6px;
+      border-bottom: 1px solid rgba(255,255,255,0.04);
+      transition: background var(--duration-fast); user-select: none;
+      list-style: none;
+    }}
+    .scp-part-group > summary::-webkit-details-marker {{ display: none; }}
+    .scp-part-group > summary::marker {{ display: none; content: ''; }}
+    .scp-part-group > summary:hover {{ background: rgba(255,255,255,0.03); }}
+    .scp-part-arr {{ font-size: 10px; transition: transform var(--duration-normal) var(--ease-out); display: inline-block; }}
+    .scp-part-group[open] .scp-part-arr {{ transform: rotate(90deg); }}
+
+    /* ── Dimension Watch ── */
+    .scp-watch {{
+      margin-top: 32px; padding-top: 24px;
+      border-top: 1px solid rgba(51,65,85,0.5);
+    }}
+    .scp-watch-title {{ font-size: 16px; font-weight: 580; color: #F1F5F9; margin-bottom: 6px; }}
+    .scp-watch-desc {{ font-size: 12px; color: #64748B; margin-bottom: 16px; font-weight: 380; }}
+    .scp-watch-wrap {{ overflow-x: auto; -webkit-overflow-scrolling: touch; }}
+    .scp-watch-table {{ width: 100%; border-collapse: collapse; font-size: 12px; }}
+    .scp-watch-table th {{
+      text-align: left; font-size: 10px; font-weight: 580;
+      color: #64748B; text-transform: uppercase;
+      letter-spacing: 0.06em; padding: 8px 10px;
+      border-bottom: 1px solid #334155; white-space: nowrap;
+    }}
+    .scp-watch-table td {{
+      padding: 10px; border-bottom: 1px solid rgba(255,255,255,0.03);
+      vertical-align: top; color: #94A3B8; line-height: 1.5; font-weight: 380;
+    }}
+    .scp-watch-table tr:last-child td {{ border-bottom: none; }}
+    .scp-watch-table tr:hover td {{ background: rgba(255,255,255,0.01); }}
+    .scp-watch-actor {{ color: var(--scp-aik); text-decoration: none; font-weight: 480; }}
+    .scp-watch-actor:hover {{ text-decoration: underline; }}
+
+    /* ── Footer ── */
+    .scp-page-footer {{
+      margin-top: 40px; padding-top: 20px;
+      border-top: 1px solid rgba(51,65,85,0.5);
+    }}
+    .scp-footer-cta {{
+      font-size: 12px; color: #94A3B8; margin-bottom: 12px;
+      padding: 10px 14px;
+      background: rgba(59,130,246,0.04); border: 1px solid rgba(59,130,246,0.12);
+      border-radius: var(--weo-radius-sm); font-weight: 380;
+    }}
+    .scp-footer-links {{ display: flex; gap: 16px; margin-bottom: 10px; font-size: 12px; }}
+    .scp-footer-links a {{ color: var(--scp-aik); text-decoration: none; }}
+    .scp-footer-links a:hover {{ text-decoration: underline; }}
+    .scp-footer-disclaimer {{
+      font-size: 10px; color: #94A3B8; line-height: 1.5; opacity: 0.7; font-style: italic;
+    }}
+    .scp-footer-version {{
+      font-family: 'Geist Mono','Fira Code',monospace;
+      font-size: 10px; font-weight: 480; color: #94A3B8; opacity: 0.5; margin-top: 8px;
+    }}
+    .scp-footer-copy {{ font-size: 11px; color: #64748B; margin-top: 8px; }}
+
+    /* ── Responsive ── */
+    @media (max-width: 768px) {{
+      .page-wrap {{ padding: 24px 16px 40px; }}
+      .scp-row-name {{ width: 120px; font-size: 13px; }}
+      .scp-row-bar {{ max-width: 100px; margin: 0 10px; }}
+      .nav-links {{ gap: 10px; font-size: 11px; }}
+    }}
+    @media (max-width: 480px) {{
+      .scp-row-name {{ width: 100px; font-size: 12px; }}
+      .scp-row-bar {{ max-width: 80px; margin: 0 6px; }}
+      .scp-dim-row {{ font-size: 12px; }}
+      .scp-page-title {{ font-size: 18px; }}
+      .page-nav {{ padding: 10px 16px; }}
+    }}
+
+    @media (prefers-reduced-motion: reduce) {{
+      *, *::before, *::after {{
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+      }}
+    }}
   </style>
 </head>
 <body>
+  <nav class="page-nav">
+    <a href="/" class="nav-brand"><span>Warmth Engine Observatory</span></a>
+    <div class="nav-links">
+      <a href="/">Map</a>
+      <a href="/atlas.html">Atlas</a>
+      <a href="/events.html">Events</a>
+      <a href="/profiles/" aria-current="page" style="color:#E2E8F0;">Profiles</a>
+      <a href="/about.html">About</a>
+    </div>
+  </nav>
+
   <div class="page-wrap">
-    <header class="page-header">
-      <h1>Sovereign Capability Profiles</h1>
-      <p class="page-subtitle">Actor Designation Framework — {total_actors} actors assessed</p>
-      <p class="page-framework">{framework_desc}</p>
-      <div class="page-meta">
-        <span>Assessment date: {assessment_date}</span>
-        <span>Methodology: V{methodology_version}</span>
-        <span>Register: SCP-REG-009</span>
-      </div>
-      <p class="legend-heading">Dimensions</p>
-      {legend_html}
-    </header>
+    <div class="scp-page-header">
+      <h1 class="scp-page-title">Sovereign Capability Profiles</h1>
+      <div class="scp-page-subtitle">Actor Designation Framework — {meta.get('total_actors',14)} actors assessed</div>
+      <div class="scp-page-meta">Assessment: {assessment_date.replace('-',' ')} · Methodology V{meth_version} · {reg_version}</div>
+    </div>
 
-    <main>
-{sections_html}
-      {watch_html}
-    </main>
+    {body}
 
-    <footer class="page-footer">
-      <p class="footer-cta">Full analysis and sources for all actors available with supporter access.</p>
-      <div class="footer-links">
-        <a href="/?scp=open">Explore the interactive Sovereign Capability Profiles →</a>
+    <div class="scp-page-footer">
+      <div class="scp-footer-cta">Full analysis and sources for all actors available with supporter access.</div>
+      <div class="scp-footer-links">
+        <a href="/">Explore the interactive map →</a>
         <a href="/research/methodology/manual/">Methodology Manual →</a>
       </div>
-      <p class="footer-mono">SCP Register v1.0 · Assessment: May 2026 · Methodology V{methodology_version} · WEO v1.3.0</p>
-      <p class="footer-mono" style="margin-top:4px;opacity:0.5;">© 2026 Warmth Engine Observatory</p>
-    </footer>
+      <p class="scp-footer-disclaimer">Designation scores reflect assessed capabilities at the most recent evaluation date. They are not retrospective assessments of capabilities at the time each event in the database occurred.</p>
+      <div class="scp-footer-version">SCP Register v1.0 · Assessment: {assessment_date} · Methodology V{meth_version}</div>
+      <p class="scp-footer-copy">© 2026 Warmth Engine Observatory</p>
+    </div>
   </div>
-<script data-goatcounter="https://warmthengine.goatcounter.com/count"
-        async src="//gc.zgo.at/count.js"></script>
-<script>
-(function(){{
-  var v = document.querySelector('meta[name="weo-version"]');
-  if (v) console.log('WEO v' + v.getAttribute('content'));
-}})();
-</script>
-</body>
-</html>"""
 
+  <script>
+    /* Dimension pill column highlighting */
+    (function() {{
+      var pills = document.querySelectorAll('.scp-pill');
+      var segs = document.querySelectorAll('.scp-row-seg');
+      var active = -1;
+      pills.forEach(function(p) {{
+        p.addEventListener('click', function() {{
+          var di = parseInt(p.getAttribute('data-dim'));
+          if (active === di) {{
+            active = -1;
+            pills.forEach(function(pp) {{ pp.classList.remove('active'); }});
+            segs.forEach(function(s) {{ s.classList.remove('col-hl','col-dim'); }});
+          }} else {{
+            active = di;
+            pills.forEach(function(pp) {{ pp.classList.remove('active'); }});
+            p.classList.add('active');
+            segs.forEach(function(s) {{
+              var si = parseInt(s.getAttribute('data-di'));
+              if (si === di) {{ s.classList.add('col-hl'); s.classList.remove('col-dim'); }}
+              else {{ s.classList.add('col-dim'); s.classList.remove('col-hl'); }}
+            }});
+          }}
+        }});
+      }});
+    }})();
+  </script>
+  <script data-goatcounter="https://warmthengine.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
+  <script>(function(){{ var v=document.querySelector('meta[name="weo-version"]'); if(v) console.log('WEO v'+v.getAttribute('content')); }})();</script>
+</body>
+</html>'''
+    return page
 
 def main():
     parser = argparse.ArgumentParser(description='Generate static SCP profiles page')
-    parser.add_argument('--input',  required=True, help='Path to actors-free.json')
-    parser.add_argument('--output', required=True, help='Output path for index.html')
+    parser.add_argument('--input', required=True, help='Path to actors-free.json')
+    parser.add_argument('--output', required=True, help='Output path for profiles/index.html')
     args = parser.parse_args()
 
-    input_path  = Path(args.input).expanduser()
-    output_path = Path(args.output).expanduser()
-
-    with open(input_path, encoding='utf-8') as f:
+    with open(args.input, 'r') as f:
         data = json.load(f)
 
-    html = generate_html(data)
+    html_content = build_page(data)
 
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(output_path, 'w', encoding='utf-8') as f:
-        f.write(html)
+    os.makedirs(os.path.dirname(args.output) or '.', exist_ok=True)
+    with open(args.output, 'w') as f:
+        f.write(html_content)
 
-    print(f'Generated: {output_path}')
-
+    print(f'Generated {args.output} ({len(html_content):,} bytes)')
+    print(f'Actors: {len(data["actors"])}')
 
 if __name__ == '__main__':
     main()

--- a/scripts/generate_profiles.py
+++ b/scripts/generate_profiles.py
@@ -42,38 +42,75 @@ INLINE_CSS = """
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
 :root {
-  --bg-primary: #0F172A;
-  --bg-card: #1E293B;
-  --bg-deep: #0B1120;
-  --text-primary: #E2E8F0;
-  --text-secondary: #94A3B8;
-  --text-muted: #64748B;
-  --accent: #3B82F6;
-  --border: rgba(255,255,255,0.07);
-  --scp-hw: #60A5FA;
-  --scp-pl: #A78BFA;
-  --scp-gv: #2DD4BF;
-  --scp-paa: #F59E0B;
-  --scp-aik: #06B6D4;
-  --scp-acs: #A855F7;
+  /* WEO design tokens — aligned with index.html / 404.html */
+  --weo-surface-base:    #0F172A;
+  --weo-surface-raised:  #1E293B;
+  --weo-text-primary:    #E2E8F0;
+  --weo-text-secondary:  rgba(226, 232, 240, 0.7);
+  --weo-text-muted:      #94A3B8;
+  --weo-accent-hover:    #60A5FA;
+  --weo-border-primary:  #334155;
+  --weo-radius-sm:       4px;
+  --weo-radius-md:       8px;
+  --weo-radius-lg:       12px;
+
+  /* SCP palette */
+  --scp-hw:   #60A5FA;
+  --scp-pl:   #A78BFA;
+  --scp-gv:   #2DD4BF;
+  --scp-paa:  #F59E0B;
+  --scp-aik:  #06B6D4;
+  --scp-acs:  #A855F7;
   --scp-part: #64748B;
-  --scp-met: #22C55E;
-  --r-sm: 4px;
-  --r-md: 6px;
+  --scp-met:  #22C55E;
+
+  /* local shorthand */
   --r-pill: 20px;
 }
 
 html { scroll-behavior: smooth; }
 
+/* ── Focus & motion ── */
+*:focus { outline: none; }
+*:focus-visible { outline: 2px solid var(--weo-accent-hover); outline-offset: 2px; }
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
 body {
-  background: var(--bg-primary);
-  color: var(--text-primary);
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+  background: var(--weo-surface-base);
+  color: var(--weo-text-primary);
+  font-family: 'Geist', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   line-height: 1.6;
   -webkit-font-smoothing: antialiased;
 }
 
-a { color: var(--accent); text-decoration: none; }
+/* ── Geist dark-mode weight compensation ──
+   Variable font weights adjusted for light-on-dark halation.
+   Standard 400 body → 380, standard 600 heading → 580, standard 500 data → 480. */
+body               { font-weight: 380; }
+.page-header h1    { font-weight: 580; }
+.actor-name        { font-weight: 580; }
+.desig-heading h2  { font-weight: 580; }
+.watch-section h2  { font-weight: 580; }
+.dim-status        { font-weight: 580; }
+.constraint-label  { font-weight: 580; }
+.sev-label         { font-weight: 580; }
+.aik-label         { font-weight: 580; }
+.actor-badge       { font-weight: 580; }
+.src-type          { font-weight: 580; }
+.src-grade         { font-weight: 580; }
+.actor-score       { font-weight: 480; }
+.dim-key           { font-weight: 480; }
+.dim-ref           { font-weight: 480; }
+.legend-key        { font-weight: 480; }
+
+a { color: var(--weo-accent-hover); text-decoration: none; }
 a:hover { text-decoration: underline; }
 
 .page-wrap { max-width: 900px; margin: 0 auto; padding: 0 20px 60px; }
@@ -81,26 +118,26 @@ a:hover { text-decoration: underline; }
 /* ── Page header ── */
 .page-header {
   padding: 48px 0 36px;
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--weo-border-primary);
   margin-bottom: 40px;
 }
 .page-header h1 {
-  font-size: 28px; font-weight: 700; color: var(--text-primary);
+  font-size: 28px; color: var(--weo-text-primary);
   letter-spacing: -0.02em; margin-bottom: 6px;
 }
-.page-subtitle { font-size: 15px; color: var(--text-secondary); margin-bottom: 18px; }
+.page-subtitle { font-size: 15px; color: var(--weo-text-secondary); margin-bottom: 18px; }
 .page-framework {
-  font-size: 13px; color: var(--text-secondary); line-height: 1.7;
+  font-size: 13px; color: var(--weo-text-secondary); line-height: 1.7;
   max-width: 720px; margin-bottom: 20px;
 }
 .page-meta {
   display: flex; gap: 20px; flex-wrap: wrap;
-  font-size: 12px; color: var(--text-muted); margin-bottom: 24px;
+  font-size: 12px; color: #64748B; margin-bottom: 24px;
 }
 
 /* ── Dimension legend ── */
 .legend-heading {
-  font-size: 11px; font-weight: 700; color: var(--text-muted);
+  font-size: 11px; color: var(--weo-text-muted);
   letter-spacing: 0.08em; text-transform: uppercase; margin-bottom: 10px;
 }
 .dim-legend {
@@ -109,62 +146,69 @@ a:hover { text-decoration: underline; }
   gap: 6px;
 }
 .legend-item {
-  display: flex; align-items: flex-start; gap: 7px;
-  font-size: 12px; line-height: 1.45; padding: 6px 8px;
-  background: rgba(30,41,59,0.5); border-radius: var(--r-sm);
-  border: 1px solid var(--border);
+  display: flex; align-items: center; gap: 7px;
+  font-size: 12px; padding: 6px 8px;
+  background: rgba(30,41,59,0.5); border-radius: var(--weo-radius-sm);
+  border: 1px solid var(--weo-border-primary);
+  min-width: 0;
 }
-.legend-dot { width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0; margin-top: 3px; }
+.legend-dot { width: 7px; height: 7px; border-radius: 50%; flex-shrink: 0; }
 .legend-key {
-  font-family: 'SF Mono','Fira Code',monospace; font-size: 10px;
-  color: var(--text-muted); flex-shrink: 0; min-width: 20px;
+  font-family: 'Geist Mono', 'Fira Code', 'Consolas', monospace; font-size: 10px;
+  color: #64748B; flex-shrink: 0; min-width: 20px;
 }
-.legend-name { font-weight: 500; color: var(--text-secondary); flex-shrink: 0; min-width: 100px; }
-.legend-desc { color: var(--text-muted); font-size: 11px; }
+.legend-name { color: var(--weo-text-muted); flex-shrink: 0; min-width: 100px; }
+.legend-desc {
+  color: #64748B; font-size: 11px;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
 
 /* ── Designation groups ── */
 .desig-section { margin-bottom: 48px; }
 .desig-heading { display: flex; align-items: center; gap: 12px; margin-bottom: 18px; }
-.desig-heading h2 { font-size: 14px; font-weight: 700; letter-spacing: 0.01em; white-space: nowrap; }
-.desig-line { flex: 1; height: 1px; background: var(--border); }
-.desig-paa .desig-heading h2 { color: var(--scp-paa); }
-.desig-aik .desig-heading h2 { color: var(--scp-aik); }
-.desig-acs .desig-heading h2 { color: var(--scp-acs); }
+.desig-heading h2 { font-size: 14px; letter-spacing: 0.01em; white-space: nowrap; }
+.desig-line { flex: 1; height: 1px; background: var(--weo-border-primary); }
+.desig-paa .desig-heading h2         { color: var(--scp-paa); }
+.desig-aik .desig-heading h2         { color: var(--scp-aik); }
+.desig-acs .desig-heading h2         { color: var(--scp-acs); }
 .desig-participant .desig-heading h2 { color: var(--scp-part); }
 
 /* ── Actor cards ── */
 .actor-card {
-  background: var(--bg-card); border: 1px solid var(--border);
-  border-radius: var(--r-md); margin-bottom: 14px; overflow: hidden;
+  background: var(--weo-surface-raised);
+  border: 1px solid var(--weo-border-primary);
+  border-radius: var(--weo-radius-md);
+  box-shadow: 0 1px 3px rgba(0,0,0,0.2), 0 0 0 1px rgba(255,255,255,0.03);
+  margin-bottom: 14px; overflow: hidden;
 }
 .actor-header {
-  padding: 14px 20px 12px; border-bottom: 1px solid var(--border);
+  padding: 14px 20px 12px; border-bottom: 1px solid var(--weo-border-primary);
 }
 .actor-title-row {
   display: flex; align-items: center; justify-content: space-between;
   flex-wrap: wrap; gap: 8px; margin-bottom: 10px;
 }
 .actor-name {
-  font-size: 17px; font-weight: 700; color: var(--text-primary);
+  font-size: 17px; color: var(--weo-text-primary);
   display: flex; align-items: center; gap: 8px;
 }
 .actor-meta { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
 .actor-score {
-  font-family: 'SF Mono','Fira Code',monospace; font-size: 13px;
-  font-weight: 700; color: var(--text-secondary);
+  font-family: 'Geist Mono', 'Fira Code', 'Consolas', monospace; font-size: 13px;
+  color: var(--weo-text-muted);
   background: rgba(255,255,255,0.05); padding: 2px 8px;
-  border-radius: var(--r-sm); border: 1px solid var(--border);
+  border-radius: var(--weo-radius-sm); border: 1px solid var(--weo-border-primary);
 }
 .actor-badge {
-  font-size: 11px; font-weight: 700; letter-spacing: 0.04em;
+  font-size: 11px; letter-spacing: 0.04em;
   padding: 3px 10px; border-radius: var(--r-pill); border: 1px solid;
 }
-.badge-paa   { background: rgba(245,158,11,0.15); color: #F59E0B;   border-color: rgba(245,158,11,0.35); }
-.badge-aik   { background: rgba(6,182,212,0.12);  color: #22D3EE;   border-color: rgba(6,182,212,0.3); }
-.badge-acs   { background: rgba(168,85,247,0.12); color: #C084FC;   border-color: rgba(168,85,247,0.3); }
+.badge-paa         { background: rgba(245,158,11,0.15); color: #F59E0B;  border-color: rgba(245,158,11,0.35); }
+.badge-aik         { background: rgba(6,182,212,0.12);  color: #22D3EE;  border-color: rgba(6,182,212,0.3); }
+.badge-acs         { background: rgba(168,85,247,0.12); color: #C084FC;  border-color: rgba(168,85,247,0.3); }
 .badge-participant { background: rgba(100,116,139,0.12); color: #64748B; border-color: rgba(100,116,139,0.25); }
 .sample-badge {
-  font-size: 10px; font-weight: 600;
+  font-size: 10px;
   background: rgba(255,215,0,0.1); color: #FFD700;
   border: 1px solid rgba(255,215,0,0.25); padding: 1px 6px;
   border-radius: 3px; letter-spacing: 0.03em;
@@ -176,9 +220,9 @@ a:hover { text-decoration: underline; }
   width: 10px; height: 10px; border-radius: 50%; border: 1.5px solid;
   flex-shrink: 0;
 }
-.dim-bar-dot.hw.met  { background: var(--scp-hw);  border-color: var(--scp-hw); }
-.dim-bar-dot.pl.met  { background: var(--scp-pl);  border-color: var(--scp-pl); }
-.dim-bar-dot.gv.met  { background: var(--scp-gv);  border-color: var(--scp-gv); }
+.dim-bar-dot.hw.met  { background: var(--scp-hw); border-color: var(--scp-hw); }
+.dim-bar-dot.pl.met  { background: var(--scp-pl); border-color: var(--scp-pl); }
+.dim-bar-dot.gv.met  { background: var(--scp-gv); border-color: var(--scp-gv); }
 .dim-bar-dot.hw.nmet { background: transparent; border-color: rgba(96,165,250,0.3); }
 .dim-bar-dot.pl.nmet { background: transparent; border-color: rgba(167,139,250,0.3); }
 .dim-bar-dot.gv.nmet { background: transparent; border-color: rgba(45,212,191,0.3); }
@@ -204,47 +248,47 @@ a:hover { text-decoration: underline; }
 .dim-dot.pl.met { background: var(--scp-pl); }
 .dim-dot.gv.met { background: var(--scp-gv); }
 .dim-key {
-  font-family: 'SF Mono','Fira Code',monospace; font-size: 10px;
-  color: var(--text-muted); flex-shrink: 0; min-width: 20px;
+  font-family: 'Geist Mono', 'Fira Code', 'Consolas', monospace; font-size: 10px;
+  color: #64748B; flex-shrink: 0; min-width: 20px;
 }
-.dim-name  { color: var(--text-secondary); flex: 1; }
-.dim-status { font-size: 11px; font-weight: 700; flex-shrink: 0; }
+.dim-name  { color: var(--weo-text-muted); flex: 1; }
+.dim-status { font-size: 11px; flex-shrink: 0; }
 .dim-met   { color: var(--scp-met); }
-.dim-nmet  { color: var(--text-muted); }
+.dim-nmet  { color: #64748B; }
 
 .dim-qual-hl {
-  font-size: 12px; color: #CBD5E1; line-height: 1.55;
+  font-size: 12px; color: var(--weo-text-secondary); line-height: 1.55;
   padding: 4px 0 2px 13px;
 }
 .dim-constraint {
-  font-size: 12px; color: var(--text-muted); line-height: 1.55;
+  font-size: 12px; color: #64748B; line-height: 1.55;
   padding: 4px 0 2px 13px; font-style: italic;
 }
-.constraint-label { font-style: normal; font-weight: 700; color: var(--text-secondary); }
+.constraint-label { font-style: normal; color: var(--weo-text-secondary); }
 
 .dim-details-dd { padding: 2px 0 2px 13px; }
 details.dim-details summary {
-  font-size: 11px; color: var(--text-muted); cursor: pointer;
+  font-size: 11px; color: #64748B; cursor: pointer;
   padding: 3px 0; display: inline-flex; align-items: center; gap: 5px;
   list-style: none; -webkit-appearance: none; transition: color 0.15s;
 }
 details.dim-details summary::-webkit-details-marker { display: none; }
 details.dim-details summary::before { content: '▸'; font-size: 9px; }
 details.dim-details[open] summary::before { content: '▾'; }
-details.dim-details summary:hover { color: var(--text-secondary); }
+details.dim-details summary:hover { color: var(--weo-text-muted); }
 
 .dim-qual-block {
   margin-top: 6px; padding: 10px 12px;
-  background: rgba(15,23,42,0.6); border-radius: var(--r-sm);
-  border: 1px solid var(--border);
-  font-size: 12px; color: var(--text-secondary); line-height: 1.65;
+  background: rgba(15,23,42,0.6); border-radius: var(--weo-radius-sm);
+  border: 1px solid var(--weo-border-primary);
+  font-size: 12px; color: var(--weo-text-secondary); line-height: 1.65;
 }
 
 /* ── Sources ── */
 .src-block {
   margin-top: 6px; padding: 10px 12px;
-  background: rgba(15,23,42,0.6); border-radius: var(--r-sm);
-  border: 1px solid var(--border);
+  background: rgba(15,23,42,0.6); border-radius: var(--weo-radius-sm);
+  border: 1px solid var(--weo-border-primary);
 }
 .src-entry {
   padding: 8px 0; border-bottom: 1px solid rgba(255,255,255,0.04);
@@ -253,79 +297,83 @@ details.dim-details summary:hover { color: var(--text-secondary); }
 .src-meta {
   display: flex; flex-wrap: wrap; align-items: center; gap: 8px; margin-bottom: 5px;
 }
-.src-type  { font-size: 10px; font-weight: 700; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.05em; }
-.src-grade { font-size: 10px; font-weight: 700; padding: 1px 7px; border-radius: 3px; }
-.src-pub   { font-size: 11px; color: var(--text-secondary); }
-.src-date  { font-size: 10px; color: var(--text-muted); }
-.src-fact  { font-size: 11px; color: var(--text-secondary); line-height: 1.55; margin-bottom: 5px; }
-.src-link  { font-size: 11px; color: var(--accent); }
+.src-type  { font-size: 10px; color: var(--weo-text-muted); text-transform: uppercase; letter-spacing: 0.05em; }
+.src-grade { font-size: 10px; padding: 1px 7px; border-radius: 3px; }
+.src-pub   { font-size: 11px; color: var(--weo-text-muted); }
+.src-date  { font-size: 10px; color: #64748B; }
+.src-fact  { font-size: 11px; color: var(--weo-text-secondary); line-height: 1.55; margin-bottom: 5px; }
+.src-link  { font-size: 11px; color: var(--weo-accent-hover); }
 
 /* ── AIK chokepoint ── */
 .aik-profile {
   margin-top: 12px; padding: 10px 12px;
   background: rgba(6,182,212,0.06); border: 1px solid rgba(6,182,212,0.15);
-  border-radius: var(--r-sm);
+  border-radius: var(--weo-radius-sm);
 }
 .aik-label  {
-  font-size: 10px; font-weight: 700; color: #94A3B8;
+  font-size: 10px; color: var(--weo-text-muted);
   letter-spacing: 0.07em; text-transform: uppercase; margin-bottom: 4px;
 }
-.aik-nature   { font-size: 13px; color: #CBD5E1; font-weight: 500; line-height: 1.45; }
-.aik-entities { font-size: 11px; color: var(--text-muted); font-style: italic; line-height: 1.55; margin-top: 3px; }
+.aik-nature   { font-size: 13px; color: var(--weo-text-secondary); line-height: 1.45; }
+.aik-entities { font-size: 11px; color: #64748B; font-style: italic; line-height: 1.55; margin-top: 3px; }
 
 /* ── Severance ── */
 .actor-severance {
-  font-size: 12px; color: var(--text-muted); margin-top: 12px;
+  font-size: 12px; color: #64748B; margin-top: 12px;
   padding-top: 10px; border-top: 1px solid rgba(255,255,255,0.04);
   line-height: 1.55;
 }
-.sev-label  { font-weight: 700; color: var(--text-secondary); }
-.sev-pass   { color: var(--scp-met); font-weight: 700; }
-.sev-fail   { color: #F87171; font-weight: 700; }
+.sev-label  { color: var(--weo-text-secondary); }
+.sev-pass   { color: var(--scp-met); }
+.sev-fail   { color: #F87171; }
 
 /* ── Dimension watch ── */
 .watch-section {
-  margin-top: 48px; padding-top: 32px; border-top: 1px solid var(--border);
+  margin-top: 48px; padding-top: 32px; border-top: 1px solid var(--weo-border-primary);
 }
 .watch-section h2 {
-  font-size: 17px; font-weight: 700; color: var(--text-primary); margin-bottom: 8px;
+  font-size: 17px; color: var(--weo-text-primary); margin-bottom: 8px;
 }
-.watch-desc { font-size: 13px; color: var(--text-muted); margin-bottom: 16px; }
+.watch-desc { font-size: 13px; color: #64748B; margin-bottom: 16px; }
 .table-wrap { overflow-x: auto; -webkit-overflow-scrolling: touch; }
 .watch-table { width: 100%; border-collapse: collapse; font-size: 12px; }
 .watch-table th {
-  text-align: left; font-size: 10px; font-weight: 700;
-  color: var(--text-muted); text-transform: uppercase;
+  text-align: left; font-size: 10px;
+  color: var(--weo-text-muted); text-transform: uppercase;
   letter-spacing: 0.06em; padding: 8px 12px;
-  border-bottom: 1px solid var(--border); white-space: nowrap;
+  border-bottom: 1px solid var(--weo-border-primary); white-space: nowrap;
 }
 .watch-table td {
   padding: 10px 12px; border-bottom: 1px solid rgba(255,255,255,0.03);
-  vertical-align: top; color: var(--text-secondary); line-height: 1.5;
+  vertical-align: top; color: var(--weo-text-secondary); line-height: 1.5;
 }
 .watch-table tr:last-child td { border-bottom: none; }
 .watch-table tr:hover td { background: rgba(255,255,255,0.01); }
 .dim-ref {
-  font-family: 'SF Mono','Fira Code',monospace; font-size: 10px;
-  color: var(--text-muted);
+  font-family: 'Geist Mono', 'Fira Code', 'Consolas', monospace; font-size: 10px;
+  color: var(--weo-text-muted);
 }
-.w-met  { color: var(--scp-met); font-weight: 700; }
-.w-nmet { color: var(--text-muted); }
+.w-met  { color: var(--scp-met); }
+.w-nmet { color: #64748B; }
 
 /* ── Footer ── */
 .page-footer {
-  margin-top: 56px; padding-top: 24px; border-top: 1px solid var(--border);
-  font-size: 12px; color: var(--text-muted); line-height: 1.8;
+  margin-top: 56px; padding-top: 24px; border-top: 1px solid var(--weo-border-primary);
+  font-size: 12px; color: #64748B; line-height: 1.8;
 }
 .footer-cta {
-  font-size: 13px; color: var(--text-secondary); margin-bottom: 14px;
+  font-size: 13px; color: var(--weo-text-secondary); margin-bottom: 14px;
   padding: 10px 14px;
-  background: rgba(59,130,246,0.05); border: 1px solid rgba(59,130,246,0.15);
-  border-radius: var(--r-sm);
+  background: rgba(96,165,250,0.05); border: 1px solid rgba(96,165,250,0.15);
+  border-radius: var(--weo-radius-sm);
 }
 .footer-links { display: flex; flex-wrap: wrap; gap: 16px; margin-bottom: 12px; }
-.footer-links a { color: var(--accent); }
-.footer-copy { font-size: 11px; color: var(--text-muted); }
+.footer-links a { color: var(--weo-accent-hover); }
+.footer-mono {
+  font-family: 'Geist Mono', 'Fira Code', 'Consolas', monospace;
+  font-size: 11px; color: var(--weo-text-muted); opacity: 0.5;
+  letter-spacing: 0.04em;
+}
 
 /* ── Responsive ── */
 @media (max-width: 600px) {
@@ -552,7 +600,7 @@ def render_legend(dimensions_meta):
         name = esc(info.get('name', dk))
         desc = esc(info.get('description', ''))
         items += f"""<div class="legend-item">
-  <span class="legend-dot" style="background:{cat_var};"></span>
+  <span class="legend-dot" style="background:{cat_var};flex-shrink:0;"></span>
   <span class="legend-key">{dk}</span>
   <span class="legend-name">{name}</span>
   <span class="legend-desc">{desc}</span>
@@ -623,10 +671,14 @@ def generate_html(data):
     )
 
     return f"""<!DOCTYPE html>
-<html lang="en">
+<html lang="en-GB">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="weo-version" content="1.3.0">
+  <link rel="icon" type="image/png" sizes="48x48" href="/favicon_48x48.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon_32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon_16x16.png">
   <title>Sovereign Capability Profiles — AI Infrastructure Assessments | Warmth Engine Observatory</title>
   <meta name="description" content="Nation-state AI infrastructure assessments across 14 actors. Chip design, fabrication, equipment, compute, frontier models, regulation, and sovereign investment dimensions evaluated with sourced evidence.">
   <link rel="canonical" href="https://warmthengine.com/profiles/">
@@ -634,6 +686,10 @@ def generate_html(data):
   <meta property="og:description" content="Which nations control the AI infrastructure stack? 14 actors assessed across 7 dimensions with sourced evidence.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://warmthengine.com/profiles/">
+  <meta property="og:image" content="https://www.warmthengine.com/og-image.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Geist:wght@100..900&family=Geist+Mono:wght@100..900&display=swap" rel="stylesheet">
   <script type="application/ld+json">
 {json_ld}
   </script>
@@ -667,9 +723,18 @@ def generate_html(data):
         <a href="/?scp=open">Explore the interactive Sovereign Capability Profiles →</a>
         <a href="/research/methodology/manual/">Methodology Manual →</a>
       </div>
-      <p class="footer-copy">SCP Register v1.0 · Assessment: May 2026 · Methodology V1.4 · © 2026 Warmth Engine</p>
+      <p class="footer-mono">SCP Register v1.0 · Assessment: May 2026 · Methodology V{methodology_version} · WEO v1.3.0</p>
+      <p class="footer-mono" style="margin-top:4px;opacity:0.5;">© 2026 Warmth Engine Observatory</p>
     </footer>
   </div>
+<script data-goatcounter="https://warmthengine.goatcounter.com/count"
+        async src="//gc.zgo.at/count.js"></script>
+<script>
+(function(){{
+  var v = document.querySelector('meta[name="weo-version"]');
+  if (v) console.log('WEO v' + v.getAttribute('content'));
+}})();
+</script>
 </body>
 </html>"""
 

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -56,7 +56,7 @@
   </url>
   <url>
     <loc>https://www.warmthengine.com/profiles/</loc>
-    <lastmod>2026-06-03</lastmod>
+    <lastmod>2026-06-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -54,6 +54,12 @@
     <priority>0.3</priority>
     <changefreq>yearly</changefreq>
   </url>
+  <url>
+    <loc>https://www.warmthengine.com/profiles/</loc>
+    <lastmod>2026-06-03</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
   <!-- Self-hosted publications -->
   <url>
     <loc>https://www.warmthengine.com/research/methodology/manual/</loc>


### PR DESCRIPTION
## Summary

- **Profiles page rebuilt** as a full-screen replica of the homepage SCP panel, generated from `actors-free.json` via `scripts/generate_profiles.py`
- **Actors collapsed by default** — each row shows name, dimension bar (7 segments), score, designation badge, expand chevron
- **Dimension pills** filter the column across all actors on click; active state highlighted
- **Expanded actor view** shows qualification headlines, constraints, expandable Qualification/Sources for US sample, lock icons for non-US actors, AIK Chokepoint Profile blocks, and Severance line
- **Dimension Watch** table present with 11 rows; "Possible MET" (not "Probable MET") for UK D4
- **All 14 actors** in correct designation group order (PAA → AIK → ACS → Participants)
- **Step 7 routing changes** (separate commit): hamburger menu "Actor Profiles" now navigates to `/profiles/`; SCP sidebar panel gains a subtle "View full screen →" link; info panel `◆ Actor Profiles →` button is unchanged
- Sitemap lastmod updated to 2026-06-04

## Commits

1. `feat(profiles)` — page rebuild + generate script + sitemap
2. `feat(routing)` — hamburger + SCP panel fullscreen link

## Test plan

- [ ] Open `/profiles/` — all 14 actors present, collapsed by default
- [ ] Expand/collapse each actor row works
- [ ] Dimension pills highlight correct column across all actors; click again deselects
- [ ] US (★) shows expandable Qualification + Sources with content
- [ ] Non-US actors show 🔒 Sources (supporter access)
- [ ] Japan, South Korea, Netherlands show Chokepoint Profile block
- [ ] Dimension Watch table: 11 rows, UK D4 reads "Possible MET"
- [ ] Hamburger menu "Actor Profiles" navigates to `/profiles/` (does NOT open sidebar)
- [ ] Homepage SCP sidebar shows "View full screen →" link that goes to `/profiles/`
- [ ] Info panel `◆ Actor Profiles →` still opens the sidebar panel (unchanged)
- [ ] Responsive at 1440 / 1024 / 768 / 375px — no horizontal overflow
- [ ] Geist font loading, GoatCounter analytics present

🤖 Generated with [Claude Code](https://claude.com/claude-code)