### PR TITLE
feat: profiles mobile V2 — native layout replacing scroll containers

### DIFF
--- a/profiles/index.html
+++ b/profiles/index.html
@@ -92,7 +92,7 @@ body{font-family:'Geist',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;
 .paa-fold-label{display:block;font-size:10px;color:rgba(245,158,11,.5);text-align:right;letter-spacing:.03em}
 
 /* Actor rows — flex + grid dots */
-.actor{border-bottom:1px solid rgba(255,255,255,.03)}
+.actor{border-bottom:1px solid rgba(255,255,255,.03);scroll-margin-top:90px}
 .actor[open]>.row{background:rgba(51,65,85,.15)}
 .actor[open] .row-chev{transform:rotate(180deg);color:var(--t4)}
 .row{display:flex;align-items:center;padding:10px 0;cursor:pointer;transition:background var(--fast) var(--ease);list-style:none}
@@ -116,7 +116,7 @@ body{font-family:'Geist',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;
 .badge-aik{background:rgba(6,182,212,.12);color:#22D3EE;border:1px solid rgba(6,182,212,.3)}
 .badge-acs{background:rgba(168,85,247,.12);color:#C084FC;border:1px solid rgba(168,85,247,.3)}
 .badge-part{background:rgba(100,116,139,.12);color:var(--part);border:1px solid rgba(100,116,139,.25)}
-.row-chev{font-size:10px;color:var(--t5);margin-left:10px;transition:transform var(--norm) var(--ease);flex-shrink:0}
+.row-chev{font-size:10px;color:var(--t5);margin-left:6px;transition:transform var(--norm) var(--ease);flex-shrink:0}
 
 /* Detail */
 .det{padding:12px 20px 20px;background:rgba(15,23,42,.3);border-top:1px solid rgba(255,255,255,.03)}
@@ -179,6 +179,7 @@ body{font-family:'Geist',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;
 .snapshot-date{font-family:'Geist Mono',monospace;font-size:12px;color:var(--t4);min-width:90px;font-weight:480}
 .snapshot-label{font-size:12px;color:var(--t3);flex:1}
 .snapshot-badge{font-family:'Geist Mono',monospace;font-size:10px;font-weight:600;text-transform:uppercase;letter-spacing:.05em;padding:2px 8px;border-radius:var(--r-sm);background:rgba(45,212,191,.1);color:#5EEAD4}
+.snapshot-desc-row{display:flex;align-items:center;gap:8px;flex:1}
 
 /* Footer */
 .ftr{margin-top:28px;padding-top:20px;border-top:1px solid rgba(51,65,85,.5);text-align:left}
@@ -235,14 +236,14 @@ body{font-family:'Geist',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;
   .pill.gv{border-color:rgba(45,212,191,.2)}
   .pill-ct{font-size:8px}
   .pill-group{gap:1px}
-  .pill-group>.weo-info-trigger{width:9px;height:9px;font-size:6px}
+  .pill-group>.weo-info-trigger{display:none}
   .pills-row{padding:12px 0 10px}
   .row-name{width:120px;flex-shrink:0;font-size:12px}
   .row-dots{grid-template-columns:repeat(7,76px)}
   .dot{width:28px;height:10px;border-radius:3px}
   .row-score{font-size:12px;width:34px;margin-left:8px}
   .row-badge{margin-left:6px}
-  .row-chev{margin-left:4px}
+  .row-chev{display:none}
   .row{padding:10px 0}
   .grp{padding:14px 16px 6px}
   .paa-fold{margin:6px 16px 0}
@@ -260,9 +261,9 @@ body{font-family:'Geist',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;
   .register-meta{flex-direction:column;align-items:flex-start;padding:12px 16px;gap:12px}
   .snapshot-history{padding:0;text-align:left}
   .snapshot-title{text-align:left;display:block}
-  .snapshot-list{display:flex;flex-direction:column;align-items:flex-start;gap:6px}
-  .snapshot-item{display:flex;flex-direction:column;align-items:flex-start!important;gap:6px;text-align:left}
-  .snapshot-badge{align-self:flex-start}
+  .snapshot-list{display:flex;flex-direction:column;gap:6px;width:100%}
+  .snapshot-item{display:flex;flex-direction:column;align-items:flex-start;gap:6px;text-align:left;width:100%}
+  .snapshot-desc-row{display:flex;flex-wrap:wrap;align-items:center;gap:8px}
   #weo-tooltip-overlay{width:300px;font-size:13px;padding:14px 16px}
 }
 
@@ -306,7 +307,7 @@ body{font-family:'Geist',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;
     <div class="ftr-cta">Full analysis and sources for all actors available with supporter access.</div>
     <div class="ftr-links"><a href="/">Explore the interactive map &rarr;</a><a href="/research/methodology/manual/">Methodology Manual &rarr;</a></div>
     <p class="ftr-disc">Designation scores reflect assessed capabilities at the most recent evaluation date. They are not retrospective assessments of capabilities at the time each event in the database occurred.</p>
-    <div class="snapshot-history"><div class="snapshot-title">Snapshot History</div><div class="snapshot-list"><div class="snapshot-item active"><span class="snapshot-date">6 May 2026</span><span class="snapshot-label">Initial register (2026.05.06-001) — 14 actors assessed</span><span class="snapshot-badge">Active</span></div></div></div>
+    <div class="snapshot-history"><div class="snapshot-title">Snapshot History</div><div class="snapshot-list"><div class="snapshot-item active"><div class="snapshot-date">6 May 2026</div><div class="snapshot-desc-row"><span class="snapshot-label">Initial register (2026.05.06-001) — 14 actors assessed</span><span class="snapshot-badge">Active</span></div></div></div></div>
     <div class="ftr-ver">SCP Register v1.0 &middot; Assessment: 6 May 2026 &middot; Methodology V1.4 &middot; WEO v1.3.0</div>
     <p class="ftr-copy">&copy; 2026 Warmth Engine Observatory</p>
     <p class="ftr-legal"><a href="/legal.html">Privacy Policy &amp; Terms of Service</a></p>
@@ -377,7 +378,7 @@ if(navToggle&&navLinks){
       if(partGroup)partGroup.open=true;
       actorEl.open=true;
       requestAnimationFrame(function(){
-        actorEl.scrollIntoView({behavior:'smooth',block:'center'});
+        actorEl.scrollIntoView({behavior:'smooth',block:'start'});
       });
     });
   });

--- a/profiles/index.html
+++ b/profiles/index.html
@@ -220,16 +220,22 @@ body{font-family:'Geist',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;
 @media(max-width:1140px){.panel{margin:24px 16px;padding:24px 24px 28px} :root{--col-w:64px} .row-name,.pills-spacer{width:160px} .row-name{font-size:14px}}
 @media(max-width:860px){:root{--col-w:52px} .row-name,.pills-spacer{width:130px} .row-name{font-size:13px} .dot{width:12px;height:12px} .row-score{font-size:13px;width:38px} .badge{font-size:10px;padding:2px 8px}}
 
-/* Responsive — mobile: enable scroll containers */
+/* Responsive — mobile: native layout, no horizontal scroll */
 @media(max-width:767px){
+  /* Panel & header */
   .panel{margin:12px 8px;padding:16px 0 20px;overflow:hidden}
   .hdr{padding:0 16px 16px}
   .hdr-title{font-size:18px}
-  .matrix-scroll{overflow-x:auto;-webkit-overflow-scrolling:touch;scrollbar-width:none;-ms-overflow-style:none}
-  .matrix-scroll::-webkit-scrollbar{display:none}
-  .matrix-inner{min-width:750px;padding:0 16px}
-  .pills-spacer{width:120px;flex-shrink:0}
-  .pills-grid{grid-template-columns:repeat(7,76px);gap:4px 0}
+
+  /* Matrix — remove scroll container, content fits natively */
+  .matrix-scroll{overflow-x:visible}
+  .matrix-inner{min-width:unset;padding:0}
+  .matrix-scroll-wrap>.scroll-fade{display:none}
+
+  /* Pills — wrapping flex row, no column alignment on mobile */
+  .pills-spacer{display:none}
+  .pills-row{display:block;padding:12px 16px 10px}
+  .pills-grid{display:flex;flex-wrap:wrap;gap:4px 6px}
   .pill{font-size:10px;padding:4px 7px;gap:3px;border-radius:10px}
   .pill.hw{border-color:rgba(96,165,250,.2)}
   .pill.pl{border-color:rgba(167,139,250,.2)}
@@ -237,18 +243,30 @@ body{font-family:'Geist',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;
   .pill-ct{font-size:8px}
   .pill-group{gap:1px}
   .pill-group>.weo-info-trigger{display:none}
-  .pills-row{padding:12px 0 10px}
-  .row-name{width:120px;flex-shrink:0;font-size:12px}
-  .row-dots{grid-template-columns:repeat(7,76px)}
-  .dot{width:28px;height:10px;border-radius:3px}
-  .row-score{font-size:12px;width:34px;margin-left:8px}
+
+  /* Actor rows — compact flex bar matching homepage SCP panel */
+  .row{padding:8px 16px}
+  .row-name{width:100px;flex-shrink:0;font-size:12px}
+  .row-dots{display:flex;gap:2px;flex:1;margin:0 8px}
+  .dot{flex:1;width:auto;height:8px;border-radius:2px}
+  .row-score{font-size:11px;width:28px;margin-left:6px}
   .row-badge{margin-left:6px}
+  .badge{font-size:9px;padding:2px 7px}
   .row-chev{display:none}
-  .row{padding:10px 0}
+
+  /* Dot highlight — outline instead of scale for flex segments */
+  .dot.col-hl{transform:none;box-shadow:none;outline:2px solid rgba(255,255,255,.5);outline-offset:1px;z-index:1}
+  .dot.col-hl.hw{outline-color:rgba(96,165,250,.7)}
+  .dot.col-hl.pl{outline-color:rgba(167,139,250,.7)}
+  .dot.col-hl.gv{outline-color:rgba(45,212,191,.7)}
+
+  /* Groups, detail, participants */
   .grp{padding:14px 16px 6px}
   .paa-fold{margin:6px 16px 0}
   .part-group>summary{padding:10px 16px}
   .det{padding:12px 16px 16px}
+
+  /* Watch table — justified horizontal scroll (real data table) */
   .watch{margin-top:32px;padding-top:16px}
   .watch-title{padding:0 16px;font-size:15px}
   .watch-desc{padding:0 16px;margin-bottom:10px}
@@ -256,14 +274,20 @@ body{font-family:'Geist',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;
   .watch-scroll::-webkit-scrollbar{display:none}
   .watch-tbl{min-width:580px}
   .watch-tbl td:nth-child(2){white-space:nowrap}
+
+  /* Footer */
   .ftr{margin-top:20px;padding:16px;text-align:left}
   .ftr-links{flex-direction:column;gap:8px}
+
+  /* Register metadata & snapshot history */
   .register-meta{flex-direction:column;align-items:flex-start;padding:12px 16px;gap:12px}
   .snapshot-history{padding:0;text-align:left}
   .snapshot-title{text-align:left;display:block}
   .snapshot-list{display:flex;flex-direction:column;gap:6px;width:100%}
   .snapshot-item{display:flex;flex-direction:column;align-items:flex-start;gap:6px;text-align:left;width:100%}
   .snapshot-desc-row{display:flex;flex-wrap:wrap;align-items:center;gap:8px}
+
+  /* Tooltip overlay */
   #weo-tooltip-overlay{width:300px;font-size:13px;padding:14px 16px}
 }
 

--- a/scripts/generate_profiles.py
+++ b/scripts/generate_profiles.py
@@ -196,9 +196,9 @@ def snapshot_history_html(meta):
         '<div class="snapshot-title">Snapshot History</div>'
         '<div class="snapshot-list">'
         f'<div class="snapshot-item active">'
-        f'<span class="snapshot-date">{ad_fmt}</span>'
-        f'<span class="snapshot-label">Initial register ({rv}) — {ta} actors assessed</span>'
-        '<span class="snapshot-badge">Active</span>'
+        f'<div class="snapshot-date">{ad_fmt}</div>'
+        f'<div class="snapshot-desc-row"><span class="snapshot-label">Initial register ({rv}) — {ta} actors assessed</span>'
+        '<span class="snapshot-badge">Active</span></div>'
         '</div>'
         '</div></div>'
     )
@@ -344,7 +344,7 @@ body{{font-family:'Geist',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif
 .paa-fold-label{{display:block;font-size:10px;color:rgba(245,158,11,.5);text-align:right;letter-spacing:.03em}}
 
 /* Actor rows — flex + grid dots */
-.actor{{border-bottom:1px solid rgba(255,255,255,.03)}}
+.actor{{border-bottom:1px solid rgba(255,255,255,.03);scroll-margin-top:90px}}
 .actor[open]>.row{{background:rgba(51,65,85,.15)}}
 .actor[open] .row-chev{{transform:rotate(180deg);color:var(--t4)}}
 .row{{display:flex;align-items:center;padding:10px 0;cursor:pointer;transition:background var(--fast) var(--ease);list-style:none}}
@@ -368,7 +368,7 @@ body{{font-family:'Geist',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif
 .badge-aik{{background:rgba(6,182,212,.12);color:#22D3EE;border:1px solid rgba(6,182,212,.3)}}
 .badge-acs{{background:rgba(168,85,247,.12);color:#C084FC;border:1px solid rgba(168,85,247,.3)}}
 .badge-part{{background:rgba(100,116,139,.12);color:var(--part);border:1px solid rgba(100,116,139,.25)}}
-.row-chev{{font-size:10px;color:var(--t5);margin-left:10px;transition:transform var(--norm) var(--ease);flex-shrink:0}}
+.row-chev{{font-size:10px;color:var(--t5);margin-left:6px;transition:transform var(--norm) var(--ease);flex-shrink:0}}
 
 /* Detail */
 .det{{padding:12px 20px 20px;background:rgba(15,23,42,.3);border-top:1px solid rgba(255,255,255,.03)}}
@@ -431,6 +431,7 @@ body{{font-family:'Geist',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif
 .snapshot-date{{font-family:'Geist Mono',monospace;font-size:12px;color:var(--t4);min-width:90px;font-weight:480}}
 .snapshot-label{{font-size:12px;color:var(--t3);flex:1}}
 .snapshot-badge{{font-family:'Geist Mono',monospace;font-size:10px;font-weight:600;text-transform:uppercase;letter-spacing:.05em;padding:2px 8px;border-radius:var(--r-sm);background:rgba(45,212,191,.1);color:#5EEAD4}}
+.snapshot-desc-row{{display:flex;align-items:center;gap:8px;flex:1}}
 
 /* Footer */
 .ftr{{margin-top:28px;padding-top:20px;border-top:1px solid rgba(51,65,85,.5);text-align:left}}
@@ -487,14 +488,14 @@ body{{font-family:'Geist',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif
   .pill.gv{{border-color:rgba(45,212,191,.2)}}
   .pill-ct{{font-size:8px}}
   .pill-group{{gap:1px}}
-  .pill-group>.weo-info-trigger{{width:9px;height:9px;font-size:6px}}
+  .pill-group>.weo-info-trigger{{display:none}}
   .pills-row{{padding:12px 0 10px}}
   .row-name{{width:120px;flex-shrink:0;font-size:12px}}
   .row-dots{{grid-template-columns:repeat(7,76px)}}
   .dot{{width:28px;height:10px;border-radius:3px}}
   .row-score{{font-size:12px;width:34px;margin-left:8px}}
   .row-badge{{margin-left:6px}}
-  .row-chev{{margin-left:4px}}
+  .row-chev{{display:none}}
   .row{{padding:10px 0}}
   .grp{{padding:14px 16px 6px}}
   .paa-fold{{margin:6px 16px 0}}
@@ -512,9 +513,9 @@ body{{font-family:'Geist',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif
   .register-meta{{flex-direction:column;align-items:flex-start;padding:12px 16px;gap:12px}}
   .snapshot-history{{padding:0;text-align:left}}
   .snapshot-title{{text-align:left;display:block}}
-  .snapshot-list{{display:flex;flex-direction:column;align-items:flex-start;gap:6px}}
-  .snapshot-item{{display:flex;flex-direction:column;align-items:flex-start!important;gap:6px;text-align:left}}
-  .snapshot-badge{{align-self:flex-start}}
+  .snapshot-list{{display:flex;flex-direction:column;gap:6px;width:100%}}
+  .snapshot-item{{display:flex;flex-direction:column;align-items:flex-start;gap:6px;text-align:left;width:100%}}
+  .snapshot-desc-row{{display:flex;flex-wrap:wrap;align-items:center;gap:8px}}
   #weo-tooltip-overlay{{width:300px;font-size:13px;padding:14px 16px}}
 }}
 
@@ -629,7 +630,7 @@ if(navToggle&&navLinks){{
       if(partGroup)partGroup.open=true;
       actorEl.open=true;
       requestAnimationFrame(function(){{
-        actorEl.scrollIntoView({{behavior:'smooth',block:'center'}});
+        actorEl.scrollIntoView({{behavior:'smooth',block:'start'}});
       }});
     }});
   }});

--- a/scripts/generate_profiles.py
+++ b/scripts/generate_profiles.py
@@ -472,16 +472,22 @@ body{{font-family:'Geist',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif
 @media(max-width:1140px){{.panel{{margin:24px 16px;padding:24px 24px 28px}} :root{{--col-w:64px}} .row-name,.pills-spacer{{width:160px}} .row-name{{font-size:14px}}}}
 @media(max-width:860px){{:root{{--col-w:52px}} .row-name,.pills-spacer{{width:130px}} .row-name{{font-size:13px}} .dot{{width:12px;height:12px}} .row-score{{font-size:13px;width:38px}} .badge{{font-size:10px;padding:2px 8px}}}}
 
-/* Responsive — mobile: enable scroll containers */
+/* Responsive — mobile: native layout, no horizontal scroll */
 @media(max-width:767px){{
+  /* Panel & header */
   .panel{{margin:12px 8px;padding:16px 0 20px;overflow:hidden}}
   .hdr{{padding:0 16px 16px}}
   .hdr-title{{font-size:18px}}
-  .matrix-scroll{{overflow-x:auto;-webkit-overflow-scrolling:touch;scrollbar-width:none;-ms-overflow-style:none}}
-  .matrix-scroll::-webkit-scrollbar{{display:none}}
-  .matrix-inner{{min-width:750px;padding:0 16px}}
-  .pills-spacer{{width:120px;flex-shrink:0}}
-  .pills-grid{{grid-template-columns:repeat(7,76px);gap:4px 0}}
+
+  /* Matrix — remove scroll container, content fits natively */
+  .matrix-scroll{{overflow-x:visible}}
+  .matrix-inner{{min-width:unset;padding:0}}
+  .matrix-scroll-wrap>.scroll-fade{{display:none}}
+
+  /* Pills — wrapping flex row, no column alignment on mobile */
+  .pills-spacer{{display:none}}
+  .pills-row{{display:block;padding:12px 16px 10px}}
+  .pills-grid{{display:flex;flex-wrap:wrap;gap:4px 6px}}
   .pill{{font-size:10px;padding:4px 7px;gap:3px;border-radius:10px}}
   .pill.hw{{border-color:rgba(96,165,250,.2)}}
   .pill.pl{{border-color:rgba(167,139,250,.2)}}
@@ -489,18 +495,30 @@ body{{font-family:'Geist',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif
   .pill-ct{{font-size:8px}}
   .pill-group{{gap:1px}}
   .pill-group>.weo-info-trigger{{display:none}}
-  .pills-row{{padding:12px 0 10px}}
-  .row-name{{width:120px;flex-shrink:0;font-size:12px}}
-  .row-dots{{grid-template-columns:repeat(7,76px)}}
-  .dot{{width:28px;height:10px;border-radius:3px}}
-  .row-score{{font-size:12px;width:34px;margin-left:8px}}
+
+  /* Actor rows — compact flex bar matching homepage SCP panel */
+  .row{{padding:8px 16px}}
+  .row-name{{width:100px;flex-shrink:0;font-size:12px}}
+  .row-dots{{display:flex;gap:2px;flex:1;margin:0 8px}}
+  .dot{{flex:1;width:auto;height:8px;border-radius:2px}}
+  .row-score{{font-size:11px;width:28px;margin-left:6px}}
   .row-badge{{margin-left:6px}}
+  .badge{{font-size:9px;padding:2px 7px}}
   .row-chev{{display:none}}
-  .row{{padding:10px 0}}
+
+  /* Dot highlight — outline instead of scale for flex segments */
+  .dot.col-hl{{transform:none;box-shadow:none;outline:2px solid rgba(255,255,255,.5);outline-offset:1px;z-index:1}}
+  .dot.col-hl.hw{{outline-color:rgba(96,165,250,.7)}}
+  .dot.col-hl.pl{{outline-color:rgba(167,139,250,.7)}}
+  .dot.col-hl.gv{{outline-color:rgba(45,212,191,.7)}}
+
+  /* Groups, detail, participants */
   .grp{{padding:14px 16px 6px}}
   .paa-fold{{margin:6px 16px 0}}
   .part-group>summary{{padding:10px 16px}}
   .det{{padding:12px 16px 16px}}
+
+  /* Watch table — justified horizontal scroll (real data table) */
   .watch{{margin-top:32px;padding-top:16px}}
   .watch-title{{padding:0 16px;font-size:15px}}
   .watch-desc{{padding:0 16px;margin-bottom:10px}}
@@ -508,14 +526,20 @@ body{{font-family:'Geist',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif
   .watch-scroll::-webkit-scrollbar{{display:none}}
   .watch-tbl{{min-width:580px}}
   .watch-tbl td:nth-child(2){{white-space:nowrap}}
+
+  /* Footer */
   .ftr{{margin-top:20px;padding:16px;text-align:left}}
   .ftr-links{{flex-direction:column;gap:8px}}
+
+  /* Register metadata & snapshot history */
   .register-meta{{flex-direction:column;align-items:flex-start;padding:12px 16px;gap:12px}}
   .snapshot-history{{padding:0;text-align:left}}
   .snapshot-title{{text-align:left;display:block}}
   .snapshot-list{{display:flex;flex-direction:column;gap:6px;width:100%}}
   .snapshot-item{{display:flex;flex-direction:column;align-items:flex-start;gap:6px;text-align:left;width:100%}}
   .snapshot-desc-row{{display:flex;flex-wrap:wrap;align-items:center;gap:8px}}
+
+  /* Tooltip overlay */
   #weo-tooltip-overlay{{width:300px;font-size:13px;padding:14px 16px}}
 }}
 


### PR DESCRIPTION
## Summary
- Replaces horizontal scroll containers with native wrapping layouts for mobile profiles
- Flex bar dots and wrapping pills eliminate the need for overflow-x scrolling on small screens
- Generator (`scripts/generate_profiles.py`) updated to produce the new markup

## Test plan
- [ ] Open profiles page on a mobile viewport (≤ 375px width) and verify no horizontal scroll
- [ ] Confirm bar dots render inline and wrap naturally on narrow screens
- [ ] Confirm dimension pills wrap to multiple lines rather than scrolling horizontally
- [ ] Spot-check desktop layout is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)