### PR TITLE
fix(manual): add missing section-3-5-[a-g] anchors to AI Connection F…

### DIFF
--- a/research/methodology/manual/index.html
+++ b/research/methodology/manual/index.html
@@ -2874,6 +2874,7 @@ infrastructure)</p>
 <h3 id="stage-2-substantive-ai-connection">Stage 2: Substantive AI
 Connection</h3>
 <p>Event must demonstrate ONE of the following:</p>
+<span id="section-3-5-a"></span>
 <p><strong>Option A: Measurable AI-Specific Allocation (≥10% Threshold
 OR ≥$100M Absolute)</strong></p>
 <ul>
@@ -2936,6 +2937,7 @@ future re-verification if documentation emerges</li>
 <li>✗ “$500M data centre with $30M AI workloads” (6% &lt; 10% AND $30M
 &lt; $100M absolute)</li>
 </ul>
+<span id="section-3-5-b"></span>
 <p><strong>Option B: Dedicated AI Provisions (≥1
 Section/Chapter)</strong></p>
 <ul>
@@ -2960,6 +2962,7 @@ chapter)</li>
 <li>✗ “Digital Services Act mentioning AI in passing” (no dedicated
 section)</li>
 </ul>
+<span id="section-3-5-c"></span>
 <p><strong>Option C: AI-Explicit Mandate</strong></p>
 <ul>
 <li>Charter, agreement, or scope explicitly states AI as primary
@@ -3142,6 +3145,7 @@ evidence that establishes AI connection inherently verifies event
 existence. See §3.4.11 for confidence assessment guidance.</p>
 <p><em>For empirical derivation: See Methodology Rationale, Section
 3.8.</em></p>
+<span id="section-3-5-e"></span>
 <p><strong>Option E: Corporate Strategic Disclosure (Corporate events
 only)</strong></p>
 <p>For Corporate events where the operative instrument (power purchase
@@ -3206,6 +3210,7 @@ standard.</p>
 <p><em>For empirical derivation: See Methodology Rationale, Section
 3.6.2.</em></p>
 <hr />
+<span id="section-3-5-f"></span>
 <p><strong>Option F: Defence Appropriation Evidence (Policy events
 only)</strong></p>
 <p>For Policy events where Options A, B, and C all fail, the AI
@@ -3311,6 +3316,7 @@ standard.</p>
 <p><em>For empirical derivation: See Methodology Rationale, Section
 3.6.3.</em></p>
 <hr />
+<span id="section-3-5-g"></span>
 <h3
 id="option-g-supply-chain-response-evidence-policy-events-only">Option
 G: Supply-Chain Response Evidence (Policy events only)</h3>


### PR DESCRIPTION
…ilter options

Options A, B, C, E, F, G were missing <span id="section-3-5-x"> anchors, causing methodology tooltip deep-links to land at the page top. D and §3.5.1 were already present. All eight anchors now verified.