### PR TITLE
feat: blocs SCP card — extend contained treatment to desktop

### DIFF
--- a/blocs.html
+++ b/blocs.html
@@ -1100,12 +1100,6 @@
             .scp-table thead th:nth-child(2),
             .scp-table tbody td:nth-child(2) { display: none; }
             .scp-table td:first-child { padding-left: var(--weo-space-sm); }
-            .scp-section {
-                background: var(--weo-surface-raised);
-                border: 1px solid var(--weo-border-primary);
-                border-radius: var(--weo-radius-lg);
-                padding: var(--weo-space-lg);
-            }
         }
         
         @media (min-width: 768px) {
@@ -1159,6 +1153,10 @@
             --scp-aik: #06B6D4;
             --scp-acs: #A855F7;
             --scp-part: #64748B;
+            background: var(--weo-surface-raised);
+            border: 1px solid var(--weo-border-primary);
+            border-radius: var(--weo-radius-lg);
+            padding: var(--weo-space-lg);
         }
 
         .scp-intro {


### PR DESCRIPTION
## Summary

Moves the `.scp-section` card styles (`background`, `border`, `border-radius`, `padding`) from inside `@media (max-width: 767px)` to the base rule, so the contained card feel applies at all viewports — consistent with the changelog card treatment.

No other changes. Net diff: 4 lines added to base rule, 6 lines removed from mobile block.

## Test plan

- [ ] Desktop: SCP section renders with card border, raised background, and padding matching the changelog card
- [ ] Mobile (≤767px): SCP section card appearance unchanged from PR #168
- [ ] No other sections affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)