### PR TITLE
fix(ui): PIET second checkpoint + events.html pathway/generic row break

### DIFF
--- a/atlas.html
+++ b/atlas.html
@@ -9784,9 +9784,16 @@
                 return rows;
             }
             if (pathway === 'piet' && piet && piet.gates && piet.gates.length > 0) {
-                const rows = [{ label: 'Evidence Pathways Met (' + piet.gatesPassed + ' of ' + piet.gates.length + ')', pass: (piet.gatesPassed || 0) >= (piet.gatesRequired || 3) }];
-                if (piet.t2ImpactDemonstrated) rows.push({ label: 'Trade-Impact Confirmed', pass: true });
-                return rows;
+                const gatesPass = (piet.gatesPassed || 0) >= (piet.gatesRequired || 3);
+                // Two prominent checkpoints: the gate tally, and the PIET
+                // confidence verdict (always "Trade-Impact Confirmed" for
+                // qualified PIET events). t2ImpactDemonstrated is a separate
+                // T2-classification byproduct and is NOT used here — it is
+                // false for some qualified PIET events.
+                return [
+                    { label: 'Evidence Pathways Met (' + piet.gatesPassed + ' of ' + piet.gates.length + ')', pass: gatesPass },
+                    { label: piet.confidence || 'Trade-Impact Confirmed', pass: gatesPass }
+                ];
             }
             if (pathway === 'oep' && oep && oep.pathways && oep.pathways.length > 0) {
                 return [{ label: 'Operational Evidence Confirmed' + (oep.result ? ' (' + oep.result + ')' : ''), pass: (oep.pathwaysConfirmed || 0) >= (oep.pathwaysRequired || 1) }];

--- a/events.html
+++ b/events.html
@@ -3488,9 +3488,15 @@ function weoPathwayCheckpointRows(pathway, trace, piet, oep) {
     return rows;
   }
   if (pathway === 'piet' && piet && piet.gates && piet.gates.length > 0) {
-    var rows = [{ label: 'Evidence Pathways Met (' + piet.gatesPassed + ' of ' + piet.gates.length + ')', pass: (piet.gatesPassed || 0) >= (piet.gatesRequired || 3) }];
-    if (piet.t2ImpactDemonstrated) rows.push({ label: 'Trade-Impact Confirmed', pass: true });
-    return rows;
+    var gatesPass = (piet.gatesPassed || 0) >= (piet.gatesRequired || 3);
+    // Two prominent checkpoints: the gate tally, and the PIET confidence
+    // verdict (always "Trade-Impact Confirmed" for qualified PIET events).
+    // t2ImpactDemonstrated is a separate T2-classification byproduct and
+    // is NOT used here — it is false for some qualified PIET events.
+    return [
+      { label: 'Evidence Pathways Met (' + piet.gatesPassed + ' of ' + piet.gates.length + ')', pass: gatesPass },
+      { label: piet.confidence || 'Trade-Impact Confirmed', pass: gatesPass }
+    ];
   }
   if (pathway === 'oep' && oep && oep.pathways && oep.pathways.length > 0) {
     return [{ label: 'Operational Evidence Confirmed' + (oep.result ? ' (' + oep.result + ')' : ''), pass: (oep.pathwaysConfirmed || 0) >= (oep.pathwaysRequired || 1) }];
@@ -5364,6 +5370,7 @@ const openModal = (id) => {
                             const gs = (icon, txt) => `<span style="font-size:0.8125rem;color:var(--weo-text-secondary);opacity:${genOp};">${icon} ${txt}</span>`;
                             return (isAlt ? '' : `<span style="font-size:0.8125rem;color:var(--weo-text-secondary);">${e.verification_checkpoints.ai_connection?WEO_ICON_CHECK:WEO_ICON_CROSS} AI Connection Verified</span>`)
                                 + pwSpans
+                                + (pwRows ? '<span style="flex:0 0 100%;height:0;"></span>' : '')
                                 + gs(e.verification_checkpoints.quantitative_threshold?WEO_ICON_CHECK:WEO_ICON_CROSS, 'Quantitative Threshold Met')
                                 + gs(e.verification_checkpoints.implementation_status?WEO_ICON_CHECK:WEO_ICON_CROSS, 'Implementation Evidence Confirmed')
                                 + gs(e.verification_checkpoints.currency_window?WEO_ICON_CHECK:WEO_ICON_CROSS, 'Active Status Confirmed');
@@ -5691,6 +5698,7 @@ const openModal = (id) => {
                             const gs = (icon, txt) => `<span style="font-size:0.8125rem;color:var(--weo-text-secondary);opacity:${genOp};">${icon} ${txt}</span>`;
                             return (isAlt ? '' : `<span style="font-size:0.8125rem;color:var(--weo-text-secondary);">${e.verification_checkpoints.ai_connection?WEO_ICON_CHECK:WEO_ICON_CROSS} AI Connection</span>`)
                                 + pwSpans
+                                + (pwRows ? '<span style="flex:0 0 100%;height:0;"></span>' : '')
                                 + gs(e.verification_checkpoints.quantitative_threshold?WEO_ICON_CHECK:WEO_ICON_CROSS, 'Quantitative Threshold')
                                 + gs(e.verification_checkpoints.implementation_status?WEO_ICON_CHECK:WEO_ICON_CROSS, 'Implementation Evidence')
                                 + gs(e.verification_checkpoints.currency_window?WEO_ICON_CHECK:WEO_ICON_CROSS, 'Active Status');

--- a/index.html
+++ b/index.html
@@ -10397,9 +10397,15 @@ function generateCCSection(eventId, showFullContent) {
         return rows;
       }
       if (pathway === 'piet' && piet && piet.gates && piet.gates.length > 0) {
-        var rows = [{ label: 'Evidence Pathways Met (' + piet.gatesPassed + ' of ' + piet.gates.length + ')', pass: (piet.gatesPassed || 0) >= (piet.gatesRequired || 3) }];
-        if (piet.t2ImpactDemonstrated) rows.push({ label: 'Trade-Impact Confirmed', pass: true });
-        return rows;
+        var gatesPass = (piet.gatesPassed || 0) >= (piet.gatesRequired || 3);
+        // Two prominent checkpoints: the gate tally, and the PIET confidence
+        // verdict (always "Trade-Impact Confirmed" for qualified PIET events).
+        // t2ImpactDemonstrated is a separate T2-classification byproduct and
+        // is NOT used here — it is false for some qualified PIET events.
+        return [
+          { label: 'Evidence Pathways Met (' + piet.gatesPassed + ' of ' + piet.gates.length + ')', pass: gatesPass },
+          { label: piet.confidence || 'Trade-Impact Confirmed', pass: gatesPass }
+        ];
       }
       if (pathway === 'oep' && oep && oep.pathways && oep.pathways.length > 0) {
         return [{ label: 'Operational Evidence Confirmed' + (oep.result ? ' (' + oep.result + ')' : ''), pass: (oep.pathwaysConfirmed || 0) >= (oep.pathwaysRequired || 1) }];


### PR DESCRIPTION
Follow-up to #170 (pathway-specific verification checkpoints). Two rendering fixes in `weoPathwayCheckpointRows` / the verification render path, applied across all three event-panel files.

## 1. PIET "Trade-Impact Confirmed" was missing

The second prominent PIET checkpoint was gated on `piet.t2ImpactDemonstrated`. That field is the separate **T2-classification byproduct** (Gate 3 cleared) and is `false` for some fully-qualified PIET events — e.g. **E121** (China Graphite, 3/4 gates) and **E122** (MOFCOM No. 46/2024). Those events showed only "Evidence Pathways Met", missing "Trade-Impact Confirmed".

Now the second checkpoint derives from the PIET **confidence verdict** (`piet.confidence`), which is `"Trade-Impact Confirmed"` for all qualified PIET events. Both checkpoints render for every PIET event, with pass tied to the gate result.

## 2. events.html — pathway and generic rows flowed together inline

`events.html` lays the verification checkpoints out as inline `flex-wrap` spans. With only 1–2 pathway items (PIET/OEP), the dimmed generic checkpoints wrapped up onto the same row as the pathway checkpoints. TRACE only looked correct by accident (its 3 items filled the row width).

Added a forced flex break (`flex:0 0 100%`) between the pathway group and the generic group in both events.html builders, so pathway checkpoints occupy row 1 (prominent) and generics drop to the next row — for all pathway types. `index.html` and `atlas.html` use `flex-direction:column` and already stack vertically, so they were unaffected (no change to their layout).

## Testing

- **Helper unit test** (extracted real function from each of the 3 files, run against full data): E121/E122 (PIET, `t2=false`) now return both checkpoints; E128 (OEP) and E188 (TRACE) unchanged. Identical output across all three files.
- **Render path** (index.html, E14 with injected `t2=false`): both "Evidence Pathways Met (3 of 4)" and "Trade-Impact Confirmed" render as prominent `.pathway` rows.
- **events.html flex break** (measured offsetTop in the real container CSS, 2-item PIET case): pathway checkpoints on row 1, generics on the row below.
- **atlas.html** E188: pathway rows prominent, generics dimmed.
- Inline-script syntax: 0 errors across all three files.

> Note: free tier strips `piet`/`oep` objects, so E121/E128 were validated via the extracted-helper unit test and an injected render-path test; recommend a live spot-check on E121 (PIET) and a real OEP event (E128/E168–E171) post-merge. `E141` is a standard event (no pathway) in the current dataset — the OEP sample IDs are E128/E168–E171.

🤖 Generated with [Claude Code](https://claude.com/claude-code)