### PR TITLE
fix: refinements — header dedup, snapshot text, footer alignment, atlas tier layout

### DIFF
--- a/atlas.html
+++ b/atlas.html
@@ -855,7 +855,9 @@
             font-family: var(--font-mono);
         }
         .topo-kv-label { color: var(--text-secondary); }
-        .topo-kv-value { color: var(--text-primary); font-weight: 500; text-align: right; font-variant-numeric: tabular-nums; }
+        .topo-kv-value { color: var(--text-primary); font-weight: 500; font-variant-numeric: tabular-nums; }
+        .topo-kv-count { display: inline-block; min-width: 2.5em; text-align: right; }
+        .topo-kv-pct { color: #94A3B8; margin-left: 6px; }
         .topo-expand-btn {
             /* Patch §3 — hidden until the "expand to full network"
                feature is implemented. Kept in DOM (not deleted) so
@@ -7782,7 +7784,7 @@
                     row.className = 'topo-kv-row';
                     row.innerHTML = `
                         <span class="topo-kv-label">T${escapeHtml(String(tier))}</span>
-                        <span class="topo-kv-value">${n} (${pct}%)</span>`;
+                        <span class="topo-kv-value"><span class="topo-kv-count">${escapeHtml(String(n))}</span><span class="topo-kv-pct">(${pct}%)</span></span>`;
                     tierEl.appendChild(row);
                 });
 

--- a/profiles/index.html
+++ b/profiles/index.html
@@ -283,7 +283,6 @@ body{font-family:'Geist',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;
   <div class="hdr">
     <h1 class="hdr-title">Sovereign Capability Profiles</h1>
     <div class="hdr-sub">Actor Designation Framework &mdash; 14 actors assessed</div>
-    <div class="hdr-meta">Assessment: 6 May 2026 &middot; Methodology V1.4</div>
     <div class="register-meta">
       <div class="register-meta-item">
         <span class="register-meta-label">Last Verified</span>
@@ -314,7 +313,7 @@ body{font-family:'Geist',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;
       <div class="snapshot-list">
         <div class="snapshot-item active">
           <span class="snapshot-date">6 May 2026</span>
-          <span class="snapshot-label">Initial register (2026.05.06-001) — Batch 1, 14 actors assessed</span>
+          <span class="snapshot-label">Initial register (2026.05.06-001) — 14 actors assessed</span>
           <span class="snapshot-badge">Active</span>
         </div>
       </div>

--- a/research/methodology/materials-register/index.html
+++ b/research/methodology/materials-register/index.html
@@ -352,20 +352,20 @@
             border: 1px solid var(--weo-border-primary);
             border-radius: var(--weo-radius-sm);
             transition: all var(--weo-duration-fast) var(--weo-ease-out);
-            margin-bottom: var(--weo-space-xl);
+            margin-bottom: var(--weo-space-md);
             display: inline-flex;
         }
         .reg-ref:hover { color: #60a5fa; border-color: #60a5fa; }
 
         /* Footer */
         .page-footer {
-            margin-top: var(--weo-space-3xl);
+            margin-top: var(--weo-space-sm);
             padding-top: var(--weo-space-lg);
             border-top: 1px solid var(--weo-border-primary);
             text-align: left;
         }
         .footer-text { font-size: 0.8125rem; color: var(--weo-text-muted); margin-bottom: 0.5rem; }
-        .footer-version { text-align: left; font-family: var(--weo-font-mono, 'Geist Mono', monospace); font-size: 11px; opacity: 0.4; color: var(--weo-text-muted); margin-bottom: 8px; }
+        .footer-version { text-align: right; font-family: var(--weo-font-mono, 'Geist Mono', monospace); font-size: 11px; opacity: 0.4; color: var(--weo-text-muted); margin-bottom: 8px; }
         .footer-links { margin-top: 0.5rem; }
         .footer-links a { color: var(--weo-text-muted); font-size: 0.75rem; text-decoration: none; transition: color 150ms ease; }
         .footer-links a:hover { color: #60a5fa; }


### PR DESCRIPTION
Refinement pass 2. 3 files changed:

- **profiles/index.html** — removed redundant `hdr-meta` line (Assessment/Methodology already covered by the register card + footer); removed "Batch 1" dev-speak from snapshot history label
- **research/methodology/materials-register/index.html** — version stamp restored to `text-align: right` (was incorrectly changed to left in PR #152); gap above footer separator tightened: `.reg-ref` margin-bottom reduced from `var(--weo-space-xl)` to `var(--weo-space-md)` and `.page-footer` margin-top reduced from `var(--weo-space-3xl)` to `var(--weo-space-sm)`, giving ~24px total gap
- **atlas.html** — tier distribution count/percentage split into separate spans (`.topo-kv-count` with `min-width: 2.5em; text-align: right` for digit column alignment, `.topo-kv-pct` with `color: #94A3B8; margin-left: 6px` for muted supporting text); applies to all filtered states

🤖 Generated with [Claude Code](https://claude.com/claude-code)