### PR TITLE
Atlas structural-position relabel (bloc-term collision fix) + ToS API/MCP & bulk-extraction terms

### DIFF
--- a/atlas.html
+++ b/atlas.html
@@ -4394,7 +4394,7 @@
                 Math.max(80, Math.min(350, spacingFactor * 1.8 * idealEdgeMul))
             );
             // Patch — base constant raised from 0.03 to 0.05. Our 127-node
-            // graph has 43 degree-0 orphans; with weaker gravity fcose
+            // graph has 66 degree-0 orphans; with weaker gravity fcose
             // lets them drift outward and stretches the bounding box,
             // forcing cy.fit() to zoom out further than necessary. The
             // bumped base brings orphans closer to the connected mass
@@ -9392,7 +9392,7 @@
                 return 'This event has no Coordination Connections recorded in the current database.';
             }
 
-            const role = total >= 6 ? 'Hub' : (total >= 3 ? 'Connected node' : 'Peripheral node');
+            const role = total >= 6 ? 'Highly connected node' : (total >= 3 ? 'Connected node' : 'Sparsely connected node');
 
             const parts = [];
             if (outbound.length > 0) parts.push(`${outbound.length} outbound`);

--- a/legal.html
+++ b/legal.html
@@ -605,13 +605,16 @@
                         <li><strong>Analyst Tier:</strong> Full analysis, framework assessments, and detailed source documentation require an active subscription.</li>
                         <li><strong>Attribution:</strong> If you reference WEO data or analysis in publications or presentations, please cite "Warmth Engine Observatory" with a link to the platform.</li>
                         <li><strong>No Redistribution:</strong> Analyst-tier content should not be systematically redistributed or republished without permission.</li>
+                        <li><strong>Programmatic Access (API/MCP):</strong> The API and MCP server are provided for individual analytical use, subject to the tier gating where a subscription is required. Automated access must respect that gating; access credentials must not be shared or used to provide access to third parties.</li>
+                        <li><strong>No Bulk Extraction:</strong> Systematic extraction, scraping, or wholesale copying of the event and Coordination Connection corpus — whether via the website, the API, or the MCP server — for the purpose of reconstructing, redistributing, or operating a derivative dataset or service is not permitted.</li>
                     </ul>
                     
                     <h3>Intellectual Property</h3>
                     <p>WEO's original methodological contributions — including the Coordination Connections taxonomy and the specific integration of analytical frameworks for AI infrastructure coordination — are the intellectual property of Warmth Engine.</p>
                     <p>WEO adapts established frameworks (Basel Committee G-SIB methodology, Keohane institutional cooperation theory, intelligence community verification standards) with appropriate attribution for the novel domain of AI infrastructure coordination.</p>
                     <p>The underlying event data is compiled from public sources, which retain their original ownership and licensing.</p>
-                    
+                    <p>WEO's published methodology — the Methodology Manual and associated papers — is released under Creative Commons Attribution 4.0 (CC BY 4.0) and may be reused with attribution. This open licence applies to the methodology only. The compiled analyst-tier dataset — the verified event records, Coordination Connections, and Sovereign Capability Profile assessments — is not placed under CC BY 4.0 and remains subject to the Use of Content terms above.</p>
+
                     <h3>Disclaimer</h3>
                     <p>WEO provides documentation and analysis of AI infrastructure coordination dynamics. This content is for informational and research purposes only. WEO:</p>
                     <ul>


### PR DESCRIPTION
## Summary

- **atlas.html (Edit 2.1):** Relabels the structural-position degree scale to avoid bloc-membership term collisions — `Hub` → `Highly connected node`, `Peripheral node` → `Sparsely connected node`; `Connected node` unchanged. These label choices are clean of defined WEO methodology terms (AIK, bloc-membership categories, SCP).
- **atlas.html (Edit 2.2):** Updates stale orphan count in layout comment from `43` to `66` (accuracy fix; code comment only, not a rendered value).
- **legal.html (Edit 3.1):** Adds two new bullets to "Use of Content" — Programmatic Access (API/MCP tier gating) and No Bulk Extraction.
- **legal.html (Edit 3.2):** Adds a CC BY 4.0 clarification paragraph to "Intellectual Property" — open licence applies to the *methodology* only; compiled analyst-tier dataset is not CC BY 4.0.

## Review notes

- The ToS additions (3.1, 3.2) were drafted in WEO register to match the existing page; review for alignment with actual Zenodo deposit licences before merging.
- No logic changes — atlas.html role labels are display-only strings; the degree-threshold logic (`>= 6`, `>= 3`) is unchanged.

## Test plan

- [ ] Open atlas.html locally — click an event with 1–2 CCs; confirm STRUCTURAL POSITION reads "Sparsely connected node"
- [ ] Click an event with 3–5 CCs; confirm "Connected node"
- [ ] Click an event with 6+ CCs; confirm "Highly connected node"
- [ ] Open legal.html — verify two new bullets appear under "Use of Content" and CC BY 4.0 paragraph appears under "Intellectual Property"

🤖 Generated with [Claude Code](https://claude.com/claude-code)