### PR TITLE
fix: deep-link Materials Register manual ref to §3.5 Option G

### DIFF
--- a/research/methodology/materials-register/index.html
+++ b/research/methodology/materials-register/index.html
@@ -530,7 +530,7 @@
                 <p>The AI-Critical Materials Register is reviewed at methodology version milestones. Materials are added when their AI infrastructure application is documented at primary source standard. Materials are removed when the AI infrastructure application is superseded (e.g., a material replaced by a substitute in semiconductor manufacturing). The register is a convenience list, not an exhaustive boundary — materials not on the register can qualify through individual Condition 1(a)+(b) documentation.</p>
             </div>
 
-            <a class="reg-ref" href="/research/methodology/manual/">
+            <a class="reg-ref" href="/research/methodology/manual/#section-3-5-g">
                 <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline></svg>
                 WEO Methodology Manual — §3.5 Option G
             </a>


### PR DESCRIPTION
Updates the manual link at the bottom of the Materials Register page to anchor directly to §3.5 Option G instead of the manual's default load screen.