### PR TITLE
fix(profiles): correct col-w, dot dimensions, pills-grid column alignment

### DIFF
--- a/profiles/index.html
+++ b/profiles/index.html
@@ -31,7 +31,7 @@
   --t1:#F1F5F9;--t2:#E2E8F0;--t3:#CBD5E1;--t4:#94A3B8;--t5:#64748B;
   --r-sm:4px;--r-md:8px;--r-lg:12px;
   --fast:150ms;--norm:250ms;--ease:cubic-bezier(.33,1,.68,1);
-  --col-w:76px;
+  --col-w:88px;
   --link:#3B82F6;--link-hover:#60A5FA;
 }
 html{scroll-behavior:smooth}
@@ -64,7 +64,7 @@ body{font-family:'Geist',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;
 /* Pills — column-aligned with dots below */
 .pills-row{display:flex;align-items:center;padding:16px 0 12px;border-bottom:1px solid rgba(51,65,85,.5)}
 .pills-spacer{width:200px;flex-shrink:0}
-.pills-grid{display:flex;flex-wrap:wrap;justify-content:center;gap:6px 12px}
+.pills-grid{display:grid;grid-template-columns:repeat(7,var(--col-w));justify-items:center;gap:6px 0}
 .pill{font-size:11px;font-weight:480;padding:4px 8px;cursor:pointer;transition:all var(--fast);user-select:none;white-space:nowrap;display:flex;align-items:center;justify-content:center;gap:4px;border-radius:10px;border:1px solid transparent}
 .pill .pill-dot{width:6px;height:6px;border-radius:50%;flex-shrink:0}
 .pill.hw{color:#7DB8F5} .pill.hw .pill-dot{background:var(--hw)}
@@ -94,7 +94,7 @@ body{font-family:'Geist',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;
 .row-name{font-size:15px;font-weight:480;color:var(--t2);width:200px;flex-shrink:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
 .sample-star{display:inline-block;vertical-align:super;margin-left:3px;line-height:1}
 .row-dots{display:grid;grid-template-columns:repeat(7,var(--col-w));justify-items:center;align-items:center}
-.dot{width:14px;height:14px;border-radius:4px;transition:all var(--fast)}
+.dot{width:36px;height:14px;border-radius:4px;transition:all var(--fast)}
 .dot-met.hw{background:var(--hw)} .dot-met.pl{background:var(--pl)} .dot-met.gv{background:var(--gv)}
 .dot-unmet{background:transparent;border:1.5px solid rgba(255,255,255,.1)}
 .dot.col-hl{transform:scale(1.3);box-shadow:0 0 8px rgba(255,255,255,.2)}

--- a/scripts/generate_profiles.py
+++ b/scripts/generate_profiles.py
@@ -187,7 +187,7 @@ def build_page(data):
   --t1:#F1F5F9;--t2:#E2E8F0;--t3:#CBD5E1;--t4:#94A3B8;--t5:#64748B;
   --r-sm:4px;--r-md:8px;--r-lg:12px;
   --fast:150ms;--norm:250ms;--ease:cubic-bezier(.33,1,.68,1);
-  --col-w:76px;
+  --col-w:88px;
   --link:#3B82F6;--link-hover:#60A5FA;
 }}
 html{{scroll-behavior:smooth}}
@@ -220,7 +220,7 @@ body{{font-family:'Geist',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif
 /* Pills — column-aligned with dots below */
 .pills-row{{display:flex;align-items:center;padding:16px 0 12px;border-bottom:1px solid rgba(51,65,85,.5)}}
 .pills-spacer{{width:200px;flex-shrink:0}}
-.pills-grid{{display:flex;flex-wrap:wrap;justify-content:center;gap:6px 12px}}
+.pills-grid{{display:grid;grid-template-columns:repeat(7,var(--col-w));justify-items:center;gap:6px 0}}
 .pill{{font-size:11px;font-weight:480;padding:4px 8px;cursor:pointer;transition:all var(--fast);user-select:none;white-space:nowrap;display:flex;align-items:center;justify-content:center;gap:4px;border-radius:10px;border:1px solid transparent}}
 .pill .pill-dot{{width:6px;height:6px;border-radius:50%;flex-shrink:0}}
 .pill.hw{{color:#7DB8F5}} .pill.hw .pill-dot{{background:var(--hw)}}
@@ -250,7 +250,7 @@ body{{font-family:'Geist',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif
 .row-name{{font-size:15px;font-weight:480;color:var(--t2);width:200px;flex-shrink:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}}
 .sample-star{{display:inline-block;vertical-align:super;margin-left:3px;line-height:1}}
 .row-dots{{display:grid;grid-template-columns:repeat(7,var(--col-w));justify-items:center;align-items:center}}
-.dot{{width:14px;height:14px;border-radius:4px;transition:all var(--fast)}}
+.dot{{width:36px;height:14px;border-radius:4px;transition:all var(--fast)}}
 .dot-met.hw{{background:var(--hw)}} .dot-met.pl{{background:var(--pl)}} .dot-met.gv{{background:var(--gv)}}
 .dot-unmet{{background:transparent;border:1.5px solid rgba(255,255,255,.1)}}
 .dot.col-hl{{transform:scale(1.3);box-shadow:0 0 8px rgba(255,255,255,.2)}}


### PR DESCRIPTION
## Summary

- `--col-w`: 76px → 88px
- `.dot`: 14×14px → 36×14px with `border-radius:4px` (rounded rectangles that fill the column width)
- `.pills-grid`: `display:flex;flex-wrap:wrap` → `display:grid;grid-template-columns:repeat(7,var(--col-w))` so pills and dots column-align under the same `--col-w` variable

Regenerated `profiles/index.html` from `actors-free.json` (82,785 bytes, 14 actors).

## Test plan

- [ ] Profiles page loads at `/profiles/`
- [ ] Dimension pills and dot indicators are vertically aligned in the same columns
- [ ] Dot indicators are 36×14px rounded rectangles, not circles
- [ ] Column width is consistent at 88px desktop, scaling down at breakpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)